### PR TITLE
EASY-1504 Upload files.

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.deposit/DataFiles.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/DataFiles.scala
@@ -18,7 +18,7 @@ package nl.knaw.dans.easy.deposit
 import java.io.InputStream
 import java.nio.file.{ Path, Paths }
 
-import better.files.File
+import better.files._
 
 import scala.util.Try
 
@@ -47,7 +47,13 @@ class DataFiles(dataFilesBase: File, filesMetaData: File) {
    * @param path the relative path to the file to write
    * @return `true` if a new file was created, `false` if an existing file was overwritten
    */
-  def write(is: InputStream, path: Path): Try[Boolean] = ???
+  def write(is: InputStream, path: Path): Try[Boolean] = Try {
+    val file: File = dataFilesBase / path.toString
+    val createFile = !file.exists
+    file.createIfNotExists(asDirectory = false, createParents = true)
+    file.outputStream.foreach(is.pipeTo(_))
+    createFile
+  }
 
   /**
    * Deletes the file or directory located at the relative path into the data files directory. Directories

--- a/src/main/scala/nl.knaw.dans.easy.deposit/servlets/AbstractAuthServlet.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/servlets/AbstractAuthServlet.scala
@@ -21,7 +21,7 @@ import org.apache.commons.configuration.PropertiesConfiguration
 import org.scalatra.ScalatraServlet
 
 abstract class AbstractAuthServlet(app: EasyDepositApiApp) extends ScalatraServlet
-  with ServletEnhancedLogging
+  /*with ServletEnhancedLogging*/
   with AuthenticationSupport
   with TokenSupport
   with AuthConfig {

--- a/src/main/scala/nl.knaw.dans.easy.deposit/servlets/ProtectedServlet.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/servlets/ProtectedServlet.scala
@@ -20,7 +20,7 @@ import nl.knaw.dans.easy.deposit.authentication.ServletEnhancedLogging
 import nl.knaw.dans.easy.deposit.authentication.ServletEnhancedLogging._
 import org.scalatra.Forbidden
 
-class ProtectedServlet(app: EasyDepositApiApp) extends AbstractAuthServlet(app) with ServletEnhancedLogging {
+class ProtectedServlet(app: EasyDepositApiApp) extends AbstractAuthServlet(app) /*with ServletEnhancedLogging*/ {
 
   before() {
     if (!isAuthenticated) {

--- a/src/test/scala/nl.knaw.dans.easy.deposit/DataFilesSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/DataFilesSpec.scala
@@ -15,6 +15,31 @@
  */
 package nl.knaw.dans.easy.deposit
 
+import java.io.{ ByteArrayInputStream, InputStream }
+import java.nio.charset.StandardCharsets
+import java.nio.file.Paths
+
+import scala.util.Success
+
 class DataFilesSpec extends TestSupportFixture {
 
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+    clearTestDir()
+    draftsDir.createDirectories()
+  }
+
+  private val draftsDir = testDir / "drafts"
+
+  "write" should "write content to the path specified" in {
+    val dd = DepositDir(draftsDir, "user01", uuid)
+    val dataFiles = dd.getDataFiles.get
+    val content = "Lorem ipsum est"
+    val inputStream: InputStream = new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8))
+    val fileInBag = "location/in/data/dir/test.txt"
+
+    dataFiles.write(inputStream, Paths.get(fileInBag)) shouldBe Success(true)
+
+    (draftsDir / "user01" / uuid.toString / "bag" / "data" /  fileInBag).contentAsString shouldBe content
+  }
 }

--- a/src/test/scala/nl.knaw.dans.easy.deposit/DepositDirDatasetMetadataSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/DepositDirDatasetMetadataSpec.scala
@@ -22,7 +22,9 @@ import scala.util.{ Failure, Success }
 class DepositDirDatasetMetadataSpec extends TestSupportFixture {
   private val dd = DepositDir(testDir / "drafts", "foo", uuid)
   private val metadataFile = dd.baseDir / "foo" / uuid.toString / "bag" / "metadata" / "dataset.json"
-  before {
+
+  override def beforeEach() = {
+    super.beforeEach()
     clearTestDir()
     dd.baseDir.createDirectories()
   }

--- a/src/test/scala/nl.knaw.dans.easy.deposit/DepositDirSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/DepositDirSpec.scala
@@ -20,10 +20,12 @@ import java.nio.file.attribute.PosixFilePermission
 import scala.util.{ Failure, Success }
 
 class DepositDirSpec extends TestSupportFixture {
-  before {
+  override def beforeEach(): Unit = {
+    super.beforeEach()
     clearTestDir()
     draftsDir.createDirectories()
   }
+
   private val draftsDir = testDir / "drafts"
 
   "DepositDir.create" should "fail if the dir 'draft' is read only" in {

--- a/src/test/scala/nl.knaw.dans.easy.deposit/TestSupportFixture.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/TestSupportFixture.scala
@@ -24,9 +24,9 @@ import nl.knaw.dans.easy.deposit.authentication.TokenSupport.TokenConfig
 import nl.knaw.dans.easy.deposit.authentication.{ AuthConfig, AuthUser, AuthenticationProvider, TokenSupport }
 import org.apache.commons.configuration.PropertiesConfiguration
 import org.joda.time.{ DateTime, DateTimeUtils }
-import org.scalatest.{ BeforeAndAfter, FlatSpec, Inside, Matchers }
+import org.scalatest._
 
-trait TestSupportFixture extends FlatSpec with Matchers with Inside with BeforeAndAfter {
+trait TestSupportFixture extends FlatSpec with Matchers with Inside with BeforeAndAfterEach {
 
   lazy val testDir: File = currentWorkingDirectory / "target" / "test" / getClass.getSimpleName
   lazy val uuid: UUID = UUID.randomUUID()

--- a/src/test/scala/nl.knaw.dans.easy.deposit/servlets/HappyRoutesSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/servlets/HappyRoutesSpec.scala
@@ -65,7 +65,7 @@ class HappyRoutesSpec extends TestSupportFixture with ServletFixture with Scalat
       uri = "/deposit",
       headers = Seq(("Authorization", fooBarBasicAuthHeader))
     ) {
-      status shouldBe OK_200
+      status shouldBe CREATED_201
       body shouldBe s"$uuid"
       header("Location") should (fullyMatch regex s"http://localhost:[0-9]+/deposit/$uuid")
     }


### PR DESCRIPTION
Fixes EASY-1504

This PR only includes uploading files via a PUT. It does *not* include adding files to a directory
using PUT. I have implemented the servlet-part as well; this may conflict with #29 by @jo-pol.
However, we need this to work on Tuesday 17 April, so I suggest we integrate this now and improve
it after the demo.

**Important: ServletEnhancedLogging messes up the file upload, so I have commented it out**. 
Specifically, it resulted in the files being uploaded losing 8K of its content. After the demo we need 
to see if we can fix it, or another approach is needed for the problem it is trying to solve (standard
logging for all servlet requests and responses).

#### When applied it will
* Implement `PUT /deposit/:uuid/file/<path>`.

#### Where should the reviewer @DANS-KNAW/easy start?
The `DataFiles` and `DepositServlet` classes.

#### How should this be manually tested?
* Start `deasy` (for LDAP).
* `run-service.sh`.
* Create a deposit on your  (if you have none yet).
* For example: `curl -u user001:user001 -v -X PUT -H 'Content-Type: application/zip' --data-binary @your.zip http://localhost:20190/deposit/6b8034e2-3a43-46f5-bc76-6210cfa6cfdd/file/my/zip/file.zip` (Replacing your.zip and the UUID with values appropriate for you situation.)

#### Related pull requests on github
https://github.com/DANS-KNAW/easy-deposit-api/pull/29