### PR TITLE
EASY-1539: Remove fixed-schemed attribute names

### DIFF
--- a/docs/api/api.yml
+++ b/docs/api/api.yml
@@ -846,9 +846,7 @@ components:
         surname:
           type: string
         role:
-          type: array
-          items:
-            $ref: "#/components/schemas/SchemedKeyValue"
+          $ref: "#/components/schemas/SchemedKeyValue"
         ids:
           type: array
           items:


### PR DESCRIPTION
Fixes EASY-1539

#### When applied it will

- Remove all schemed-attribute names: datesIso8601, languagesOfFilesIso639, typesDcmi, formatsMediaType, spatialCoverageIso3166, subjectsAbrComplex, temporalCoveragesAbr

- Give 'languageOfDescription' and 'doi'  a SchemedValue
- Create new type Date, assign to dateCreated, dateAvailable and other dates
- Remove dateCreated, dateAvailable, dateSubmitted and store in 'dates', with qualifier
- Rename 'identifiers' to 'alternativeIdentifiers' to better capture the meaning
- Make the type for subjects PossiblySchemedKeyValue, to accommodate for other schemes
- Remove archisNrs, now part of relatedIdentifiers
- Remove rightsHolder, now part of contributor, with 'RightsHolder' role
- Remove extraClarinMetadataPresent, part of 'formats'
- Make the Author/role a schemedKeyValue
- Disallow additional properties in DatasetMetadata
- Make 'audiences' and 'languagesOfFiles' arrays
- Add enum for qualifier in Date and make qualifier required
- Give Author some required properties

#### Questions:
* 'instructionsForReuse' is a stringArray, but messageForDataManager is just a string. why?

#### Where should the reviewer @DANS-KNAW/easy start?

see google sheet [DDD: metadata fields in deposit-ui](https://docs.google.com/spreadsheets/d/1LzCVQh1vf6zJKFFuLXiG7XqH-kh8U5srJvmSVs0YBuI/edit?usp=sharing) for a mapping between the depositor-ui and this JSON representation