### PR TITLE
EASY-1539: Rename 'doi' to 'identifier'

### DIFF
--- a/docs/api/api.yml
+++ b/docs/api/api.yml
@@ -714,8 +714,10 @@ components:
       additionalProperties: false
       properties:
         # Basic information
-        doi:
-          $ref: "#/components/schemas/SchemedValue"
+        identifier:
+          type: array
+          items:
+            $ref: "#/components/schemas/SchemedValue"
         languageOfDescription:
           $ref: "#/components/schemas/SchemedValue"
         titles:


### PR DESCRIPTION
amend on  EASY-1539

#### When applied it will
* Rename 'doi' to 'identifier'
* Make 'identifier' an array
* 

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### Related pull requests on github
repo                       | PR                | note
-------------------------- | ----------------- | ----
easy-                      | [PR#](PRlink)     | ..
