### PR TITLE
EASY-1538: Sync json example and api.yml 

### DIFF
--- a/docs/api/api.yml
+++ b/docs/api/api.yml
@@ -929,6 +929,11 @@ components:
           type: string
         title:
           type: string
+      oneOf:
+        - required:
+          - title
+        - required:
+          - url
 
     SchemedValue:
       type: object


### PR DESCRIPTION
Fixes EASY-1538

#### When applied it will
* Make spatialCoverage KeyValue
* Use ddm-accessCategoryTypes
* Give date-types a dcterms prefix 
* Make languageOfDesc SchemedKeyValue
* Add relatedIdentifiers as relation-type
* Enumerate the qualifiers for Relation-object; 
* Make 'qualifier' required, use generic 'dcterms:relation' in no specific one applies
* Make one of {url,title} required in Relation

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

