### PR TITLE
EASY-1487 Transform JSON object to mandatory part of DDM (dataset.xml)

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.deposit/DepositDir.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/DepositDir.scala
@@ -170,7 +170,7 @@ case class DepositDir private(baseDir: File, user: String, id: UUID) extends Deb
       _ = msgFromDepositorFile.write(datasetMetadata.messageForDataManager.getOrElse(""))
       agreementsXml <- AgreementsXml(user, dateSubmitted, datasetMetadata)
       _ <- agreementsFile.writePretty(agreementsXml)
-      datasetXml <- DatasetXml(dateSubmitted, datasetMetadata)
+      datasetXml <- DatasetXml(datasetMetadata)
       _ <- datasetXmlFile.writePretty(datasetXml)
     } yield ()
   }

--- a/src/main/scala/nl.knaw.dans.easy.deposit/docs/AgreementsXml.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/docs/AgreementsXml.scala
@@ -1,0 +1,31 @@
+package nl.knaw.dans.easy.deposit.docs
+
+import org.joda.time.DateTime
+
+import scala.util.{ Failure, Success, Try }
+import scala.xml.Elem
+
+object AgreementsXml {
+  def apply(userId: String, dateSubmitted: DateTime, dm: DatasetMetadata): Try[Elem] = {
+    for {
+      _ <- dm.licenceAccepted
+      privacy <- dm.privacyBoolean
+    } yield
+      <agr:agreements
+          xmlns:agr="http://easy.dans.knaw.nl/schemas/bag/metadata/agreements/"
+          xmlns:dcterms="http://purl.org/dc/terms/"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://easy.dans.knaw.nl/schemas/bag/metadata/agreements/ agreements.xsd">
+        <agr:licenseAgreement>
+          <agr:depositorId>{userId}</agr:depositorId>
+          <dateAccepted>{dateSubmitted}</dateAccepted>
+          <agr:licenseAgreementAccepted>{dm.acceptLicenseAgreement}</agr:licenseAgreementAccepted>
+        </agr:licenseAgreement>
+        <agr:personalDataStatement>
+          <agr:signerId>{userId}</agr:signerId>
+          <agr:dateSigned>{dateSubmitted}</agr:dateSigned>
+          <agr:containsPrivacySensitiveData>{privacy}</agr:containsPrivacySensitiveData>
+        </agr:personalDataStatement>
+      </agr:agreements>
+  }
+}

--- a/src/main/scala/nl.knaw.dans.easy.deposit/docs/AgreementsXml.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/docs/AgreementsXml.scala
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2018 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package nl.knaw.dans.easy.deposit.docs
 
 import org.joda.time.DateTime

--- a/src/main/scala/nl.knaw.dans.easy.deposit/docs/DatasetMetadata.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/docs/DatasetMetadata.scala
@@ -58,6 +58,10 @@ case class DatasetMetadata(identifiers: Option[Seq[SchemedValue[String]]] = None
     case SchemedValue(`doiScheme`, value) => value
   })
 
+  lazy val dateCreated: Option[String] = dates.flatMap(_.collectFirst {
+    case QualifiedSchemedValue(Some(`dateCreatedQualifier`), value, _) => value
+  })
+
   lazy val privacyBoolean: Try[Boolean] = privacySensitiveDataPresent match {
     case PrivacySensitiveDataPresent.yes => Success(true)
     case PrivacySensitiveDataPresent.no => Success(false)
@@ -77,6 +81,7 @@ object DatasetMetadata {
   def apply(input: JsonInput): Try[DatasetMetadata] = input.deserialize[DatasetMetadata]
 
   private val doiScheme = "id-type:DOI"
+  private val dateCreatedQualifier = "id-type:DOI"
 
   def missingValue(label: String): InvalidDocumentException = {
     InvalidDocumentException(s"Please set $label in DatasetMetadata")

--- a/src/main/scala/nl.knaw.dans.easy.deposit/docs/DatasetMetadata.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/docs/DatasetMetadata.scala
@@ -58,10 +58,6 @@ case class DatasetMetadata(identifiers: Option[Seq[SchemedValue[String]]] = None
     case SchemedValue(`doiScheme`, value) => value
   })
 
-  lazy val dateCreated: Option[String] = dates.flatMap(_.collectFirst {
-    case QualifiedSchemedValue(Some(`dateCreatedQualifier`), value, _) => value
-  })
-
   lazy val privacyBoolean: Try[Boolean] = privacySensitiveDataPresent match {
     case PrivacySensitiveDataPresent.yes => Success(true)
     case PrivacySensitiveDataPresent.no => Success(false)

--- a/src/main/scala/nl.knaw.dans.easy.deposit/docs/DatasetXml.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/docs/DatasetXml.scala
@@ -1,0 +1,16 @@
+package nl.knaw.dans.easy.deposit.docs
+
+import org.joda.time.DateTime
+
+import scala.util.Try
+import scala.xml.Elem
+
+object DatasetXml {
+  def apply(dateSubmitted: DateTime, dm: DatasetMetadata): Try[Elem] = {
+    for {
+      _ <- dm.licenceAccepted
+      privacy <- dm.privacyBoolean
+    } yield
+      <stub/>
+  }
+}

--- a/src/main/scala/nl.knaw.dans.easy.deposit/docs/DatasetXml.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/docs/DatasetXml.scala
@@ -1,69 +1,121 @@
 package nl.knaw.dans.easy.deposit.docs
 
-import nl.knaw.dans.easy.deposit.docs.DatasetMetadata.DateQualifier.{ available, created }
-import nl.knaw.dans.easy.deposit.docs.DatasetMetadata.{ AccessRights, Author, QualifiedSchemedValue, SchemedKeyValue }
+import nl.knaw.dans.easy.deposit.docs.DatasetMetadata.DateQualifier.{ DateQualifier, available, created }
+import nl.knaw.dans.easy.deposit.docs.DatasetMetadata._
 
 import scala.util.Try
 import scala.xml.Elem
 
 object DatasetXml {
-  def apply(dm: DatasetMetadata): Try[Elem] = Try {
-    // TODO dc* namespaces
+  private type Lang = Option[SchemedKeyValue[String]]
+  private val otherDates = DateQualifier.values.filter(d => d != created && d != available).toSeq
+
+  def apply(dm: DatasetMetadata): Try[Elem] = Try { // TODO "dct:" or "dcterms:"
     <ddm:DDM
       xmlns:dc="http://purl.org/dc/elements/1.1/"
-      xmlns:ddm="http://easy.dans.knaw.nl/schemas/md/ddm/"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xmlns:dct="http://purl.org/dc/terms/"
+      xmlns:dcx-dai="http://easy.dans.knaw.nl/schemas/dcx/dai/"
+      xmlns:ddm="http://easy.dans.knaw.nl/schemas/md/ddm/"
+      xsi:schemaLocation="http://easy.dans.knaw.nl/schemas/md/ddm/ http://easy.dans.knaw.nl/schemas/md/2017/09/ddm.xsd"
     >
       <ddm:profile>
-        { requiredElems(dm.titles, "dc:title") }
-        { requiredElems(dm.descriptions, "dc:description") }
+        { requiredElems(dm.titles, "dct:title", dm.languageOfDescription) }
+        { requiredElems(dm.alternativeTitles, "dct:alternative", dm.languageOfDescription) }
+        { requiredElems(dm.descriptions, "dc:description", dm.languageOfDescription) }
         { requiredElems(dm.creators, "dcx-dai:creatorDetails") }
-        { requiredElems(dm.dates.map(filter(_, created)), "ddm:created") }
-        { requiredElems(dm.dates.map(filter(_, available)), "ddm:available") }
+        { requiredElems(dm.dates.map(filter(_, Seq(created))), "ddm:created") }
+        { requiredElems(dm.dates.map(filter(_, Seq(available))), "ddm:available") }
         { requiredElems(dm.audiences, "ddm:audience") }
         { requiredElems(dm.accessRights.map(Seq(_)), "ddm:accessRights") }
       </ddm:profile>
+      <ddm:dcmiMetadata>
+        { elems(dm.contributors, "dcx-dai:creatorDetails") }
+        { elems(dm.dates.map(filter(_, otherDates)), "otherDate") }
+        { elems(dm.subjects, "ddm:subject") }
+        { elems(dm.relations, "ddm:relation", dm.languageOfDescription) }
+        { optionalElem(dm.license, "dct:license") /* TODO xsi:type="dct:URI" not supported by json */ }
+      </ddm:dcmiMetadata>
+      <ddm:additional-xml>
+      </ddm:additional-xml>
     </ddm:DDM>
   }
 
-  private def elem[T](target: String)(source: T): Elem = (source match {
-    case QualifiedSchemedValue(Some(scheme), value, _) => <key scheme={scheme.toString}>{value}</key>
-    case QualifiedSchemedValue(None, value, _) => <key>{value}</key> // TODO so far just date-created/available
-    case SchemedKeyValue(scheme, key, _) => <key scheme={scheme.toString}>{key}</key> // e.g. role, audience
-    case a: AccessRights => <key>{a.category.toString}</key>
-    case a: Author => <key>{authorDetails(a)}</key>
-    case v => <key>{v}</key>
-  }).copy(label = target)
+  // called by requiredElems, elems, optionalElem
+  private def elem[T](target: String, lang: Lang)(source: T): Elem = {
+    (source match {
+      case _ if target == "ddm:subject" => subjectDetails(source)
+      case a: Author => <key>{authorDetails(a, lang)}</key>
+      case QualifiedSchemedValue(Some(scheme), value, _) => <key scheme={scheme.toString}>{value}</key>
+      case QualifiedSchemedValue(None, value, _) => <key>{value}</key>
+      case SchemedKeyValue(scheme, key, _) => <key scheme={scheme.toString}>{key}</key> // e.g. role, audience
+      case PossiblySchemedKeyValue(Some(scheme), key, _) => <key scheme={scheme.toString}>{key}</key>
+      case PossiblySchemedKeyValue(None, key, _) => <key>{key}</key>
+      case Relation(_, Some(url), Some(title)) => <key href={url}>{title}</key>
+      case Relation(_, None, Some(title)) => <key>{title}</key>
+      case Relation(_, Some(url), None) => <key href={url}>{url}</key>
+      case RelatedIdentifier(Some(scheme), value, _) => <key scheme={scheme}>{value}</key> // TODO ?
+      case RelatedIdentifier(None, value, _) => <key>{value}</key> // TODO ?
+      case a: AccessRights => <key>{a.category.toString}</key>
+      case v => <key>{v}</key>
+    }).copy(label = elemLabel(target, source)) // TODO attribute lang if available, for relations if it has a title, for authors to titles/organisation-name, otherwise to root
+  }
 
-  private def authorDetails(a: Author) =
+  /**
+   * @param target the default label
+   * @param source may have some property that determines the label
+   */
+  private def elemLabel[T](target: String, source: T) = {
+    val rightsholder = "rightsholder"
+    source match {
+      case QualifiedSchemedValue(_, _, q: DateQualifier) if target == "otherDate" => q.toString
+      case Author(_, _, _, _, Some(SchemedKeyValue(_, _, `rightsholder`)), _, _) => "dcterms:rightsholder"
+      case Relation(qualifier, _, _) => qualifier.toString.replace("dcterms", "ddm")
+      case RelatedIdentifier(_, _, qualifier) => qualifier.toString.replace("dcterms", "ddm")
+      case _ => target
+    }
+  }
+
+  private def subjectDetails[T](source: T) = source match {
+    case PossiblySchemedKeyValue(Some(scheme), Some(key), value) =>
+      // TODO subjectScheme or schemeURI?
+      <key valueURI={key} xml:lang="en" subjectScheme={scheme.toString} schemeURI="???">{value}</key>
+    case PossiblySchemedKeyValue(None, Some(key), value) =>
+      <key valueURI={key} xml:lang="en">{value}</key>
+    case PossiblySchemedKeyValue(None, None, value) =>
+      <key xml:lang="en">{value}</key>
+  }
+
+  private def authorDetails(a: Author, lang: Lang) =
     <dcx-dai:author>
       { optionalElem(a.titles, "dcx-dai:titles") }
       { optionalElem(a.initials, "dcx-dai:initials") }
       { optionalElem(a.insertions, "dcx-dai:insertions") }
       { optionalElem(a.surname, "dcx-dai:surname") }
       { optionalElem(a.role, "dcx-dai:role") }
-      { a.organization.map(str => // TODO what is the source of the language?
+      {
+        a.organization.map(str =>
           <dcx-dai:organization>
-            <dcx-dai:name xml:lang="en">{str}</dcx-dai:name>
+            <dcx-dai:name>{str}</dcx-dai:name>
           </dcx-dai:organization>
         ).getOrElse(Seq.empty)
       }
     </dcx-dai:author>
 
-  private def requiredElems[T](source: Option[Seq[T]], target: String): Seq[Elem] = {
-    source.map(_.map(elem(target))).getOrElse(throwMandatory(target))
+  private def requiredElems[T](source: Option[Seq[T]], target: String, lang: Lang = None): Seq[Elem] = {
+    source.map(_.map(elem(target, lang))).getOrElse(throwMandatory(target))
   }
 
-  private def elems[T](source: Option[Seq[T]], target: String): Seq[Elem] = {
-    source.map(_.map(elem(target))).getOrElse(Seq.empty)
+  private def elems[T](source: Option[Seq[T]], target: String, lang: Lang = None): Seq[Elem] = {
+    source.map(_.map(elem(target, lang))).getOrElse(Seq.empty)
   }
 
-  private def optionalElem[T](source: Option[T], target: String): Seq[Elem] = {
-    source.map(elem(target)).toSeq
+  private def optionalElem[T](source: Option[T], target: String, lang: Lang = None): Seq[Elem] = {
+    source.map(elem(target, lang)).toSeq
   }
 
   private def filter[S, T](xs: Seq[QualifiedSchemedValue[S, T]],
-                           q: T*
+                           q: Seq[T]
                           ): Seq[QualifiedSchemedValue[S, T]] = {
     xs.filter(x => q.contains(x.qualifier))
   }

--- a/src/main/scala/nl.knaw.dans.easy.deposit/docs/DatasetXml.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/docs/DatasetXml.scala
@@ -1,16 +1,74 @@
 package nl.knaw.dans.easy.deposit.docs
 
-import org.joda.time.DateTime
+import nl.knaw.dans.easy.deposit.docs.DatasetMetadata.DateQualifier.{ available, created }
+import nl.knaw.dans.easy.deposit.docs.DatasetMetadata.{ AccessRights, Author, QualifiedSchemedValue, SchemedKeyValue }
 
 import scala.util.Try
 import scala.xml.Elem
 
 object DatasetXml {
-  def apply(dateSubmitted: DateTime, dm: DatasetMetadata): Try[Elem] = {
-    for {
-      _ <- dm.licenceAccepted
-      privacy <- dm.privacyBoolean
-    } yield
-      <stub/>
+  def apply(dm: DatasetMetadata): Try[Elem] = Try {
+    // TODO dc* namespaces
+    <ddm:DDM
+      xmlns:dc="http://purl.org/dc/elements/1.1/"
+      xmlns:ddm="http://easy.dans.knaw.nl/schemas/md/ddm/"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    >
+      <ddm:profile>
+        { requiredElems(dm.titles, "dc:title") }
+        { requiredElems(dm.descriptions, "dc:description") }
+        { requiredElems(dm.creators, "dcx-dai:creatorDetails") }
+        { requiredElems(dm.dates.map(filter(_, created)), "ddm:created") }
+        { requiredElems(dm.dates.map(filter(_, available)), "ddm:available") }
+        { requiredElems(dm.audiences, "ddm:audience") }
+        { requiredElems(dm.accessRights.map(Seq(_)), "ddm:accessRights") }
+      </ddm:profile>
+    </ddm:DDM>
+  }
+
+  private def elem[T](target: String)(source: T): Elem = (source match {
+    case QualifiedSchemedValue(Some(scheme), value, _) => <key scheme={scheme.toString}>{value}</key>
+    case QualifiedSchemedValue(None, value, _) => <key>{value}</key> // TODO so far just date-created/available
+    case SchemedKeyValue(scheme, key, _) => <key scheme={scheme.toString}>{key}</key> // e.g. role, audience
+    case a: AccessRights => <key>{a.category.toString}</key>
+    case a: Author => <key>{authorDetails(a)}</key>
+    case v => <key>{v}</key>
+  }).copy(label = target)
+
+  private def authorDetails(a: Author) =
+    <dcx-dai:author>
+      { optionalElem(a.titles, "dcx-dai:titles") }
+      { optionalElem(a.initials, "dcx-dai:initials") }
+      { optionalElem(a.insertions, "dcx-dai:insertions") }
+      { optionalElem(a.surname, "dcx-dai:surname") }
+      { optionalElem(a.role, "dcx-dai:role") }
+      { a.organization.map(str => // TODO what is the source of the language?
+          <dcx-dai:organization>
+            <dcx-dai:name xml:lang="en">{str}</dcx-dai:name>
+          </dcx-dai:organization>
+        ).getOrElse(Seq.empty)
+      }
+    </dcx-dai:author>
+
+  private def requiredElems[T](source: Option[Seq[T]], target: String): Seq[Elem] = {
+    source.map(_.map(elem(target))).getOrElse(throwMandatory(target))
+  }
+
+  private def elems[T](source: Option[Seq[T]], target: String): Seq[Elem] = {
+    source.map(_.map(elem(target))).getOrElse(Seq.empty)
+  }
+
+  private def optionalElem[T](source: Option[T], target: String): Seq[Elem] = {
+    source.map(elem(target)).toSeq
+  }
+
+  private def filter[S, T](xs: Seq[QualifiedSchemedValue[S, T]],
+                           q: T*
+                          ): Seq[QualifiedSchemedValue[S, T]] = {
+    xs.filter(x => q.contains(x.qualifier))
+  }
+
+  private def throwMandatory(tag: String) = {
+    throw new IllegalArgumentException(s"no content for mandatory $tag")
   }
 }

--- a/src/main/scala/nl.knaw.dans.easy.deposit/docs/DatasetXml.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/docs/DatasetXml.scala
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2018 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package nl.knaw.dans.easy.deposit.docs
 
 import nl.knaw.dans.easy.deposit.docs.DatasetMetadata.DateQualifier.{ available, created }

--- a/src/test/scala/nl.knaw.dans.easy.deposit/DepositDirSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/DepositDirSpec.scala
@@ -22,6 +22,7 @@ import nl.knaw.dans.easy.deposit.PidRequesterComponent.PidType.PidType
 import nl.knaw.dans.easy.deposit.docs.DatasetMetadata.PrivacySensitiveDataPresent
 import nl.knaw.dans.easy.deposit.docs.StateInfo.State
 import nl.knaw.dans.easy.deposit.docs.{ DatasetMetadata, StateInfo }
+import org.joda.time.DateTime
 import org.scalamock.scalatest.MockFactory
 
 import scala.util.{ Failure, Success }
@@ -192,8 +193,8 @@ class DepositDirSpec extends TestSupportFixture with MockFactory {
     deposit.writeDatasetMetadataJson(datasetMetadata)
     val oldSize = (mdDir / "dataset.json").size
 
-    deposit.splitDatasetMetadata shouldBe Success(())
-    (mdDir / "dataset.json").size should be > oldSize
+    deposit.splitDatasetMetadata(DateTime.now) shouldBe Success(())
+    (mdDir / "dataset.json").size shouldBe oldSize // date submitted is no longer addededd
     (mdDir / "message-from-depositor.txt").contentAsString shouldBe message
     (mdDir / "agreements.xml").lineIterator.next() shouldBe prologue
     (mdDir / "dataset.xml").lineIterator.next() shouldBe prologue

--- a/src/test/scala/nl.knaw.dans.easy.deposit/DepositDirSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/DepositDirSpec.scala
@@ -17,9 +17,9 @@ package nl.knaw.dans.easy.deposit
 
 import java.nio.file.attribute.PosixFilePermission
 
+import better.files.File
 import nl.knaw.dans.easy.deposit.PidRequesterComponent.PidRequester
 import nl.knaw.dans.easy.deposit.PidRequesterComponent.PidType.PidType
-import nl.knaw.dans.easy.deposit.docs.DatasetMetadata.PrivacySensitiveDataPresent
 import nl.knaw.dans.easy.deposit.docs.StateInfo.State
 import nl.knaw.dans.easy.deposit.docs.{ DatasetMetadata, StateInfo }
 import org.joda.time.DateTime
@@ -182,11 +182,9 @@ class DepositDirSpec extends TestSupportFixture with MockFactory {
   "writeSplittedDatasetMetadata" should "write 4 files" in {
     val prologue = """<?xml version='1.0' encoding='UTF-8'?>"""
     val message = "Lorum ipsum"
-    val datasetMetadata = DatasetMetadata(
-      privacySensitiveDataPresent = PrivacySensitiveDataPresent.yes,
-      acceptLicenseAgreement = true,
-      messageForDataManager = Some(message)
-    )
+    val datasetMetadata = DatasetMetadata((File("src") / "test" / "resources" / "manual-test" / "datasetmetadata-from-ui-all.json").contentAsString)
+      .getOrElse(fail("preparing a valid json failed"))
+      .copy(messageForDataManager = Some(message))
     val deposit = createDepositAsPreparation("user001")
     val mdDir = deposit.getDataFiles.getOrElse(fail("preconditions are not met"))
       .filesMetaData.parent.createIfNotExists(asDirectory = true, createParents = true)

--- a/src/test/scala/nl.knaw.dans.easy.deposit/docs/DatasetXmlSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/docs/DatasetXmlSpec.scala
@@ -87,16 +87,6 @@ class DatasetXmlSpec extends TestSupportFixture {
           <dcterms:valid scheme="dcterms:W3CDTF">2018-03-17</dcterms:valid>
           <dcterms:modified>2018-02-02</dcterms:modified>
           <dcterms:issued>Groundhog day</dcterms:issued>
-          <ddm:subject xml:lang="en">subject1</ddm:subject>
-          <ddm:subject xml:lang="en">subject2</ddm:subject>
-          <ddm:subject valueURI="RKER" xml:lang="en" subjectScheme="abr:ABRcomplex" schemeURI="???">Religie - Kerk</ddm:subject>
-          <ddm:subject valueURI="VK" xml:lang="en" subjectScheme="abr:ABRcomplex" schemeURI="???">Versterking - Kasteel</ddm:subject>
-          <ddm:isReferencedBy scheme="id-type:ISSN">2123-34X</ddm:isReferencedBy>
-          <ddm:conformsTo href="http://x">title1</ddm:conformsTo>
-          <ddm:requires>title2</ddm:requires>
-          <ddm:isReplacedBy href="http://y">http://y</ddm:isReplacedBy>
-          <ddm:relation href="http://z">http://z</ddm:relation>
-          <ddm:relation>title3</ddm:relation>
           <dct:license>http://creativecommons.org/publicdomain/zero/1.0</dct:license>
         </ddm:dcmiMetadata>
         <ddm:additional-xml>

--- a/src/test/scala/nl.knaw.dans.easy.deposit/docs/DatasetXmlSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/docs/DatasetXmlSpec.scala
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2018 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package nl.knaw.dans.easy.deposit.docs
 
 import better.files.File

--- a/src/test/scala/nl.knaw.dans.easy.deposit/docs/DatasetXmlSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/docs/DatasetXmlSpec.scala
@@ -1,0 +1,53 @@
+package nl.knaw.dans.easy.deposit.docs
+
+import better.files.File
+import nl.knaw.dans.easy.deposit.TestSupportFixture
+
+class DatasetXmlSpec extends TestSupportFixture {
+
+  val prettyPrinter = new scala.xml.PrettyPrinter(1024, 2)
+
+  "apply" should "produce a minimal DDM" in {
+    val datasetMetadata = DatasetMetadata((File("src") / "test" / "resources" / "manual-test" / "datasetmetadata-from-ui-all.json").contentAsString)
+      .getOrElse(fail("preparing a valid json failed"))
+    val expected =
+      <ddm:DDM
+        xmlns:dc="http://purl.org/dc/elements/1.1/"
+        xmlns:ddm="http://easy.dans.knaw.nl/schemas/md/ddm/"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      >
+        <ddm:profile>
+          <dc:title>title 1</dc:title>
+          <dc:title>title2</dc:title>
+          <dc:description>description1</dc:description>
+          <dc:description>description2</dc:description>
+          <dcx-dai:creatorDetails>
+            <dcx-dai:author>
+              <dcx-dai:titles>Drs.</dcx-dai:titles>
+              <dcx-dai:initials>D.A.</dcx-dai:initials>
+              <dcx-dai:insertions></dcx-dai:insertions>
+              <dcx-dai:surname>NS</dcx-dai:surname>
+              <dcx-dai:role scheme="datacite:contributorType">ContactPerson</dcx-dai:role>
+              <dcx-dai:organization>
+                <dcx-dai:name xml:lang="en">KNAW</dcx-dai:name>
+              </dcx-dai:organization></dcx-dai:author>
+          </dcx-dai:creatorDetails>
+          <dcx-dai:creatorDetails>
+            <dcx-dai:author>
+              <dcx-dai:initials>Foo</dcx-dai:initials>
+              <dcx-dai:insertions>van</dcx-dai:insertions>
+              <dcx-dai:surname>Bar</dcx-dai:surname>
+            </dcx-dai:author>
+          </dcx-dai:creatorDetails>
+          <ddm:created scheme="dcterms:W3CDTF">2018-03-19</ddm:created>
+          <ddm:available scheme="dcterms:W3CDTF">2018-03-14</ddm:available>
+          <ddm:audience scheme="narcis:DisciplineType">D35200</ddm:audience>
+          <ddm:audience scheme="narcis:DisciplineType">D33000</ddm:audience>
+          <ddm:accessRights>OPEN_ACCESS</ddm:accessRights>
+        </ddm:profile>
+      </ddm:DDM>
+    val actual = DatasetXml(datasetMetadata).getOrElse(fail("conversion failed"))
+    println(actual)
+    prettyPrinter.format(actual) shouldBe prettyPrinter.format(expected)
+  }
+}

--- a/src/test/scala/nl.knaw.dans.easy.deposit/docs/DatasetXmlSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/docs/DatasetXmlSpec.scala
@@ -13,12 +13,17 @@ class DatasetXmlSpec extends TestSupportFixture {
     val expected =
       <ddm:DDM
         xmlns:dc="http://purl.org/dc/elements/1.1/"
-        xmlns:ddm="http://easy.dans.knaw.nl/schemas/md/ddm/"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns:dct="http://purl.org/dc/terms/"
+        xmlns:dcx-dai="http://easy.dans.knaw.nl/schemas/dcx/dai/"
+        xmlns:ddm="http://easy.dans.knaw.nl/schemas/md/ddm/"
+        xsi:schemaLocation="http://easy.dans.knaw.nl/schemas/md/ddm/ http://easy.dans.knaw.nl/schemas/md/2017/09/ddm.xsd"
       >
         <ddm:profile>
-          <dc:title>title 1</dc:title>
-          <dc:title>title2</dc:title>
+          <dct:title>title 1</dct:title>
+          <dct:title>title2</dct:title>
+          <dct:alternative>alternative title 1</dct:alternative>
+          <dct:alternative>alternative title2</dct:alternative>
           <dc:description>description1</dc:description>
           <dc:description>description2</dc:description>
           <dcx-dai:creatorDetails>
@@ -29,7 +34,7 @@ class DatasetXmlSpec extends TestSupportFixture {
               <dcx-dai:surname>NS</dcx-dai:surname>
               <dcx-dai:role scheme="datacite:contributorType">ContactPerson</dcx-dai:role>
               <dcx-dai:organization>
-                <dcx-dai:name xml:lang="en">KNAW</dcx-dai:name>
+                <dcx-dai:name>KNAW</dcx-dai:name>
               </dcx-dai:organization></dcx-dai:author>
           </dcx-dai:creatorDetails>
           <dcx-dai:creatorDetails>
@@ -45,9 +50,60 @@ class DatasetXmlSpec extends TestSupportFixture {
           <ddm:audience scheme="narcis:DisciplineType">D33000</ddm:audience>
           <ddm:accessRights>OPEN_ACCESS</ddm:accessRights>
         </ddm:profile>
+        <ddm:dcmiMetadata>
+          <dcx-dai:creatorDetails>
+            <dcx-dai:author>
+            <dcx-dai:titles>Dr.</dcx-dai:titles>
+            <dcx-dai:initials>O.</dcx-dai:initials>
+            <dcx-dai:insertions>van</dcx-dai:insertions>
+            <dcx-dai:surname>Belix</dcx-dai:surname>
+            </dcx-dai:author>
+          </dcx-dai:creatorDetails>
+          <dcx-dai:creatorDetails>
+            <dcx-dai:author>
+            <dcx-dai:organization>
+                  <dcx-dai:name>my organization</dcx-dai:name>
+            </dcx-dai:organization>
+            </dcx-dai:author>
+          </dcx-dai:creatorDetails>
+          <dcterms:rightsholder>
+            <dcx-dai:author>
+              <dcx-dai:role scheme="datacite:contributorType">RightsHolder</dcx-dai:role>
+              <dcx-dai:organization>
+                <dcx-dai:name>rightsHolder1</dcx-dai:name>
+              </dcx-dai:organization>
+            </dcx-dai:author>
+          </dcterms:rightsholder>
+          <dcterms:rightsholder>
+            <dcx-dai:author>
+              <dcx-dai:titles>Dr.</dcx-dai:titles>
+              <dcx-dai:initials>A.S.</dcx-dai:initials>
+              <dcx-dai:insertions>van</dcx-dai:insertions>
+              <dcx-dai:surname>Terix</dcx-dai:surname>
+              <dcx-dai:role scheme="datacite:contributorType">RightsHolder</dcx-dai:role>
+            </dcx-dai:author>
+          </dcterms:rightsholder>
+          <dcterms:dateCopyrighted scheme="dcterms:W3CDTF">2018-03-18</dcterms:dateCopyrighted>
+          <dcterms:valid scheme="dcterms:W3CDTF">2018-03-17</dcterms:valid>
+          <dcterms:modified>2018-02-02</dcterms:modified>
+          <dcterms:issued>Groundhog day</dcterms:issued>
+          <ddm:subject xml:lang="en">subject1</ddm:subject>
+          <ddm:subject xml:lang="en">subject2</ddm:subject>
+          <ddm:subject valueURI="RKER" xml:lang="en" subjectScheme="abr:ABRcomplex" schemeURI="???">Religie - Kerk</ddm:subject>
+          <ddm:subject valueURI="VK" xml:lang="en" subjectScheme="abr:ABRcomplex" schemeURI="???">Versterking - Kasteel</ddm:subject>
+          <ddm:isReferencedBy scheme="id-type:ISSN">2123-34X</ddm:isReferencedBy>
+          <ddm:conformsTo href="http://x">title1</ddm:conformsTo>
+          <ddm:requires>title2</ddm:requires>
+          <ddm:isReplacedBy href="http://y">http://y</ddm:isReplacedBy>
+          <ddm:relation href="http://z">http://z</ddm:relation>
+          <ddm:relation>title3</ddm:relation>
+          <dct:license>http://creativecommons.org/publicdomain/zero/1.0</dct:license>
+        </ddm:dcmiMetadata>
+        <ddm:additional-xml>
+        </ddm:additional-xml>
       </ddm:DDM>
     val actual = DatasetXml(datasetMetadata).getOrElse(fail("conversion failed"))
-    println(actual)
+    println(prettyPrinter.format(actual))
     prettyPrinter.format(actual) shouldBe prettyPrinter.format(expected)
   }
 }


### PR DESCRIPTION
Fixes [EASY-1487](https://drivenbydata.atlassian.net/browse/EASY-1487)

#### When applied it will have
* [ ] unit tests for each line of the specs
* [ ] unit tests that validate the produce DDM against the schema
* 
#### Where should the reviewer @DANS-KNAW/easy start?

The (for now) dropped relations/subjects may illustrate the cause of some choices https://github.com/DANS-KNAW/easy-deposit-api/commit/14defa050c0c052ba8f4aad2e6108506ec0987e6


#### How should this be manually tested?

not applicable

#### Related pull requests on github
repo                       | PR                | note
-------------------------- | ----------------- | ----
easy-                      | [PR#](PRlink)     | ..
