### PR TITLE
EASY-1547 allow manual test: servlet call writeXMLs (first phase json -> ddm)

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.deposit/DepositDir.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/DepositDir.scala
@@ -164,8 +164,10 @@ case class DepositDir private(baseDir: File, user: String, id: UUID) extends Deb
     () // satisfy the compiler which doesn't want a File
   }.recoverWith { case _: NoSuchFileException => notFoundFailure() }
 
-  /** part of submit sequence */
-  def splitDatasetMetadata(dateSubmitted: DateTime): Try[Unit] = {
+  /** create dataset.xml, agreements.xml, files.xml
+   *  from datasetmetadata.json and files in data folder
+   */
+  def createXMLs(dateSubmitted: DateTime): Try[Unit] = {
     for {
       datasetMetadata <- getDatasetMetadata // TODO skip recover? Depends on to be implemented submit.
       _ = msgFromDepositorFile.write(datasetMetadata.messageForDataManager.getOrElse(""))
@@ -204,7 +206,7 @@ case class DepositDir private(baseDir: File, user: String, id: UUID) extends Deb
   private def doisMatch(dm: DatasetMetadata, doi: Option[String]) = {
     if (doi == dm.doi) Success(())
     else {
-      val e = new Exception(s"DOI in dataset.xml [${ dm.doi }] does not equal DOI in deposit.properties [$doi]")
+      val e = new Exception(s"DOI in datasetmetadata.json [${ dm.doi }] does not equal DOI in deposit.properties [$doi]")
       Failure(CorruptDepositException(user, id.toString, e))
     }
   }

--- a/src/main/scala/nl.knaw.dans.easy.deposit/Submitter.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/Submitter.scala
@@ -17,9 +17,8 @@ package nl.knaw.dans.easy.deposit
 
 import better.files.File
 import org.joda.time.DateTime
-import sun.reflect.generics.reflectiveObjects.NotImplementedException
 
-import scala.util.{ Failure, Try }
+import scala.util.Try
 
 /**
  * Object that contains the logic for submitting a deposit.
@@ -38,11 +37,12 @@ class Submitter(stagingBaseDir: File, submitToBaseDir: File) {
    */
   def submit(depositDir: DepositDir): Try[Unit] = {
     // TODO: implement as follows:
-    // 1. Set state to SUBMITTED
-    depositDir.createXMLs(DateTime.now)
-    // 5. Update/write bag checksums.
-    // 6. Copy to staging area
-    // 7. Move copy to submit-to area
-    Try(???)
+    for {
+      // 1. Set state to SUBMITTED
+      _ <- depositDir.createXMLs(DateTime.now)
+      // 5. Update/write bag checksums.
+      // 6. Copy to staging area
+      // 7. Move copy to submit-to area
+    } yield ???
   }
 }

--- a/src/main/scala/nl.knaw.dans.easy.deposit/Submitter.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/Submitter.scala
@@ -16,8 +16,10 @@
 package nl.knaw.dans.easy.deposit
 
 import better.files.File
+import org.joda.time.DateTime
+import sun.reflect.generics.reflectiveObjects.NotImplementedException
 
-import scala.util.Try
+import scala.util.{ Failure, Try }
 
 /**
  * Object that contains the logic for submitting a deposit.
@@ -37,13 +39,10 @@ class Submitter(stagingBaseDir: File, submitToBaseDir: File) {
   def submit(depositDir: DepositDir): Try[Unit] = {
     // TODO: implement as follows:
     // 1. Set state to SUBMITTED
-    // 2. getDataFiles.writeFilesXml()
-    // 3. getDatasetMetadata.writeDatasetXml()
-    // 4. getDatasetMetadata.writeAgreementsXml()
+    depositDir.createXMLs(DateTime.now)
     // 5. Update/write bag checksums.
     // 6. Copy to staging area
     // 7. Move copy to submit-to area
-
-    ???
+    Try(???)
   }
 }

--- a/src/test/scala/nl.knaw.dans.easy.deposit/DataFilesSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/DataFilesSpec.scala
@@ -33,7 +33,7 @@ class DataFilesSpec extends TestSupportFixture {
 
   private val draftsDir = testDir / "drafts"
   private val dataFiles = DepositDir(draftsDir, "user01", uuid)
-    .getDataFiles.getOrRecover(e => fail(e))
+    .getDataFiles.getOrRecover(e => fail(e.toString))
 
   "write" should "write content to the path specified" in {
     val content = "Lorem ipsum est"

--- a/src/test/scala/nl.knaw.dans.easy.deposit/DataFilesSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/DataFilesSpec.scala
@@ -33,7 +33,7 @@ class DataFilesSpec extends TestSupportFixture {
 
   private val draftsDir = testDir / "drafts"
   private val dataFiles = DepositDir(draftsDir, "user01", uuid)
-    .getDataFiles.getOrRecover(e => fail(e.toString))
+    .getDataFiles.getOrRecover(e => fail(e.toString, e))
 
   "write" should "write content to the path specified" in {
     val content = "Lorem ipsum est"

--- a/src/test/scala/nl.knaw.dans.easy.deposit/DepositDirSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/DepositDirSpec.scala
@@ -180,6 +180,6 @@ class DepositDirSpec extends TestSupportFixture with MockFactory {
   }
 
   private def createDepositAsPreparation(user: String) = {
-    DepositDir.create(draftsDir, user).getOrRecover(e => fail(e.toString))
+    DepositDir.create(draftsDir, user).getOrRecover(e => fail(e.toString, e))
   }
 }

--- a/src/test/scala/nl.knaw.dans.easy.deposit/DepositDirSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/DepositDirSpec.scala
@@ -180,6 +180,6 @@ class DepositDirSpec extends TestSupportFixture with MockFactory {
   }
 
   private def createDepositAsPreparation(user: String) = {
-    DepositDir.create(draftsDir, user).getOrRecover(e => fail(e))
+    DepositDir.create(draftsDir, user).getOrRecover(e => fail(e.toString))
   }
 }

--- a/src/test/scala/nl.knaw.dans.easy.deposit/DepositDirSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/DepositDirSpec.scala
@@ -179,30 +179,7 @@ class DepositDirSpec extends TestSupportFixture with MockFactory {
     deposit.getDOI(pidMocker) shouldBe Success(doi)
   }
 
-  "writeSplittedDatasetMetadata" should "write 4 files" in {
-    val prologue = """<?xml version='1.0' encoding='UTF-8'?>"""
-    val message = "Lorum ipsum"
-    val datasetMetadata = DatasetMetadata(getManualTestResource("datasetmetadata-from-ui-all.json"))
-      .getOrRecover(e => fail(e))
-      .copy(messageForDataManager = Some(message))
-    val deposit = createDepositAsPreparation("user001")
-    val mdDir = deposit.getDataFiles.getOrRecover(e => fail(e))
-      .filesMetaData.parent.createIfNotExists(asDirectory = true, createParents = true)
-    deposit.writeDatasetMetadataJson(datasetMetadata)
-    val oldSize = (mdDir / "dataset.json").size
-    (mdDir.parent / "data" / "text.txt").touch()
-
-    deposit.splitDatasetMetadata(DateTime.now) shouldBe Success(())
-    (mdDir / "dataset.json").size shouldBe oldSize // the dataset.json file is not changed
-    (mdDir / "message-from-depositor.txt").contentAsString shouldBe message
-    (mdDir / "agreements.xml").lineIterator.next() shouldBe prologue
-    (mdDir / "dataset.xml").lineIterator.next() shouldBe prologue
-    (mdDir / "files.xml").contentAsString should include("""filepath="data/text.txt""")
-  }
-
   private def createDepositAsPreparation(user: String) = {
-    val triedDepositDir = DepositDir.create(draftsDir, user)
-    triedDepositDir should matchPattern { case Success(_) => }
-    triedDepositDir.getOrRecover(e => fail(e))
+    DepositDir.create(draftsDir, user).getOrRecover(e => fail(e))
   }
 }

--- a/src/test/scala/nl.knaw.dans.easy.deposit/SubmitterSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/SubmitterSpec.scala
@@ -34,10 +34,10 @@ class SubmitterSpec extends TestSupportFixture {
     val prologue = """<?xml version='1.0' encoding='UTF-8'?>"""
     val message = "Lorum ipsum"
     val datasetMetadata = DatasetMetadata(getManualTestResource("datasetmetadata-from-ui-all.json"))
-      .getOrRecover(e => fail(e.toString))
+      .getOrRecover(e => fail(e.toString, e))
       .copy(messageForDataManager = Some(message))
-    val depositDir = DepositDir.create(draftsDir, "user").getOrRecover(e => fail(e.toString))
-    val mdDir = depositDir.getDataFiles.getOrRecover(e => fail(e.toString))
+    val depositDir = DepositDir.create(draftsDir, "user").getOrRecover(e => fail(e.toString, e))
+    val mdDir = depositDir.getDataFiles.getOrRecover(e => fail(e.toString, e))
       .filesMetaData.parent.createIfNotExists(asDirectory = true, createParents = true)
     depositDir.writeDatasetMetadataJson(datasetMetadata)
     val oldSize = (mdDir / "dataset.json").size

--- a/src/test/scala/nl.knaw.dans.easy.deposit/SubmitterSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/SubmitterSpec.scala
@@ -34,10 +34,10 @@ class SubmitterSpec extends TestSupportFixture {
     val prologue = """<?xml version='1.0' encoding='UTF-8'?>"""
     val message = "Lorum ipsum"
     val datasetMetadata = DatasetMetadata(getManualTestResource("datasetmetadata-from-ui-all.json"))
-      .getOrRecover(e => fail(e))
+      .getOrRecover(e => fail(e.toString))
       .copy(messageForDataManager = Some(message))
-    val depositDir = DepositDir.create(draftsDir, "user").getOrRecover(e => fail(e))
-    val mdDir = depositDir.getDataFiles.getOrRecover(e => fail(e))
+    val depositDir = DepositDir.create(draftsDir, "user").getOrRecover(e => fail(e.toString))
+    val mdDir = depositDir.getDataFiles.getOrRecover(e => fail(e.toString))
       .filesMetaData.parent.createIfNotExists(asDirectory = true, createParents = true)
     depositDir.writeDatasetMetadataJson(datasetMetadata)
     val oldSize = (mdDir / "dataset.json").size

--- a/src/test/scala/nl.knaw.dans.easy.deposit/SubmitterSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/SubmitterSpec.scala
@@ -15,6 +15,40 @@
  */
 package nl.knaw.dans.easy.deposit
 
-class SubmitterSpec extends TestSupportFixture {
+import nl.knaw.dans.easy.deposit.docs.DatasetMetadata
+import org.joda.time.DateTime
+import nl.knaw.dans.lib.error._
 
+import scala.util.{ Failure, Success }
+
+class SubmitterSpec extends TestSupportFixture {
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+    clearTestDir()
+    draftsDir.createDirectories()
+  }
+
+  private val draftsDir = testDir / "drafts"
+
+  "submit" should "write 4 files" in {
+    val prologue = """<?xml version='1.0' encoding='UTF-8'?>"""
+    val message = "Lorum ipsum"
+    val datasetMetadata = DatasetMetadata(getManualTestResource("datasetmetadata-from-ui-all.json"))
+      .getOrRecover(e => fail(e))
+      .copy(messageForDataManager = Some(message))
+    val depositDir = DepositDir.create(draftsDir, "user").getOrRecover(e => fail(e))
+    val mdDir = depositDir.getDataFiles.getOrRecover(e => fail(e))
+      .filesMetaData.parent.createIfNotExists(asDirectory = true, createParents = true)
+    depositDir.writeDatasetMetadataJson(datasetMetadata)
+    val oldSize = (mdDir / "dataset.json").size
+    (mdDir.parent / "data" / "text.txt").touch()
+
+    new Submitter(null,null).submit(depositDir) shouldBe a[Failure[_]] // implementation incomplete
+
+    (mdDir / "dataset.json").size shouldBe oldSize // the dataset.json file is not changed
+    (mdDir / "message-from-depositor.txt").contentAsString shouldBe message
+    (mdDir / "agreements.xml").lineIterator.next() shouldBe prologue
+    (mdDir / "dataset.xml").lineIterator.next() shouldBe prologue
+    (mdDir / "files.xml").contentAsString should include("""filepath="data/text.txt""")
+  }
 }

--- a/src/test/scala/nl.knaw.dans.easy.deposit/SubmitterSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/SubmitterSpec.scala
@@ -25,7 +25,7 @@ class SubmitterSpec extends TestSupportFixture {
   override def beforeEach(): Unit = {
     super.beforeEach()
     clearTestDir()
-    draftsDir.createDirectories()
+    //draftsDir.createDirectories()
   }
 
   private val draftsDir = testDir / "drafts"

--- a/src/test/scala/nl.knaw.dans.easy.deposit/docs/DatasetMetadataSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/docs/DatasetMetadataSpec.scala
@@ -66,7 +66,7 @@ class DatasetMetadataSpec extends TestSupportFixture {
   }
 
   private def prepareDatasetMetadata(example: String): DatasetMetadata = {
-    DatasetMetadata(example).getOrRecover(e => fail(e))
+    DatasetMetadata(example).getOrRecover(e => fail(e.toString))
   }
 
   "deserialization" should "report additional json info" in {

--- a/src/test/scala/nl.knaw.dans.easy.deposit/docs/DatasetMetadataSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/docs/DatasetMetadataSpec.scala
@@ -66,7 +66,7 @@ class DatasetMetadataSpec extends TestSupportFixture {
   }
 
   private def prepareDatasetMetadata(example: String): DatasetMetadata = {
-    DatasetMetadata(example).getOrRecover(e => fail(e.toString))
+    DatasetMetadata(example).getOrRecover(e => fail(e.toString, e))
   }
 
   "deserialization" should "report additional json info" in {

--- a/src/test/scala/nl.knaw.dans.easy.deposit/docs/DatasetXmlSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/docs/DatasetXmlSpec.scala
@@ -303,14 +303,18 @@ trait DdmBehavior {
   val emptyDDM: Elem
 
   lazy val triedSchema: Try[Schema] = Try { // loading postponed until we actually start validating
-    // TODO get schema from emptyDDM attributes
-    val schemas = "https://easy.dans.knaw.nl/schemas/md/2017/09/ddm.xsd" :: Nil
+    val schemas = emptyDDM.attribute("http://www.w3.org/2001/XMLSchema-instance","schemaLocation")
+      .getOrElse(fail("no schemaLocation attribute"))
+      .headOption
+      .getOrElse(fail("no schemaLocation value"))
+      .text
+      .replaceAll(".* ","") :: Nil
     SchemaFactory
       .newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI)
       .newSchema(schemas.map(xsd => new StreamSource(xsd)).toArray[Source])
   }
 
-  // pretty provides friendlier trouble shooting for complex XML's than Utility.trim
+  // pretty provides friendly trouble shooting for complex XML's
   private val prettyPrinter: PrettyPrinter = new scala.xml.PrettyPrinter(1024, 2)
 
   /**

--- a/src/test/scala/nl.knaw.dans.easy.deposit/docs/DatasetXmlSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/docs/DatasetXmlSpec.scala
@@ -48,12 +48,12 @@ class DatasetXmlSpec extends TestSupportFixture with DdmBehavior {
       |  "audiences": [ { "scheme": "blabla", "key": "D35200", "value": "some audience"} ]
       |}""".stripMargin)
     .doIfFailure { case e => println(e) }
-    .getOrRecover(e => fail(e))
+    .getOrRecover(e => fail(e.toString))
 
   /** provides the verbose namespaces for inline DDM */
   override val emptyDDM: Elem = DatasetXml(minimal)
     .doIfFailure { case e => println(e) }
-    .getOrRecover(e => fail(e))
+    .getOrRecover(e => fail(e.toString))
     .copy(child = Seq())
 
   "minimal" should behave like validDatasetMetadata(
@@ -329,10 +329,10 @@ trait DdmBehavior {
                           ): Unit = {
     lazy val datasetMetadata = input
       .doIfFailure { case e => println(s"$e") }
-      .getOrRecover(e => fail(e))
+      .getOrRecover(e => fail(e.toString))
     lazy val ddm = DatasetXml(datasetMetadata)
       .doIfFailure { case e => println(s"$e") }
-      .getOrRecover(e => fail(e))
+      .getOrRecover(e => fail(e.toString))
 
     if (expectedDdmContent.nonEmpty) it should "generate expected DDM" in {
       prettyPrinter.format(subset(ddm)) shouldBe

--- a/src/test/scala/nl.knaw.dans.easy.deposit/docs/FilesXmlSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/docs/FilesXmlSpec.scala
@@ -58,6 +58,6 @@ class FilesXmlSpec extends TestSupportFixture {
   }
 
   private def createFilesXml = {
-    FilesXml(testDir).getOrRecover(e => fail(e))
+    FilesXml(testDir).getOrRecover(e => fail(e.toString))
   }
 }

--- a/src/test/scala/nl.knaw.dans.easy.deposit/servlets/IntegrationSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/servlets/IntegrationSpec.scala
@@ -50,7 +50,7 @@ class IntegrationSpec extends TestSupportFixture with ServletFixture with Scalat
     val responseBody = post(uri = s"/deposit", headers = Seq(basicAuthentication)) {
       new String(bodyBytes)
     }
-    val uuid = DepositInfo(responseBody).map(_.id.toString).getOrRecover(e => fail(e))
+    val uuid = DepositInfo(responseBody).map(_.id.toString).getOrRecover(e => fail(e.toString))
     val metadataURI = s"/deposit/$uuid/metadata"
 
     // create dataset metadata
@@ -117,7 +117,7 @@ class IntegrationSpec extends TestSupportFixture with ServletFixture with Scalat
     val responseBody = post(uri = s"/deposit", headers = Seq(basicAuthentication)) {
       new String(bodyBytes)
     }
-    val uuid = DepositInfo(responseBody).map(_.id.toString).getOrRecover(e => fail(e))
+    val uuid = DepositInfo(responseBody).map(_.id.toString).getOrRecover(e => fail(e.toString))
 
     val dataFilesBase = DepositDir(testDir / "drafts", "foo", UUID.fromString(uuid)).getDataFiles.get.dataFilesBase
     val times = 500
@@ -143,7 +143,7 @@ class IntegrationSpec extends TestSupportFixture with ServletFixture with Scalat
     val responseBody = post(uri = s"/deposit", headers = Seq(basicAuthentication)) {
       new String(bodyBytes)
     }
-    val uuid = DepositInfo(responseBody).map(_.id.toString).getOrRecover(e => fail(e))
+    val uuid = DepositInfo(responseBody).map(_.id.toString).getOrRecover(e => fail(e.toString))
 
     val dataFilesBase = DepositDir(testDir / "drafts", "foo", UUID.fromString(uuid)).getDataFiles.get.dataFilesBase
 

--- a/src/test/scala/nl.knaw.dans.easy.deposit/servlets/IntegrationSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/servlets/IntegrationSpec.scala
@@ -50,7 +50,7 @@ class IntegrationSpec extends TestSupportFixture with ServletFixture with Scalat
     val responseBody = post(uri = s"/deposit", headers = Seq(basicAuthentication)) {
       new String(bodyBytes)
     }
-    val uuid = DepositInfo(responseBody).map(_.id.toString).getOrRecover(e => fail(e.toString))
+    val uuid = DepositInfo(responseBody).map(_.id.toString).getOrRecover(e => fail(e.toString, e))
     val metadataURI = s"/deposit/$uuid/metadata"
 
     // create dataset metadata
@@ -117,7 +117,7 @@ class IntegrationSpec extends TestSupportFixture with ServletFixture with Scalat
     val responseBody = post(uri = s"/deposit", headers = Seq(basicAuthentication)) {
       new String(bodyBytes)
     }
-    val uuid = DepositInfo(responseBody).map(_.id.toString).getOrRecover(e => fail(e.toString))
+    val uuid = DepositInfo(responseBody).map(_.id.toString).getOrRecover(e => fail(e.toString, e))
 
     val dataFilesBase = DepositDir(testDir / "drafts", "foo", UUID.fromString(uuid)).getDataFiles.get.dataFilesBase
     val times = 500
@@ -143,7 +143,7 @@ class IntegrationSpec extends TestSupportFixture with ServletFixture with Scalat
     val responseBody = post(uri = s"/deposit", headers = Seq(basicAuthentication)) {
       new String(bodyBytes)
     }
-    val uuid = DepositInfo(responseBody).map(_.id.toString).getOrRecover(e => fail(e.toString))
+    val uuid = DepositInfo(responseBody).map(_.id.toString).getOrRecover(e => fail(e.toString, e))
 
     val dataFilesBase = DepositDir(testDir / "drafts", "foo", UUID.fromString(uuid)).getDataFiles.get.dataFilesBase
 


### PR DESCRIPTION
Fixes EASY-1547

#### When applied it will
* allow manual test
* 
* 

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

Use json files in `src/test/resources/manual-test`. A deposit will fail due to a not implemented exception, but the draft bag should get the additional XML files.

#### Related pull requests on github
repo                       | PR                | note
-------------------------- | ----------------- | ----
easy-                      | [PR#](PRlink)     | ..
