### PR TITLE
EASY-1564 deposit properties + EASY-1464 submit: doi and state

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.deposit/DepositDir.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/DepositDir.scala
@@ -166,11 +166,13 @@ case class DepositDir private(baseDir: File, user: String, id: UUID) extends Deb
    * Writes the dataset level metadata for this deposit.
    *
    * @param md the metadata to write
-   *           Changing "identifiers": [{ "scheme": "id-type:DOI", "value": "..."}]
-   *           will cause an error when calling getDOI by an explicit request
-   *           or when getDOI is called implicitly by submit
-   *           because it will not match the deposit properties.
-   *           A "dates": [ { ..., "qualifier": "dcterms:dateSubmitted" }]
+   *           In terms of JSon syntax, content like
+   *           "identifiers": [{ "scheme": "id-type:DOI", "value": "..."}]
+   *           should have been acquired with an explicit getDOI request.
+   *           Otherwise submit will fail because the value
+   *           is out of sync with deposit properties.
+   *           JSon content like
+   *           "dates": [ { ..., "qualifier": "dcterms:dateSubmitted" }]
    *           will cause an error when converted to dataset.xml at submit.
    */
   def writeDatasetMetadataJson(md: DatasetMetadata): Try[Unit] = Try {

--- a/src/main/scala/nl.knaw.dans.easy.deposit/DepositDir.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/DepositDir.scala
@@ -157,15 +157,20 @@ case class DepositDir private(baseDir: File, user: String, id: UUID) extends Deb
    * Writes the dataset level metadata for this deposit.
    *
    * @param md the metadata to write
+   *           Changing "identifiers": [{ "scheme": "id-type:DOI", "value": "..."}]
+   *           will cause an error when calling getDOI by an explicit request
+   *           or when getDOI is called implicitly by submit
+   *           because it will not match the deposit properties.
+   *           A "dates": [ { ..., "qualifier": "dcterms:dateSubmitted" }]
+   *           will cause an error when converted to dataset.xml at submit.
    */
   def writeDatasetMetadataJson(md: DatasetMetadata): Try[Unit] = Try {
-    // TODO DOI should not change, only enforced by client calling getDOI. State and dateSubmitted should not change either.
     datasetMetadataJsonFile.write(toJson(md))
     () // satisfy the compiler which doesn't want a File
   }.recoverWith { case _: NoSuchFileException => notFoundFailure() }
 
   /** create dataset.xml, agreements.xml, files.xml
-   *  from datasetmetadata.json and files in data folder
+   * from datasetmetadata.json and files in data folder
    */
   def createXMLs(dateSubmitted: DateTime): Try[Unit] = {
     for {

--- a/src/main/scala/nl.knaw.dans.easy.deposit/DepositDir.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/DepositDir.scala
@@ -289,6 +289,7 @@ object DepositDir {
       addProperty("creation.timestamp", depositInfo.date)
       addProperty("state.label", depositInfo.state.toString)
       addProperty("state.description", depositInfo.stateDescription)
+      addProperty("depositor.userId", user)
       addProperty("curation.required", "yes")
       addProperty("curation.performed", "no")
       addProperty("bag-store.bag-id", depositInfo.id)

--- a/src/main/scala/nl.knaw.dans.easy.deposit/DepositDir.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/DepositDir.scala
@@ -282,7 +282,9 @@ object DepositDir {
       addProperty("creation.timestamp", depositInfo.date)
       addProperty("state.label", depositInfo.state.toString)
       addProperty("state.description", depositInfo.stateDescription)
-      addProperty("depositor.userId", user)
+      addProperty("curation.required", "yes")
+      addProperty("curation.performed", "no")
+      addProperty("bag-store.bag-id", depositInfo.id)
     }.save(depositDir.depositPropertiesFile.toJava)
 
     depositDir

--- a/src/main/scala/nl.knaw.dans.easy.deposit/DepositDir.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/DepositDir.scala
@@ -75,21 +75,23 @@ case class DepositDir private(baseDir: File, user: String, id: UUID) extends Deb
    */
   def setStateInfo(stateInfo: StateInfo): Try[Unit] = {
     for {
-      props <- getDepositProps
-      currentState = State.withName(props.getString("state.label"))
-      _ <- checkStateTransition(currentState, stateInfo.state)
+      props <- checkStateTransition(stateInfo.state) // read again as submit might have added a DOI
       _ = props.setProperty("state.label", stateInfo.state.toString)
       _ = props.setProperty("state.description", stateInfo.stateDescription.toString)
       _ = props.save()
     } yield ()
   }
 
-  private def checkStateTransition(transition: (State, State)) = {
-    transition match {
-      case (State.draft, State.submitted) => Success(())
-      case (State.rejected, State.draft) => Success(())
-      case (oldState, newState) => Failure(IllegalStateTransitionException(user, id, oldState, newState))
-    }
+  def checkStateTransition(newState: State): Try[PropertiesConfiguration] = {
+    for {
+      props <- getDepositProps
+      currentState = State.withName(props.getString("state.label"))
+      _ <- (currentState, newState) match {
+        case (State.draft, State.submitted) => Success(())
+        case (State.rejected, State.draft) => Success(())
+        case _ => Failure(IllegalStateTransitionException(user, id, currentState, newState))
+      }
+    } yield props
   }
 
   /**

--- a/src/main/scala/nl.knaw.dans.easy.deposit/EasyDepositApiApp.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/EasyDepositApiApp.scala
@@ -61,7 +61,9 @@ class EasyDepositApiApp(configuration: Configuration) extends DebugEnhancedLoggi
   private val draftsDir = getConfiguredDirectory("deposits.drafts")
   private val submitter = new Submitter(
     stagingBaseDir = getConfiguredDirectory("deposits.stage"),
-    submitToBaseDir = getConfiguredDirectory("deposits.submit-to"))
+    submitToBaseDir = getConfiguredDirectory("deposits.submit-to"),
+    pidRequester
+  )
 
   private def getConfiguredDirectory(key: String): File = {
     val dir = File(configuration.properties.getString("deposits.drafts"))

--- a/src/main/scala/nl.knaw.dans.easy.deposit/Submitter.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/Submitter.scala
@@ -16,6 +16,7 @@
 package nl.knaw.dans.easy.deposit
 
 import better.files.File
+import nl.knaw.dans.easy.deposit.PidRequesterComponent.PidRequester
 import org.joda.time.DateTime
 
 import scala.util.Try
@@ -26,7 +27,9 @@ import scala.util.Try
  * @param stagingBaseDir  the base directory for staged copies
  * @param submitToBaseDir the directory to which the staged copy must be moved.
  */
-class Submitter(stagingBaseDir: File, submitToBaseDir: File) {
+class Submitter(stagingBaseDir: File,
+                submitToBaseDir: File,
+                pidRequester: PidRequester) {
 
   /**
    * Submits `depositDir` by writing the file metadata, updating the bag checksums, staging a copy
@@ -38,11 +41,18 @@ class Submitter(stagingBaseDir: File, submitToBaseDir: File) {
   def submit(depositDir: DepositDir): Try[Unit] = {
     // TODO: implement as follows:
     for {
-      // 1. Set state to SUBMITTED
-      _ <- depositDir.createXMLs(DateTime.now)
-      // 5. Update/write bag checksums.
-      // 6. Copy to staging area
-      // 7. Move copy to submit-to area
+      // TODO cache json read (and possibly rewritten) by getDOI for createXMLs?
+      _ <- depositDir.getDOI(pidRequester) // EASY-1464 step 3.3.1 - 3.3.3
+      // EASY-1464 step 3.3.4 validation
+      //   [v] mandatory fields are present and not empty (by DatasetXml(datasetMetadata) in createXMLs)
+      //   [v] DOI in json matches properties (by getDOI)
+      //   [ ] URLs are valid
+      //   [ ] ...
+      _ <- depositDir.createXMLs(DateTime.now) // EASY-1464 3.3.5
+      // EASY-1464 step 3.3.6 Set state to SUBMITTED
+      // EASY-1464 step 3.3.7 Update/write bag checksums.
+      // EASY-1464 step 3.3.8 Copy to staging area
+      // EASY-1464 step 3.3.9 Move copy to submit-to area
     } yield ???
   }
 }

--- a/src/main/scala/nl.knaw.dans.easy.deposit/Submitter.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/Submitter.scala
@@ -17,6 +17,8 @@ package nl.knaw.dans.easy.deposit
 
 import better.files.File
 import nl.knaw.dans.easy.deposit.PidRequesterComponent.PidRequester
+import nl.knaw.dans.easy.deposit.docs.StateInfo
+import nl.knaw.dans.easy.deposit.docs.StateInfo.State
 import org.joda.time.DateTime
 
 import scala.util.Try
@@ -39,6 +41,7 @@ class Submitter(stagingBaseDir: File,
    * @return
    */
   def submit(depositDir: DepositDir): Try[Unit] = {
+    val submitted = StateInfo(State.submitted, "Deposit is ready for processing.")
     // TODO: implement as follows:
     for {
       // TODO cache json read (and possibly rewritten) by getDOI for createXMLs?
@@ -49,7 +52,8 @@ class Submitter(stagingBaseDir: File,
       //   [ ] URLs are valid
       //   [ ] ...
       _ <- depositDir.createXMLs(DateTime.now) // EASY-1464 3.3.5
-      // EASY-1464 step 3.3.6 Set state to SUBMITTED
+      _ <- depositDir.setStateInfo(submitted) // EASY-1464 3.3.6
+      // TODO: the next steps in a worker thread so that submit can return fast for large deposits.
       // EASY-1464 step 3.3.7 Update/write bag checksums.
       // EASY-1464 step 3.3.8 Copy to staging area
       // EASY-1464 step 3.3.9 Move copy to submit-to area

--- a/src/main/scala/nl.knaw.dans.easy.deposit/docs/JsonUtil.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/docs/JsonUtil.scala
@@ -34,7 +34,8 @@ import scala.util.{ Failure, Success, Try }
 object JsonUtil {
 
   case class InvalidDocumentException(s: String, t: Throwable = null)
-    extends Exception(s"invalid $s: ${ t.getClass } ${ t.getMessage }", t)
+    extends Exception(if (t == null) s"invalid $s"
+                      else s"invalid $s: ${ t.getClass } ${ t.getMessage }", t)
 
   class PathSerializer extends CustomSerializer[Path](_ =>
     ( {

--- a/src/test/scala/nl.knaw.dans.easy.deposit/DepositDirSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/DepositDirSpec.scala
@@ -19,10 +19,9 @@ import java.nio.file.attribute.PosixFilePermission
 
 import nl.knaw.dans.easy.deposit.PidRequesterComponent.PidRequester
 import nl.knaw.dans.easy.deposit.PidRequesterComponent.PidType.PidType
+import nl.knaw.dans.easy.deposit.docs.StateInfo
 import nl.knaw.dans.easy.deposit.docs.StateInfo.State
-import nl.knaw.dans.easy.deposit.docs.{ DatasetMetadata, StateInfo }
 import nl.knaw.dans.lib.error._
-import org.joda.time.DateTime
 import org.scalamock.scalatest.MockFactory
 
 import scala.util.{ Failure, Success }
@@ -161,9 +160,7 @@ class DepositDirSpec extends TestSupportFixture with MockFactory {
     val deposit = createDepositAsPreparation(user)
     (deposit.baseDir / user / deposit.id.toString / "bag" / "metadata" / "dataset.json").writeText(s"""{"doi":"$doi"}""")
 
-    val pidMocker = mock[PidRequester] // note that no pid is requested
-
-    deposit.getDOI(pidMocker) should matchPattern { case Failure(CorruptDepositException(_, _, _)) => }
+    deposit.getDOI(null) should matchPattern { case Failure(CorruptDepositException(_, _, _)) => }
   }
 
   it should """return the available DOI""" in {
@@ -174,9 +171,7 @@ class DepositDirSpec extends TestSupportFixture with MockFactory {
     (dd / "bag" / "metadata" / "dataset.json").writeText(s"""{"identifiers":[{"scheme":"id-type:DOI","value":"12345"}]}""")
     (dd / "deposit.properties").writeText(s"""identifier.doi = $doi""")
 
-    val pidMocker = mock[PidRequester] // note that no pid is requested
-
-    deposit.getDOI(pidMocker) shouldBe Success(doi)
+    deposit.getDOI(null) shouldBe Success(doi)
   }
 
   private def createDepositAsPreparation(user: String) = {

--- a/src/test/scala/nl.knaw.dans.easy.deposit/SubmitterSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/SubmitterSpec.scala
@@ -15,40 +15,86 @@
  */
 package nl.knaw.dans.easy.deposit
 
+import nl.knaw.dans.easy.deposit.PidRequesterComponent.PidRequester
+import nl.knaw.dans.easy.deposit.PidRequesterComponent.PidType.PidType
 import nl.knaw.dans.easy.deposit.docs.DatasetMetadata
-import org.joda.time.DateTime
 import nl.knaw.dans.lib.error._
+import org.scalamock.scalatest.MockFactory
 
-import scala.util.{ Failure, Success }
+import scala.util.{ Failure, Success, Try }
 
-class SubmitterSpec extends TestSupportFixture {
+class SubmitterSpec extends TestSupportFixture with MockFactory {
   override def beforeEach(): Unit = {
     super.beforeEach()
     clearTestDir()
-    //draftsDir.createDirectories()
   }
 
-  private val draftsDir = testDir / "drafts"
+  private val customMessage = "Lorum ipsum"
+  private val datasetMetadata = DatasetMetadata(getManualTestResource("datasetmetadata-from-ui-all.json"))
+    .getOrRecover(e => fail("could not get test input", e))
+  private val doi = Try { datasetMetadata.identifiers.get.headOption.get.value }
+    .getOrRecover(e => fail("could not get DOI from test input", e))
 
   "submit" should "write 4 files" in {
-    val prologue = """<?xml version='1.0' encoding='UTF-8'?>"""
-    val message = "Lorum ipsum"
-    val datasetMetadata = DatasetMetadata(getManualTestResource("datasetmetadata-from-ui-all.json"))
-      .getOrRecover(e => fail(e.toString, e))
-      .copy(messageForDataManager = Some(message))
-    val depositDir = DepositDir.create(draftsDir, "user").getOrRecover(e => fail(e.toString, e))
-    val mdDir = depositDir.getDataFiles.getOrRecover(e => fail(e.toString, e))
-      .filesMetaData.parent.createIfNotExists(asDirectory = true, createParents = true)
-    depositDir.writeDatasetMetadataJson(datasetMetadata)
-    val oldSize = (mdDir / "dataset.json").size
+
+    val (depositDir, mdDir, propsFile) = createDeposit(datasetMetadata.copy(messageForDataManager = Some(customMessage)))
+    propsFile.append(s"identifier.doi=$doi")
     (mdDir.parent / "data" / "text.txt").touch()
+    val mdOldSize = (mdDir / "dataset.json").size
+    val propsOldSize = propsFile.size
 
-    new Submitter(null,null).submit(depositDir) shouldBe a[Failure[_]] // implementation incomplete
+    new Submitter(null, null, null).submit(depositDir) should matchPattern {
+      case Failure(e) if e.isInstanceOf[NotImplementedError] =>
+    }
 
-    (mdDir / "dataset.json").size shouldBe oldSize // the dataset.json file is not changed
-    (mdDir / "message-from-depositor.txt").contentAsString shouldBe message
+    val prologue = """<?xml version='1.0' encoding='UTF-8'?>"""
+    propsFile.size shouldBe propsOldSize
+    (mdDir / "dataset.json").size shouldBe mdOldSize
+    (mdDir / "message-from-depositor.txt").contentAsString shouldBe customMessage
     (mdDir / "agreements.xml").lineIterator.next() shouldBe prologue
     (mdDir / "dataset.xml").lineIterator.next() shouldBe prologue
     (mdDir / "files.xml").contentAsString should include("""filepath="data/text.txt""")
+  }
+
+  "submit" should "write empty message-form-depositor file" in {
+
+    val (depositDir, mdDir, propsFile) = createDeposit(datasetMetadata.copy(messageForDataManager = None))
+    propsFile.append(s"identifier.doi=$doi")
+
+    new Submitter(null, null, null).submit(depositDir) should matchPattern {
+      case Failure(e) if e.isInstanceOf[NotImplementedError] =>
+    }
+
+    (mdDir / "message-from-depositor.txt").contentAsString shouldBe ""
+  }
+
+  "submit" should "add DOI to props and json" in {
+
+    val (depositDir, mdDir, propsFile) = createDeposit(datasetMetadata.copy(identifiers = None))
+    val pidMocker = mock[PidRequester]
+    val mockedPid = "12345"
+    (pidMocker.requestPid(_: PidType)) expects * once() returning Success(mockedPid)
+
+    new Submitter(null, null, pidMocker).submit(depositDir) should matchPattern {
+      case Failure(e) if e.isInstanceOf[NotImplementedError] =>
+    }
+
+    propsFile.contentAsString should include(mockedPid)
+    (mdDir / "dataset.json").contentAsString should include(mockedPid)
+  }
+
+  private def getMetadataDir(depositDir: DepositDir) = {
+    depositDir
+      .getDataFiles
+      .getOrRecover(e => fail(e.toString, e))
+      .filesMetaData
+      .parent
+  }
+
+  private def createDeposit(metadata: DatasetMetadata) = {
+    val depositDir = DepositDir.create(testDir / "drafts", "user").getOrRecover(e => fail(e.toString, e))
+    depositDir.writeDatasetMetadataJson(metadata)
+    val mdDir = getMetadataDir(depositDir)
+    (depositDir, mdDir, mdDir.parent.parent / "deposit.properties")
   }
 }

--- a/src/test/scala/nl.knaw.dans.easy.deposit/SubmitterSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/SubmitterSpec.scala
@@ -17,6 +17,7 @@ package nl.knaw.dans.easy.deposit
 
 import nl.knaw.dans.easy.deposit.PidRequesterComponent.PidRequester
 import nl.knaw.dans.easy.deposit.PidRequesterComponent.PidType.PidType
+import nl.knaw.dans.easy.deposit.docs.JsonUtil.InvalidDocumentException
 import nl.knaw.dans.easy.deposit.docs.StateInfo.State
 import nl.knaw.dans.easy.deposit.docs.{ DatasetMetadata, StateInfo }
 import nl.knaw.dans.lib.error._
@@ -86,6 +87,29 @@ class SubmitterSpec extends TestSupportFixture with MockFactory {
     }
 
     depositDir.getDOI(null) shouldBe Success(mockedPid)
+  }
+
+  "submit" should "reject an inconsistent DOI" in {
+    // invalid state transition is tested with IntegrationSpec
+
+    val (depositDir, _, _) = createDeposit(datasetMetadata)
+
+    new Submitter(null, null, null).submit(depositDir) should matchPattern {
+      case Failure(e) if e.isInstanceOf[CorruptDepositException] =>
+    }
+  }
+
+  "submit" should "reject an incomplete json" in {
+    // other validation errors are tested with DatasetXmlSpec and DepositDirSpec
+
+    val (depositDir, _, _) = createDeposit(DatasetMetadata())
+    val pidMocker = mock[PidRequester]
+    val mockedPid = "12345"
+    (pidMocker.requestPid(_: PidType)) expects * once() returning Success(mockedPid)
+
+    new Submitter(null, null, pidMocker).submit(depositDir) should matchPattern {
+      case Failure(e) if e.isInstanceOf[InvalidDocumentException] =>
+    }
   }
 
   private def getMetadataDir(depositDir: DepositDir) = {

--- a/src/test/scala/nl.knaw.dans.easy.deposit/servlets/DepositServletErrorSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/servlets/DepositServletErrorSpec.scala
@@ -82,7 +82,7 @@ class DepositServletErrorSpec extends TestSupportFixture with ServletFixture wit
     }
   }
 
-  s"get /:uuid/metadata" should "report a currupt dataset" in {
+  s"get /:uuid/metadata" should "report a corrupt dataset" in {
     (mockedApp.getDatasetMetadataForDeposit(_: String, _: UUID)) expects("foo", uuid) returning
       Failure(CorruptDepositException("foo", uuid.toString, new Exception("invalid json")))
 

--- a/src/test/scala/nl.knaw.dans.easy.deposit/servlets/IntegrationSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/servlets/IntegrationSpec.scala
@@ -184,6 +184,7 @@ class IntegrationSpec extends TestSupportFixture with ServletFixture with Scalat
       status shouldBe FORBIDDEN_403
       body shouldBe s"Cannot transition from ARCHIVED to SUBMITTED (deposit id: $uuid, user: foo)"
     }
+    (testDir / "drafts" / "foo" / uuid.toString / "metatada").entries.size shouldBe 1 // still just the json
   }
 
   private def randomContent(times: Int) = {

--- a/src/test/scala/nl.knaw.dans.easy.deposit/servlets/IntegrationSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/servlets/IntegrationSpec.scala
@@ -184,7 +184,9 @@ class IntegrationSpec extends TestSupportFixture with ServletFixture with Scalat
       status shouldBe FORBIDDEN_403
       body shouldBe s"Cannot transition from ARCHIVED to SUBMITTED (deposit id: $uuid, user: foo)"
     }
-    (testDir / "drafts" / "foo" / uuid.toString / "metatada").entries.size shouldBe 1 // still just the json
+
+    // submit did not complain about missing metadata, so the state transition check indeed came first
+    (testDir / "drafts" / "foo" / uuid.toString / "bag" / "metatada").toJava shouldNot exist
   }
 
   private def randomContent(times: Int) = {


### PR DESCRIPTION
Fixes EASY-1464 + some more steps of EASY-1464

#### When applied it will
* add the fields that wre still missing from the deposit.properties
* add a DOI if not yet available
* check state transition before submit actions
* change the state

#### Where should the reviewer @DANS-KNAW/easy start?

SubmitterSpec and a new test in IntegrationSpec illustrate the implemented changes.

#### How should this be manually tested?

Submit will fail with a not implemented exception but metadata files should be created/changed.

#### Related pull requests on github
repo                       | PR                | note
-------------------------- | ----------------- | ----
easy-                      | [PR#](PRlink)     | ..
