### PR TITLE
EASY-1464 submit

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,11 @@
             <artifactId>dans-scala-lib_2.12</artifactId>
         </dependency>
         <dependency>
+            <groupId>nl.knaw.dans.lib</groupId>
+            <artifactId>dans-bag-lib_2.12</artifactId>
+            <version>1.0.0-SNAPSHOT</version>
+        </dependency>
+        <dependency>
             <groupId>com.jsuereth</groupId>
             <artifactId>scala-arm_2.12</artifactId>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
         <dependency>
             <groupId>nl.knaw.dans.lib</groupId>
             <artifactId>dans-bag-lib_2.12</artifactId>
-            <version>1.0.0-SNAPSHOT</version>
+            <version>1.0.0-beta-1</version>
         </dependency>
         <dependency>
             <groupId>com.jsuereth</groupId>

--- a/src/main/scala/nl.knaw.dans.easy.deposit/DataFiles.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/DataFiles.scala
@@ -29,9 +29,8 @@ import scala.util.Try
  * in this.
  *
  * @param dataFilesBase the base directory of the data files
- * @param filesMetaData the file containing the file metadata
  */
-case class DataFiles(dataFilesBase: File, filesMetaData: File) extends DebugEnhancedLogging {
+case class DataFiles(dataFilesBase: File) extends DebugEnhancedLogging {
 
   /**
    * Lists information about the files the directory `path` and its subdirectories.

--- a/src/main/scala/nl.knaw.dans.easy.deposit/DepositDir.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/DepositDir.scala
@@ -49,11 +49,7 @@ case class DepositDir private(baseDir: File, user: String, id: UUID) extends Deb
   private val metadataDir = bagDir / "metadata"
   private val dataFilesDir = bagDir / "data"
   private val depositPropertiesFile = bagDir.parent / "deposit.properties"
-  private val datasetMetadataJsonFile = metadataDir / "dataset.json"
-  private val msgFromDepositorFile = metadataDir / "message-from-depositor.txt"
-  private val agreementsFile = metadataDir / "agreements.xml"
-  private val datasetXmlFile = metadataDir / "dataset.xml"
-  private val filesXmlFile = metadataDir / "files.xml"
+  val datasetMetadataJsonFile = metadataDir / "dataset.json"
 
   /**
    * @return an information object about the current state of the desposit.
@@ -180,27 +176,11 @@ case class DepositDir private(baseDir: File, user: String, id: UUID) extends Deb
     () // satisfy the compiler which doesn't want a File
   }.recoverWith { case _: NoSuchFileException => notFoundFailure() }
 
-  /** create dataset.xml, agreements.xml, files.xml
-   * from datasetmetadata.json and files in data folder
-   */
-  def createXMLs(dateSubmitted: DateTime): Try[Unit] = {
-    for {
-      datasetMetadata <- getDatasetMetadata // TODO skip recover? Depends on to be implemented submit.
-      _ = msgFromDepositorFile.write(datasetMetadata.messageForDataManager.getOrElse(""))
-      agreementsXml <- AgreementsXml(user, dateSubmitted, datasetMetadata)
-      _ <- agreementsFile.writePretty(agreementsXml)
-      datasetXml <- DatasetXml(datasetMetadata)
-      _ <- datasetXmlFile.writePretty(datasetXml)
-      filesXml <- FilesXml(dataFilesDir.parent)
-      _ <- filesXmlFile.writePretty(filesXml)
-    } yield ()
-  }
-
   /**
    * @return object to access the data files of this deposit
    */
   def getDataFiles: Try[DataFiles] = Try {
-    DataFiles(dataFilesDir, metadataDir / "files.xml")
+    DataFiles(dataFilesDir)
   }
 
   /**

--- a/src/main/scala/nl.knaw.dans.easy.deposit/DepositDir.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/DepositDir.scala
@@ -49,7 +49,7 @@ case class DepositDir private(baseDir: File, user: String, id: UUID) extends Deb
   private val metadataDir = bagDir / "metadata"
   private val dataFilesDir = bagDir / "data"
   private val depositPropertiesFile = bagDir.parent / "deposit.properties"
-  val datasetMetadataJsonFile = metadataDir / "dataset.json"
+  private val datasetMetadataJsonFile = metadataDir / "dataset.json"
 
   /**
    * @return an information object about the current state of the desposit.

--- a/src/main/scala/nl.knaw.dans.easy.deposit/EasyDepositApiApp.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/EasyDepositApiApp.scala
@@ -66,7 +66,7 @@ class EasyDepositApiApp(configuration: Configuration) extends DebugEnhancedLoggi
   )
 
   private def getConfiguredDirectory(key: String): File = {
-    val dir = File(configuration.properties.getString("deposits.drafts"))
+    val dir = File(configuration.properties.getString(key))
 
     if (!dir.exists) throw ConfigurationException(s"Configured directory '$key' does not exist: $dir")
     if (!dir.isDirectory) throw ConfigurationException(s"Configured directory '$key' is a regular file: $dir")

--- a/src/main/scala/nl.knaw.dans.easy.deposit/Submitter.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/Submitter.scala
@@ -15,6 +15,8 @@
  */
 package nl.knaw.dans.easy.deposit
 
+import java.nio.file.Paths
+
 import better.files.File
 import nl.knaw.dans.bag.v0.DansV0Bag
 import nl.knaw.dans.easy.deposit.PidRequesterComponent.PidRequester
@@ -39,41 +41,39 @@ class Submitter(stagingBaseDir: File,
    * @param depositDir the deposit directory to submit
    * @return
    */
-  def submit(depositDir: DepositDir): Try[Unit] = {
-    for {
-      // TODO cache json read (and possibly rewritten) by getDOI and  getDatasetMetadata?
-      // EASY-1464 step 3.3.1 - 3.3.3
-      _ <- depositDir.getDOI(pidRequester)
-      // EASY-1464 step 3.3.4 validation
-      //   [v] mandatory fields are present and not empty (by DatasetXml(datasetMetadata) in createXMLs)
-      //   [v] DOI in json matches properties (by getDOI)
-      //   [ ] URLs are valid
-      //   [ ] ...
-      // EASY-1464 3.3.5.a: generate (with some implicit validation) content for metadata files
-      dataFilesDir <- depositDir.getDataFiles.map(_.dataFilesBase)
-      datasetMetadata <- depositDir.getDatasetMetadata // TODO skip recover: internal error if not catched by getDOI
-      agreementsXml <- AgreementsXml(depositDir.user, DateTime.now, datasetMetadata)
-      datasetXml <- DatasetXml(datasetMetadata)
-      msg = datasetMetadata.messageForDataManager.getOrElse("")
-      filesXml <- FilesXml(dataFilesDir)
-      // EASY-1464 3.3.8.a create empty staged bag to take a copy of the deposit
-      stageDir = (stagingBaseDir / depositDir.id.toString).createDirectories()
-      stageBag <- DansV0Bag.empty(stageDir / "bag").map(_.withEasyUserAccount(depositDir.user))
-      // EASY-1464 3.3.6 change state and copy with the rest of the deposit properties to staged dir
-      _ <- depositDir.setStateInfo(StateInfo(StateInfo.State.submitted, "Deposit is ready for processing."))
-      propsFileName = "deposit.properties"
-      _ = (dataFilesDir.parent.parent / propsFileName).copyTo(stageDir / propsFileName)
-      // EASY-1464 3.3.5.b: write files to metadata
-      _ = stageBag.addTagFile(msg.asInputStream)(_ / "metadata" / "message-from-depositor.txt")
-      _ <- stageBag.addTagFile(agreementsXml.serialize.asInputStream)(_ / "metadata" / "agreements.xml")
-      _ <- stageBag.addTagFile(datasetXml.serialize.asInputStream)(_ / "metadata" / "dataset.xml")
-      _ <- stageBag.addTagFile(filesXml.serialize.asInputStream)(_ / "metadata" / "files.xml")
-      // TODO: the next steps in a worker thread so that submit can return fast for large deposits.
-      // EASY-1464 3.3.7 checksums +  3.3.8.b copy files
-      _ <- dataFilesDir.children.failFastMap(f => stageBag.addPayloadFile(f)(_ / dataFilesDir.relativize(f).toString))
-      _ <- stageBag.save() // TODO after each file to allow resume?
-      // EASY-1464 step 3.3.9 Move copy to submit-to area
-      _ = stageDir.moveTo(submitToBaseDir / depositDir.id.toString)
-    } yield ()
-  }
+  def submit(depositDir: DepositDir): Try[Unit] = for {
+    // TODO cache json read (and possibly rewritten) by getDOI and  getDatasetMetadata?
+    // EASY-1464 step 3.3.1 - 3.3.3
+    _ <- depositDir.getDOI(pidRequester)
+    // EASY-1464 step 3.3.4 validation
+    //   [v] mandatory fields are present and not empty (by DatasetXml(datasetMetadata) in createXMLs)
+    //   [v] DOI in json matches properties (by getDOI)
+    //   [ ] URLs are valid
+    //   [ ] ...
+    // EASY-1464 3.3.5.a: generate (with some implicit validation) content for metadata files
+    dataFilesDir <- depositDir.getDataFiles.map(_.dataFilesBase)
+    datasetMetadata <- depositDir.getDatasetMetadata // TODO skip recover: internal error if not catched by getDOI
+    agreementsXml <- AgreementsXml(depositDir.user, DateTime.now, datasetMetadata)
+    datasetXml <- DatasetXml(datasetMetadata)
+    msg = datasetMetadata.messageForDataManager.getOrElse("")
+    filesXml <- FilesXml(dataFilesDir)
+    // EASY-1464 3.3.8.a create empty staged bag to take a copy of the deposit
+    stageDir = (stagingBaseDir / depositDir.id.toString).createDirectories()
+    stageBag <- DansV0Bag.empty(stageDir / "bag").map(_.withEasyUserAccount(depositDir.user))
+    // EASY-1464 3.3.6 change state and copy with the rest of the deposit properties to staged dir
+    _ <- depositDir.setStateInfo(StateInfo(StateInfo.State.submitted, "Deposit is ready for processing."))
+    propsFileName = "deposit.properties"
+    _ = (dataFilesDir.parent.parent / propsFileName).copyTo(stageDir / propsFileName)
+    // EASY-1464 3.3.5.b: write files to metadata
+    _ = stageBag.addMetadataFile(msg, "message-from-depositor.txt")
+    _ <- stageBag.addMetadataFile(agreementsXml, "agreements.xml")
+    _ <- stageBag.addMetadataFile(datasetXml, "dataset.xml")
+    _ <- stageBag.addMetadataFile(filesXml, "files.xml")
+    // TODO: the next steps in a worker thread so that submit can return fast for large deposits.
+    // EASY-1464 3.3.7 checksums +  3.3.8.b copy files
+    _ <- stageBag.addPayloadFile(dataFilesDir, Paths.get("."))
+    _ <- stageBag.save() // TODO after each file to allow resume?
+    // EASY-1464 step 3.3.9 Move copy to submit-to area
+    _ = stageDir.moveTo(submitToBaseDir / depositDir.id.toString)
+  } yield ()
 }

--- a/src/main/scala/nl.knaw.dans.easy.deposit/Submitter.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/Submitter.scala
@@ -15,6 +15,9 @@
  */
 package nl.knaw.dans.easy.deposit
 
+import java.io.ByteArrayInputStream
+import java.nio.charset.StandardCharsets
+
 import better.files.File
 import nl.knaw.dans.bag.v0.DansV0Bag
 import nl.knaw.dans.easy.deposit.PidRequesterComponent.PidRequester
@@ -45,7 +48,6 @@ class Submitter(stagingBaseDir: File,
     val agreementsFile = stageMetadataDir / "agreements.xml"
     val datasetXmlFile = stageMetadataDir / "dataset.xml"
     val filesXmlFile = stageMetadataDir / "files.xml"
-    val msgFromDepositorFile = stageMetadataDir / "message-from-depositor.txt"
     val propsFileName = "deposit.properties"
     val submitted = StateInfo(StateInfo.State.submitted, "Deposit is ready for processing.")
     // TODO: implement as follows:
@@ -73,8 +75,7 @@ class Submitter(stagingBaseDir: File,
       _ = stageBag.withEasyUserAccount(depositDir.user)
       _ = (dataFilesDir.parent.parent / propsFileName).copyTo(stageDir / propsFileName)
       // EASY-1464 3.3.5 part 2: write xml files to metadata // TODO sha's?
-      _ = stageMetadataDir.createDirectories()
-      _ = msgFromDepositorFile.write(msg)
+      _ = stageBag.addTagFile(msg.asInputStream)(_ / "metadata" / "message-from-depositor.txt")
       _ <- agreementsFile.writePretty(agreementsXml)
       _ <- datasetXmlFile.writePretty(datasetXml)
       _ <- filesXmlFile.writePretty(filesXml)

--- a/src/main/scala/nl.knaw.dans.easy.deposit/Submitter.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/Submitter.scala
@@ -73,7 +73,7 @@ class Submitter(stagingBaseDir: File,
       _ <- dataFilesDir.children.failFastMap(f => stageBag.addPayloadFile(f)(_ / dataFilesDir.relativize(f).toString))
       _ <- stageBag.save() // TODO after each file to allow resume?
       // EASY-1464 step 3.3.9 Move copy to submit-to area
-      //TODO _ = stageDir.moveTo(submitToBaseDir / depositDir.id.toString)
-    } yield ???
+      _ = stageDir.moveTo(submitToBaseDir / depositDir.id.toString)
+    } yield ()
   }
 }

--- a/src/main/scala/nl.knaw.dans.easy.deposit/Submitter.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/Submitter.scala
@@ -18,10 +18,10 @@ package nl.knaw.dans.easy.deposit
 import better.files.File
 import nl.knaw.dans.bag.v0.DansV0Bag
 import nl.knaw.dans.easy.deposit.PidRequesterComponent.PidRequester
-import nl.knaw.dans.easy.deposit.docs.StateInfo
+import nl.knaw.dans.easy.deposit.docs.{ AgreementsXml, DatasetXml, FilesXml, StateInfo }
 import org.joda.time.DateTime
 
-import scala.util.{ Failure, Try }
+import scala.util.Try
 
 /**
  * Object that contains the logic for submitting a deposit.
@@ -41,37 +41,49 @@ class Submitter(stagingBaseDir: File,
    */
   def submit(depositDir: DepositDir): Try[Unit] = {
     val stageDir = stagingBaseDir / depositDir.id.toString
+    val stageMetadataDir = stageDir / "bag" / "metadata"
+    val agreementsFile = stageMetadataDir / "agreements.xml"
+    val datasetXmlFile = stageMetadataDir / "dataset.xml"
+    val filesXmlFile = stageMetadataDir / "files.xml"
+    val msgFromDepositorFile = stageMetadataDir / "message-from-depositor.txt"
+    val propsFileName = "deposit.properties"
     val submitted = StateInfo(StateInfo.State.submitted, "Deposit is ready for processing.")
     // TODO: implement as follows:
     for {
-      // TODO cache json read (and possibly rewritten) by getDOI for createXMLs?
-      _ <- depositDir.getDOI(pidRequester) // EASY-1464 step 3.3.1 - 3.3.3
+      // TODO cache json read (and possibly rewritten) by getDOI and  getDatasetMetadata?
+      // EASY-1464 step 3.3.1 - 3.3.3
+      _ <- depositDir.getDOI(pidRequester)
       // EASY-1464 step 3.3.4 validation
       //   [v] mandatory fields are present and not empty (by DatasetXml(datasetMetadata) in createXMLs)
       //   [v] DOI in json matches properties (by getDOI)
       //   [ ] URLs are valid
       //   [ ] ...
-      _ <- depositDir.createXMLs(DateTime.now) // EASY-1464 3.3.5
-      _ <- depositDir.setStateInfo(submitted) // EASY-1464 3.3.6
-      // EASY-1464 step 3.3.7 Update/write bag checksums.
-      // EASY-1464 step 3.3.8 Copy to staging area
+      // EASY-1464 3.3.5 part 1: generate xml file content for metadata
       dataFilesDir <- depositDir.getDataFiles.map(_.dataFilesBase)
-      bag <- DansV0Bag.empty(stageDir / "bag")
-      _ = bag.withEasyUserAccount(depositDir.user)
-      _ <- copyProps(stageDir, dataFilesDir.parent.parent)
+      datasetMetadata <- depositDir.getDatasetMetadata // TODO skip recover: internal error if not catched by getDOI
+      agreementsXml <- AgreementsXml(depositDir.user, DateTime.now, datasetMetadata)
+      datasetXml <- DatasetXml(datasetMetadata)
+      msg = datasetMetadata.messageForDataManager.getOrElse("")
+      filesXml <- FilesXml(dataFilesDir)
+      _ = stageDir.createDirectories()
+      // EASY-1464 3.3.8.a
+      stageBag <- DansV0Bag.empty(stageDir / "bag")
+      // EASY-1464 3.3.6
+      _ <- depositDir.setStateInfo(submitted)
+      _ = stageBag.withEasyUserAccount(depositDir.user)
+      _ = (dataFilesDir.parent.parent / propsFileName).copyTo(stageDir / propsFileName)
+      // EASY-1464 3.3.5 part 2: write xml files to metadata // TODO sha's?
+      _ = stageMetadataDir.createDirectories()
+      _ = msgFromDepositorFile.write(msg)
+      _ <- agreementsFile.writePretty(agreementsXml)
+      _ <- datasetXmlFile.writePretty(datasetXml)
+      _ <- filesXmlFile.writePretty(filesXml)
       // TODO: the next steps in a worker thread so that submit can return fast for large deposits.
-      _ <- dataFilesDir.children.failFastMap(f => bag.addPayloadFile(f)(_ / dataFilesDir.relativize(f).toString))
-      _ <- bag.save() // TODO after each file to allow resume?
+      // EASY-1464 3.3.7 checksums +  3.3.8.b copy files
+      _ <- dataFilesDir.children.failFastMap(f => stageBag.addPayloadFile(f)(_ / dataFilesDir.relativize(f).toString))
+      _ <- stageBag.save() // TODO after each file to allow resume?
       // EASY-1464 step 3.3.9 Move copy to submit-to area
+      //_ = stageDir.moveTo(submitToBaseDir / depositDir.id.toString)
     } yield ???
-  }
-
-  private def copyProps(stageDir: File, dataFilesDir: File) = {
-    val props = "deposit.properties"
-    Try {
-      (dataFilesDir / props).copyTo(stageDir / props)
-    }.recoverWith {
-      case e => Failure(new Exception(s"could not copy $props: ${ e.getClass } ${ e.getMessage }", e))
-    }
   }
 }

--- a/src/main/scala/nl.knaw.dans.easy.deposit/docs/FilesXml.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/docs/FilesXml.scala
@@ -34,9 +34,8 @@ object FilesXml {
     val files = pathData
       .listRecursively()
       .collect { case file if file.isRegularFile =>
-        val fileName = pathData.relativize(file).toString
-        <file filepath={fileName}>
-          <dcterms:format>{tika.detect(fileName)}</dcterms:format>
+        <file filepath={pathData.parent.relativize(file).toString}>
+          <dcterms:format>{tika.detect(file.toJava)}</dcterms:format>
         </file>
       }
 

--- a/src/main/scala/nl.knaw.dans.easy.deposit/package.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/package.scala
@@ -16,11 +16,12 @@
 package nl.knaw.dans.easy
 
 import java.io.{ ByteArrayInputStream, InputStream }
-import java.nio.charset.{ Charset, StandardCharsets }
-import java.nio.file.Path
+import java.nio.charset.StandardCharsets
+import java.nio.file.{ Path, Paths }
 import java.util.UUID
 
 import better.files.{ File, Files }
+import nl.knaw.dans.bag.v0.DansV0Bag
 import nl.knaw.dans.easy.deposit.docs.StateInfo.State.State
 
 import scala.util.{ Success, Try }
@@ -58,6 +59,15 @@ package object deposit {
       val printer = new PrettyPrinter(160, 2)
       val trimmed = Utility.trim(elem)
       prologue + "\n" + printer.format(trimmed)
+    }
+  }
+  implicit class BagExtensions(val bag: DansV0Bag) {
+    def addMetadataFile(content: Elem, target: String): Try[Any] = {
+      bag.addTagFile(content.serialize.asInputStream, Paths.get(s"metadata/$target"))
+    }
+
+    def addMetadataFile(content: String, target: String): Try[Any] = {
+      bag.addTagFile(content.asInputStream, Paths.get(s"metadata/$target"))
     }
   }
 

--- a/src/main/scala/nl.knaw.dans.easy.deposit/package.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/package.scala
@@ -24,7 +24,7 @@ import better.files.{ File, Files }
 import nl.knaw.dans.easy.deposit.docs.StateInfo.State.State
 
 import scala.util.{ Success, Try }
-import scala.xml.{ Elem, PrettyPrinter, Utility, XML }
+import scala.xml._
 
 package object deposit {
 
@@ -50,10 +50,14 @@ package object deposit {
    */
   case class FileInfo(fileName: String, dirPath: Path, sha1sum: String)
 
-  implicit class FileExtensions(val file: File) extends AnyVal {
-    def writePretty(elem: Elem): Try[Unit] = Try {
-      val pretty = XML.loadString(new PrettyPrinter(160, 2).format(Utility.trim(elem)))
-      XML.save(file.toString, pretty, Charset.forName("UTF-8").toString, xmlDecl = true)
+  val prologue = """<?xml version='1.0' encoding='UTF-8'?>"""
+
+  implicit class XmlExtensions(val elem: Elem) extends AnyVal {
+
+    def serialize: String = {
+      val printer = new PrettyPrinter(160, 2)
+      val trimmed = Utility.trim(elem)
+      prologue + "\n" + printer.format(trimmed)
     }
   }
 

--- a/src/main/scala/nl.knaw.dans.easy.deposit/package.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/package.scala
@@ -15,7 +15,8 @@
  */
 package nl.knaw.dans.easy
 
-import java.nio.charset.Charset
+import java.io.{ ByteArrayInputStream, InputStream }
+import java.nio.charset.{ Charset, StandardCharsets }
 import java.nio.file.Path
 import java.util.UUID
 
@@ -55,9 +56,16 @@ package object deposit {
       XML.save(file.toString, pretty, Charset.forName("UTF-8").toString, xmlDecl = true)
     }
   }
+
   implicit class FilesExtensions(val files: Files) {
     def failFastMap(f: File => Try[Any]): Try[Any] = {
       files.toStream.map(f).find(_.isFailure).getOrElse(Success(()))
+    }
+  }
+
+  implicit class StringExtensions(val s: String) {
+    def asInputStream: InputStream = {
+      new ByteArrayInputStream(s.getBytes(StandardCharsets.UTF_8))
     }
   }
 }

--- a/src/main/scala/nl.knaw.dans.easy.deposit/package.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/package.scala
@@ -19,10 +19,10 @@ import java.nio.charset.Charset
 import java.nio.file.Path
 import java.util.UUID
 
-import better.files.File
+import better.files.{ File, Files }
 import nl.knaw.dans.easy.deposit.docs.StateInfo.State.State
 
-import scala.util.Try
+import scala.util.{ Success, Try }
 import scala.xml.{ Elem, PrettyPrinter, Utility, XML }
 
 package object deposit {
@@ -53,6 +53,11 @@ package object deposit {
     def writePretty(elem: Elem): Try[Unit] = Try {
       val pretty = XML.loadString(new PrettyPrinter(160, 2).format(Utility.trim(elem)))
       XML.save(file.toString, pretty, Charset.forName("UTF-8").toString, xmlDecl = true)
+    }
+  }
+  implicit class FilesExtensions(val files: Files) {
+    def failFastMap(f: File => Try[Any]): Try[Any] = {
+      files.toStream.map(f).find(_.isFailure).getOrElse(Success(()))
     }
   }
 }

--- a/src/test/scala/nl.knaw.dans.easy.deposit/SubmitterSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/SubmitterSpec.scala
@@ -64,6 +64,9 @@ class SubmitterSpec extends TestSupportFixture with MockFactory {
     depositDir.getStateInfo should matchPattern {
       case Success(StateInfo(State.submitted, "Deposit is ready for processing.")) =>
     }
+    propsFile.contentAsString shouldBe (testDir / "staged" / depositDir.id.toString / "deposit.properties").contentAsString
+    (propsFile / ".." / "bag" / "data").children.size shouldBe
+      (testDir / "staged" / depositDir.id.toString / "bag" / "data").children.size
   }
 
   it should "write empty message-from-depositor file" in {

--- a/src/test/scala/nl.knaw.dans.easy.deposit/SubmitterSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/SubmitterSpec.scala
@@ -39,37 +39,42 @@ class SubmitterSpec extends TestSupportFixture with MockFactory {
 
   "submit" should "write 4 files" in {
 
+    // preparations
     val depositDir = createDeposit(datasetMetadata.copy(messageForDataManager = Some(customMessage)))
     val bagDir = getBagDir(depositDir)
     (bagDir.parent / "deposit.properties").append(s"identifier.doi=$doi")
     (bagDir / "data" / "text.txt").touch()
     (bagDir / "data" / "folder").createDirectories()
     (bagDir / "data" / "folder" / "text.txt").write("Lorum ipsum")
-    val mdOldSize = (bagDir / "metadata" / "dataset.json").size
-    depositDir.getStateInfo should matchPattern {
+    (testDir / "submitted").createDirectories()
+
+    // preconditions
+    val mdOldSize = (bagDir / "metadata" / "dataset.json").size // should not change
+    depositDir.getStateInfo should matchPattern { // should change
       case Success(StateInfo(State.draft, "Deposit is open for changes.")) =>
     }
 
-    new Submitter(testDir / "staged", null, null).submit(depositDir) should matchPattern {
-      case Failure(e) if e.isInstanceOf[NotImplementedError] =>
-    }
+    // the test
+    new Submitter(testDir / "staged", testDir / "submitted", null)
+      .submit(depositDir) should matchPattern { case Success(()) => }
 
+    // post conditions
+    (testDir / "staged").children.size shouldBe 0
     (bagDir / "metadata" / "dataset.json").size shouldBe mdOldSize // no DOI added
-    val stagedBagDir = testDir / "staged" / depositDir.id.toString / "bag"
-    (stagedBagDir / "metadata" / "message-from-depositor.txt").contentAsString shouldBe customMessage
-    (stagedBagDir / "metadata" / "agreements.xml").lineIterator.next() shouldBe prologue
-    (stagedBagDir / "metadata" / "dataset.xml").lineIterator.next() shouldBe prologue
-    (stagedBagDir / "data").children.size shouldBe (bagDir / "data").children.size
-    (stagedBagDir / "tagmanifest-sha1.txt").lines.size shouldBe 7 // tag files including metadata/*
-    (stagedBagDir / "manifest-sha1.txt").lines.size shouldBe 2 // the data files
-    (stagedBagDir / "metadata" / "files.xml").contentAsString.matches("(?s).*(filepath=.*){2}.*") shouldBe true
-    (stagedBagDir.parent / "deposit.properties").contentAsString shouldBe
+    val submittedBagDir = testDir / "submitted" / depositDir.id.toString / "bag"
+    (submittedBagDir / "metadata" / "message-from-depositor.txt").contentAsString shouldBe customMessage
+    (submittedBagDir / "metadata" / "agreements.xml").lineIterator.next() shouldBe prologue
+    (submittedBagDir / "metadata" / "dataset.xml").lineIterator.next() shouldBe prologue
+    (submittedBagDir / "data").children.size shouldBe (bagDir / "data").children.size
+    (submittedBagDir / "tagmanifest-sha1.txt").lines.size shouldBe 7 // tag files including metadata/*
+    (submittedBagDir / "manifest-sha1.txt").lines.size shouldBe 2 // the data files
+    (submittedBagDir / "metadata" / "files.xml").contentAsString.matches("(?s).*(filepath=.*){2}.*") shouldBe true
+    (submittedBagDir.parent / "deposit.properties").contentAsString shouldBe
       (bagDir.parent / "deposit.properties").contentAsString
     depositDir.getDOI(null) shouldBe Success(doi) // no pid-requester so obtained from json and/or props
     depositDir.getStateInfo should matchPattern {
       case Success(StateInfo(State.submitted, "Deposit is ready for processing.")) =>
     }
-    // TODO compare number of files.xml eleents with number of files
   }
 
   it should "write empty message-from-depositor file" in {
@@ -77,12 +82,12 @@ class SubmitterSpec extends TestSupportFixture with MockFactory {
     val depositDir = createDeposit(datasetMetadata.copy(messageForDataManager = None))
     val bagDir = getBagDir(depositDir)
     (bagDir.parent / "deposit.properties").append(s"identifier.doi=$doi")
+    (testDir / "submitted").createDirectories()
 
-    new Submitter(testDir / "staged", null, null).submit(depositDir) should matchPattern {
-      case Failure(e) if e.isInstanceOf[NotImplementedError] =>
-    }
+    new Submitter(testDir / "staged", testDir / "submitted", null)
+      .submit(depositDir) should matchPattern { case Success(()) => }
 
-    (testDir / "staged" / depositDir.id.toString / "bag" / "metadata" / "message-from-depositor.txt")
+    (testDir / "submitted" / depositDir.id.toString / "bag" / "metadata" / "message-from-depositor.txt")
       .contentAsString shouldBe ""
   }
 
@@ -92,10 +97,10 @@ class SubmitterSpec extends TestSupportFixture with MockFactory {
     val pidMocker = mock[PidRequester]
     val mockedPid = "12345"
     (pidMocker.requestPid(_: PidType)) expects * once() returning Success(mockedPid)
+    (testDir / "submitted").createDirectories()
 
-    new Submitter(testDir / "staged", null, pidMocker).submit(depositDir) should matchPattern {
-      case Failure(e) if e.isInstanceOf[NotImplementedError] =>
-    }
+    new Submitter(testDir / "staged", testDir / "submitted", pidMocker)
+      .submit(depositDir) should matchPattern { case Success(()) => }
 
     depositDir.getDOI(null) shouldBe Success(mockedPid)
   }
@@ -105,7 +110,7 @@ class SubmitterSpec extends TestSupportFixture with MockFactory {
 
     val depositDir = createDeposit(datasetMetadata)
 
-    new Submitter(testDir / "staged", null, null).submit(depositDir) should matchPattern {
+    new Submitter(testDir / "staged", testDir / "submitted", null).submit(depositDir) should matchPattern {
       case Failure(e) if e.isInstanceOf[CorruptDepositException] =>
     }
   }
@@ -118,7 +123,7 @@ class SubmitterSpec extends TestSupportFixture with MockFactory {
     val mockedPid = "12345"
     (pidMocker.requestPid(_: PidType)) expects * once() returning Success(mockedPid)
 
-    new Submitter(testDir / "staged", null, pidMocker).submit(depositDir) should matchPattern {
+    new Submitter(testDir / "staged", testDir / "submitted", pidMocker).submit(depositDir) should matchPattern {
       case Failure(e) if e.isInstanceOf[InvalidDocumentException] =>
     }
   }

--- a/src/test/scala/nl.knaw.dans.easy.deposit/TestSupportFixture.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/TestSupportFixture.scala
@@ -60,7 +60,11 @@ trait TestSupportFixture extends FlatSpec with Matchers with Inside with BeforeA
       private val draftDir: File = (testDir / "drafts")
         .delete(true)
         .createIfNotExists(asDirectory = true, createParents = true)
+      private val submitDir: File = (testDir / "easy-ingest-flow-inbox")
+        .delete(true)
+        .createIfNotExists(asDirectory = true, createParents = true)
       addProperty("deposits.drafts", draftDir.toString())
+      addProperty("deposits.submit-to", submitDir.toString())
       addProperty("pids.generator-service", "http://hostDoesNotExist")
     })
   }

--- a/src/test/scala/nl.knaw.dans.easy.deposit/TestSupportFixture.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/TestSupportFixture.scala
@@ -57,18 +57,23 @@ trait TestSupportFixture extends FlatSpec with Matchers with Inside with BeforeA
 
   def minimalAppConfig: Configuration = {
     new Configuration("", new PropertiesConfiguration() {
-      private val draftDir: File = (testDir / "drafts")
-        .delete(true)
-        .createIfNotExists(asDirectory = true, createParents = true)
-      private val submitDir: File = (testDir / "easy-ingest-flow-inbox")
-        .delete(true)
-        .createIfNotExists(asDirectory = true, createParents = true)
-      addProperty("deposits.drafts", draftDir.toString())
-      addProperty("deposits.submit-to", submitDir.toString())
-      addProperty("pids.generator-service", "http://hostDoesNotExist")
+      addProperty("deposits.stage", testSubDir("stage").toString())
+      addProperty("deposits.drafts", testSubDir("drafts").toString())
+      addProperty("deposits.submit-to", testSubDir("easy-ingest-flow-inbox").toString())
+      addProperty("pids.generator-service", "http://piHostDoesNotExist")
+      addProperty("users.ldap-url", "http://ldapHostDoesNotExist")
+      addProperty("users.ldap-parent-entry", "-")
+      addProperty("users.ldap-admin-principal", "-")
+      addProperty("users.ldap-admin-password", "-")
+      addProperty("users.ldap-user-id-attr-name", "-")
     })
   }
 
+  private def testSubDir(drafts: String) = {
+    (testDir / drafts)
+      .delete(true)
+      .createIfNotExists(asDirectory = true, createParents = true)
+  }
   private class TokenSupportImpl() extends TokenSupport with AuthConfig {
 
     // required by AuthConfig but not by TokenSupport

--- a/src/test/scala/nl.knaw.dans.easy.deposit/docs/FilesXmlSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/docs/FilesXmlSpec.scala
@@ -27,7 +27,7 @@ class FilesXmlSpec extends TestSupportFixture {
   override def beforeEach(): Unit = {
     super.beforeEach()
     clearTestDir()
-    testDir.createIfNotExists(asDirectory = true)
+    (testDir / "data").createIfNotExists(asDirectory = true)
   }
 
   "apply" should "produce an empty xml" in {
@@ -43,21 +43,20 @@ class FilesXmlSpec extends TestSupportFixture {
   }
 
   it should "produce xml with different mime types" in {
-    (testDir / "folder").createIfNotExists(asDirectory = true)
-
-    (testDir / "test.txt").touch()
-    (testDir / "folder" / "test.xml").touch()
+    (testDir / "data" / "folder").createIfNotExists(asDirectory = true)
+    (testDir / "data" / "test.txt").touch()
+    (testDir / "data" / "folder" / "test.xml").touch()
 
     (createFilesXml \ "file").toList.sortBy(_.attribute("filepath").toString) shouldBe
-        <file filepath="folder/test.xml">
+        <file filepath="data/folder/test.xml">
           <dcterms:format>application/xml</dcterms:format>
         </file>
-        <file filepath="test.txt">
+        <file filepath="data/test.txt">
           <dcterms:format>text/plain</dcterms:format>
         </file>
   }
 
   private def createFilesXml = {
-    FilesXml(testDir).getOrRecover(e => fail(e.toString))
+    FilesXml(testDir / "data").getOrRecover(e => fail(e.toString))
   }
 }

--- a/src/test/scala/nl.knaw.dans.easy.deposit/servlets/IntegrationSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/servlets/IntegrationSpec.scala
@@ -169,6 +169,7 @@ class IntegrationSpec extends TestSupportFixture with ServletFixture with Scalat
     val datasetMetadata = getManualTestResource("datasetmetadata-from-ui-all.json")
     val doi = Try { DatasetMetadata(datasetMetadata).get.identifiers.get.headOption.get.value }
       .getOrRecover(e => fail("could not get DOI from test input", e))
+    (testDir / "easy-ingest-flow-inbox").createDirectories()
 
     // create dataset
     expectsUserFooBar
@@ -204,9 +205,8 @@ class IntegrationSpec extends TestSupportFixture with ServletFixture with Scalat
       status shouldBe NO_CONTENT_204
     }
 
-    // TODO despite TestSupportFixture.minimalAppConfig deposits.submit-to is mixed up with drafts
     // +3 is difference in number of files in metadata directory: json versus xml's
-    ((testDir / "drafts" / "foo" / uuid.toString).walk().size + 3) shouldBe (testDir / "drafts" / uuid.toString).walk().size
+    ((testDir / "drafts" / "foo" / uuid.toString).walk().size + 3) shouldBe (testDir / "easy-ingest-flow-inbox" / uuid.toString).walk().size
   }
 
   s"scenario: POST /deposit; hack state to ARCHIVED; SUBMIT" should "reject state transition" in {


### PR DESCRIPTION
Fixes EASY-1464 submit

#### When applied it will
* [x] integration test nor the manual test should use the `draft` folder for `easy-ingest-flow-inbox`
  On the right hand side below `drafts` should have been `easy-ingest-flow-inbox`  
  https://github.com/DANS-KNAW/easy-deposit-api/blob/1f180c26480cf05ebfa0fd61a402c2b223079dc6/src/test/scala/nl.knaw.dans.easy.deposit/servlets/IntegrationSpec.scala#L207-L209

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

A submit should now result in success once the metatadata is valid.

From #38 and #47 : use deasy because the local VM has no pid-generator:

1) build, deploy an create a draft deposit:
```
cd easy-deposit-api
mvn clean install
cd easy-dtap
vagrant destroy -f && vagrant up --no-provision ### only for a fresh base-box
./deploy-role.sh easy-deposit-api
curl -i -u user001:user001 -X POST http://deasy:20190/deposit
```

2) Copy the UUID returned by the curl command above. 
3) No curl command figured out to put json content, use PostMan to add metadata and submit:
    * put metadata from one of the files in `easy-deposit-api/src/test/resources/manual-test`
      but remove the DOI from the identifiers
      to `http://localhost:20190/deposit/<UUID>/metadata`
    * put `{"state":"SUBMITTED","stateDescription":"blabla"}`
      to `http://localhost:20190/deposit/<UUID>/state`

The results in `/var/opt/dans.knaw.nl/` on deasy:
* `deposit/drafts/user001/<UUID>` should contain the draft
* `deposit/stage/<UUID>` should contain a copy while processing the state change
* `tmp/easy-ingest-flow-inbox/<UUID>` should contain a copy of the draft with different files in `metadata`

#### Related pull requests on github
* [x] https://github.com/DANS-KNAW/dans-bag-lib/milestone/1