### PR TITLE
EASY-1657 post file using content-disposition header

### DIFF
--- a/docs/api/api.yml
+++ b/docs/api/api.yml
@@ -388,8 +388,9 @@ paths:
       - directory
       summary: Adds a file or a subdirectory.
       description: |
-        By default the file in the request body is saved in `dir_path` under the file name provided
-        in the `Content-Disposition` header. However, if the request body is sent as a ZIP file, it
+        Sub request of a request with `Content-Type` value `multipart/form-data`.
+        By default the files listed in the body of the main request are saved in `dir_path` under the file name provided
+        in the `Content-Disposition` header. However, if a file has the extension ZIP, it
         is extracted in `dir_path` and `Content-Disposition` is ignored (and may be left out).
         If `dir_path`, or any of its parents do not exist yet, they are first created.
       parameters:

--- a/src/main/scala/nl.knaw.dans.easy.deposit/EasyDepositApiApp.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/EasyDepositApiApp.scala
@@ -136,7 +136,7 @@ class EasyDepositApiApp(configuration: Configuration) extends DebugEnhancedLoggi
    * @param stateInfo the state to transition to
    * @return
    */
-  def setDepositState(stateInfo: StateInfo)(user: String, id: UUID): Try[Unit] = for {
+  def setDepositState(stateInfo: StateInfo, user: String, id: UUID): Try[Unit] = for {
     deposit <- DepositDir.get(draftsDir, user, id)
     _ <- deposit.checkStateTransition(stateInfo.state)
     _ <- if (stateInfo.state == State.submitted)
@@ -190,7 +190,7 @@ class EasyDepositApiApp(configuration: Configuration) extends DebugEnhancedLoggi
    * @param dm   the dataset metadata
    * @return
    */
-  def writeDataMetadataToDeposit(dm: DatasetMetadata)(user: String, id: UUID): Try[Unit] = for {
+  def writeDataMetadataToDeposit(dm: DatasetMetadata, user: String, id: UUID): Try[Unit] = for {
     deposit <- DepositDir.get(draftsDir, user, id)
     _ <- deposit.writeDatasetMetadataJson(dm)
   } yield ()
@@ -222,7 +222,7 @@ class EasyDepositApiApp(configuration: Configuration) extends DebugEnhancedLoggi
    * @param is   the input stream to write from
    * @return `true` if a new file was created, `false` otherwise
    */
-  def writeDepositFile(is: => InputStream)(user: String, id: UUID, path: Path): Try[Boolean] = for {
+  def writeDepositFile(is: => InputStream, user: String, id: UUID, path: Path): Try[Boolean] = for {
     deposit <- DepositDir.get(draftsDir, user, id)
     dataFiles <- deposit.getDataFiles
     created <- dataFiles.write(is, path)

--- a/src/main/scala/nl.knaw.dans.easy.deposit/EasyDepositApiApp.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/EasyDepositApiApp.scala
@@ -225,8 +225,9 @@ class EasyDepositApiApp(configuration: Configuration) extends DebugEnhancedLoggi
   def writeDepositFile(is: => InputStream, user: String, id: UUID, path: Path): Try[Boolean] = for {
     deposit <- DepositDir.get(draftsDir, user, id)
     dataFiles <- deposit.getDataFiles
+    _ = logger.info(s"uploading to [${dataFiles.bag.baseDir}] of [$path]")
     created <- dataFiles.write(is, path)
-    _  = logger.info(s"created=$created $user/$id/$path")
+    _ = logger.info(s"created=$created $user/$id/$path")
   } yield created
 
   /**

--- a/src/main/scala/nl.knaw.dans.easy.deposit/EasyDepositApiApp.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/EasyDepositApiApp.scala
@@ -226,6 +226,7 @@ class EasyDepositApiApp(configuration: Configuration) extends DebugEnhancedLoggi
     deposit <- DepositDir.get(draftsDir, user, id)
     dataFiles <- deposit.getDataFiles
     created <- dataFiles.write(is, path)
+    _  = logger.info(s"created=$created $user/$id/$path")
   } yield created
 
   /**

--- a/src/main/scala/nl.knaw.dans.easy.deposit/servlets/DepositServlet.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/servlets/DepositServlet.scala
@@ -133,7 +133,7 @@ class DepositServlet(app: EasyDepositApiApp) extends ProtectedServlet(app) {
           managedIS.apply(is => app.writeDepositFile(is, user.id, uuid, fullPath))
         case (_, _) =>
           val explanation = s"Expecting header 'Content-Type: $zip' or 'Content-Type: $bin'; the latter with a filename in the 'Content-Disposition'."
-          Failure(BadRequestException(s"$explanation GOT: $maybeContentType AND $maybeContentType"))
+          Failure(BadRequestException(s"$explanation GOT: $maybeContentType AND $mayBeFileName"))
       }
     } yield fileCreatedOrOkResponse(newFileWasCreated)
       ).getOrRecoverResponse(respond)

--- a/src/main/scala/nl.knaw.dans.easy.deposit/servlets/DepositServlet.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/servlets/DepositServlet.scala
@@ -140,7 +140,7 @@ class DepositServlet(app: EasyDepositApiApp)
         case (Some(`bin`), Some(fileName: String)) => getRequestBodyAsManagedInputStream
             .flatMap(_.apply(app.writeDepositFile(_, user.id, uuid, path.resolve(fileName))))
         case (_, _) =>
-          val explanation = s"Expecting header 'Content-Type: [$zip|$bin|$multi]; $bin with a filename in the 'Content-Disposition'."
+          val explanation = s"Expecting Content-Type: [ $zip | $bin | $multi ]; $bin with a filename in the 'Content-Disposition'."
           Failure(new NotImplementedException(s"$explanation GOT: $maybeMimeType AND $mayBeFileName"))
       }
     } yield fileCreatedOrOkResponse(newFileWasCreated)

--- a/src/main/scala/nl.knaw.dans.easy.deposit/servlets/DepositServlet.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/servlets/DepositServlet.scala
@@ -156,7 +156,7 @@ class DepositServlet(app: EasyDepositApiApp) extends ProtectedServlet(app) {
 
   private def respond(t: Throwable): ActionResult = t match {
     case e: IllegalStateTransitionException => Forbidden(e.getMessage)
-    case e: NoSuchDepositException => noSuchDespositResponse(e)
+    case e: NoSuchDepositException => noSuchDepositResponse(e)
     case e: NoSuchFileException => NotFound(body = s"${ e.getMessage } not found")
     case e: InvalidResourceException => invalidResourceResponse(e)
     case e: InvalidDocumentException => badDocResponse(e)
@@ -164,7 +164,7 @@ class DepositServlet(app: EasyDepositApiApp) extends ProtectedServlet(app) {
     case _ => internalErrorResponse(t)
   }
 
-  private def noSuchDespositResponse(e: NoSuchDepositException): ActionResult = {
+  private def noSuchDepositResponse(e: NoSuchDepositException): ActionResult = {
     // we log but don't expose which file was not found
     logger.info(e.getMessage)
     NotFound(body = s"Deposit ${ e.id } not found")

--- a/src/main/scala/nl.knaw.dans.easy.deposit/servlets/UserServlet.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/servlets/UserServlet.scala
@@ -31,10 +31,10 @@ class UserServlet(app: EasyDepositApiApp) extends ProtectedServlet(app) {
       .getOrRecoverResponse(respond)
   }
   put("/") {
-    (for {
+    Try(for {
       user <- UserInfo(request.body)
-      _ <- Try(???).flatten
-    } yield Ok(???))
+      _ <- Try(???)
+    } yield Ok(???)).flatten
       .getOrRecoverResponse(respond)
   }
 

--- a/src/main/scala/nl.knaw.dans.easy.deposit/servlets/package.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/servlets/package.scala
@@ -33,7 +33,7 @@ package object servlets extends DebugEnhancedLogging {
     BadRequest(s"Bad Request. ${ t.getMessage }")
   }
 
-  implicit class RichIterable[T](val xs: Iterable[Try[T]]) extends AnyVal {
+  implicit class RichIterable[T](val xs: Stream[Try[T]]) extends AnyVal {
     def failFast: Try[Seq[T]] = {
       // TODO dans-lib candidate?
       val successes = Seq.newBuilder[T]
@@ -41,11 +41,10 @@ package object servlets extends DebugEnhancedLogging {
       xs.foreach {
         case Success(t) => successes += t
         case Failure(e) =>
-          return Failure(FailedFastException(e, successes.result()))
+          return Failure(e)
       }
 
       Success(successes.result())
     }
   }
-  case class FailedFastException[T](cause: Throwable, successes: Seq[T]) extends Exception(cause)
 }

--- a/src/main/scala/nl.knaw.dans.easy.deposit/servlets/package.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/servlets/package.scala
@@ -19,6 +19,8 @@ import nl.knaw.dans.easy.deposit.docs.JsonUtil.InvalidDocumentException
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
 import org.scalatra.{ ActionResult, BadRequest, InternalServerError }
 
+import scala.util.{ Failure, Success, Try }
+
 package object servlets extends DebugEnhancedLogging {
 
   def internalErrorResponse(t: Throwable): ActionResult = {
@@ -30,4 +32,20 @@ package object servlets extends DebugEnhancedLogging {
     logger.error(t.getMessage)
     BadRequest(s"Bad Request. ${ t.getMessage }")
   }
+
+  implicit class RichIterable[T](val xs: Iterable[Try[T]]) extends AnyVal {
+    def failFast: Try[Seq[T]] = {
+      // TODO dans-lib candidate?
+      val successes = Seq.newBuilder[T]
+
+      xs.foreach {
+        case Success(t) => successes += t
+        case Failure(e) =>
+          return Failure(FailedFastException(e, successes.result()))
+      }
+
+      Success(successes.result())
+    }
+  }
+  case class FailedFastException[T](cause: Throwable, successes: Seq[T]) extends Exception(cause)
 }

--- a/src/test/resources/manual-test/login.html
+++ b/src/test/resources/manual-test/login.html
@@ -1,7 +1,7 @@
 <html>
 <body>
 <h1>Manual test to examine browser cookie storage</h1>
-<form action="http://test.dans.knaw.nl:20190/auth/login" method="post">
+<form action="http://deasy.dans.knaw.nl:20190/auth/login" method="post">
     <h2>Explicit log in</h2>
     <p>
         <label for="login">user id</label>

--- a/src/test/resources/manual-test/readme.md
+++ b/src/test/resources/manual-test/readme.md
@@ -1,19 +1,42 @@
 JSON files for manual tests
 ---------------------------
 
-DatasetXmlSpec shows whether the `datasetmetadata-` files would produce valid DDM on submission.
-The files with `datasetmetadata-from-ui-` in their name are derived from the mockserver of [easy-deposit-ui](https://github.com/DANS-KNAW/easy-deposit-ui).
+The test class `DatasetXmlSpec` shows whether the `datasetmetadata-` files would produce valid DDM on submission.
+The files with `datasetmetadata-from-ui-` in their name are derived from the mockserver of [easy-deposit-ui].
 `servlet\IntegrationSpec` specifies only some scenarios that could be performed by the UI.
-Other tests show in the `servlets` package emulate just a single step.
+Other tests in the `servlets` package emulate just a single step.
 All these steps can be tested manually with tools like `Postman` or `curl`.
-One step involving json files is shown below.
-Play with the content of the files to check whether responses make sense for the UI and user of the UI.
 
-* Launch a virtual machine with `vagrant up` in the root of the project
-* Create a deposit, for details see `docs/api.html`
-* Use the returned UUID to replace XXX in the following command.
+* Launch the `deasy` VM
+  * go to the root of [easy-dtap]
+  * Make sure the project is up-to-date and `easy-dtap/deasy_base_box` has the latest [base-box]
+  * execute the command `vagrant up --no-provision` 
+* build the project and deploy it on a running `deasy`
 
-    curl -i  -H 'Content-Type: text/plain'  --data-binary "@XXX.json" -X POST -u user001:user001 'http://test.dans.knaw.nl:20190/deposit/XXX/datasetmetadata'
+      cd easy-deposit-api && mvn clean install && cd easy-dtap && ./deploy-role easy-deposit-api
+
+* Create a new deposit:
+
+      curl -i -u user001:user001 -X POST http://deasy:20190/deposit
+
+* Use the returned UUID to replace <UUID> in the command below (that uploads dataset metadata),
+  use the files in this directory for XXX
+  and play with the content to check whether responses make sense for the UI and user of the UI.
+
+
+      curl -i  -H 'Content-Type: application/json' --data-binary "@XXX.json" -X PUT -u user001:user001 'http://deasy.dans.knaw.nl:20190/deposit/<UUID>/datasetmetadata'
+
+* For details of other commands see `docs/api.html`, the [xls of EASY-1644] and [easy-test-resources]
+
+Reserve a DOI or submit requires a pid generator which is not deployed on the local VM.
+For other commands you can use the local `test` VM
+which you can launch with `vagrant up` in the root of the project. 
+
+[easy-test-resources]: https://github.com/DANS-KNAW/easy-test-resources/blob/master/test-run/EASY-1525-deposit-api.md
+[xls of EASY-1644]: https://drivenbydata.atlassian.net/secure/attachment/25376/2018-08-03%20EASY-1644%20Deposit_API_1.0.0.xlsx
+[base-box]: http://develop.dans.knaw.nl/boxes/
+[easy-deposit-ui]: https://github.com/DANS-KNAW/easy-deposit-ui
+[easy-dtap]: https://github.com/DANS-KNAW/easy-dtap
 
 
 Purpose of HTML files

--- a/src/test/resources/manual-test/readme.md
+++ b/src/test/resources/manual-test/readme.md
@@ -16,6 +16,8 @@ Self explaining web pages to test without a fully dressed web client.
 Examine cookies with developer tools of a browser.
 See the test classes in the servlets package for expected behaviour.
 
+Note that `upload.html`, adjust it to one you created before on `deasy`.
+
 Manual tests
 ------------
 
@@ -27,7 +29,10 @@ The steps of a deposit scenario can be tested manually with tools like `Postman`
   * execute the command `vagrant up --no-provision` 
 * build the project and deploy it on a running `deasy`
 
-      cd easy-deposit-api && mvn clean install && cd easy-dtap && ./deploy-role easy-deposit-api
+      cd ../easy-deposit-api
+      mvn clean install
+      cd ../easy-dtap
+      ./deploy-role easy-deposit-api
 
 * Create a new deposit:
 

--- a/src/test/resources/manual-test/readme.md
+++ b/src/test/resources/manual-test/readme.md
@@ -1,11 +1,25 @@
 JSON files for manual tests
 ---------------------------
 
-The test class `DatasetXmlSpec` shows whether the `datasetmetadata-` files would produce valid DDM on submission.
 The files with `datasetmetadata-from-ui-` in their name are derived from the mockserver of [easy-deposit-ui].
-`servlet\IntegrationSpec` specifies only some scenarios that could be performed by the UI.
+
+All `json` files could be used for manual tests. The expected results are documented with unit tests such as `DatasetXmlSpec`.
+
+`servlet\IntegrationSpec` specifies only some scenarios that could be performed by the UI or manual tests.
 Other tests in the `servlets` package emulate just a single step.
-All these steps can be tested manually with tools like `Postman` or `curl`.
+
+
+Purpose of HTML files
+---------------------
+
+Self explaining web pages to test without a fully dressed web client.
+Examine cookies with developer tools of a browser.
+See the test classes in the servlets package for expected behaviour.
+
+Manual tests
+------------
+
+The steps of a deposit scenario can be tested manually with tools like `Postman` or `curl`.
 
 * Launch the `deasy` VM
   * go to the root of [easy-dtap]
@@ -26,7 +40,7 @@ All these steps can be tested manually with tools like `Postman` or `curl`.
 
       curl -i  -H 'Content-Type: application/json' --data-binary "@XXX.json" -X PUT -u user001:user001 'http://deasy.dans.knaw.nl:20190/deposit/<UUID>/datasetmetadata'
 
-* For details of other commands see `docs/api.html`, the [xls of EASY-1644] and [easy-test-resources]
+* For details of other commands see `docs/api.html`, with examples in the [xls of EASY-1644] and [easy-test-resources]
 
 Reserve a DOI or submit requires a pid generator which is not deployed on the local VM.
 For other commands you can use the local `test` VM
@@ -37,11 +51,3 @@ which you can launch with `vagrant up` in the root of the project.
 [base-box]: http://develop.dans.knaw.nl/boxes/
 [easy-deposit-ui]: https://github.com/DANS-KNAW/easy-deposit-ui
 [easy-dtap]: https://github.com/DANS-KNAW/easy-dtap
-
-
-Purpose of HTML files
----------------------
-
-Self explaining web pages to test without a fully dressed web client.
-Examine cookies with developer tools of a browser.
-See the test classes in the servlets package for expected behaviour.

--- a/src/test/resources/manual-test/readme.md
+++ b/src/test/resources/manual-test/readme.md
@@ -16,8 +16,6 @@ Self explaining web pages to test without a fully dressed web client.
 Examine cookies with developer tools of a browser.
 See the test classes in the servlets package for expected behaviour.
 
-Note that `upload.html`, adjust it to one you created before on `deasy`.
-
 Manual tests
 ------------
 

--- a/src/test/resources/manual-test/upload.html
+++ b/src/test/resources/manual-test/upload.html
@@ -10,7 +10,7 @@
     </script>
     <style>
         label {width: 50px}
-        input[type="text"] {width: 200px}
+        input[type="text"] {width: 300px}
     </style>
 </head>
 <body>

--- a/src/test/resources/manual-test/upload.html
+++ b/src/test/resources/manual-test/upload.html
@@ -12,7 +12,7 @@
 <h1>Manual test for upload.</h1>
 <a href="login.html">login</a>
 <form id="form"
-      action="http://test.dans.knaw.nl:20190/deposit/07d53775-aeff-478c-85d3-a8e27724ab9f/file/some.png"
+      action="http://deasy.dans.knaw.nl:20190/deposit/196fb09a-03c5-4951-a308-4879e4b7f2ab/file/some.png"
       method="post"
       enctype="multipart/form-data"
 >

--- a/src/test/resources/manual-test/upload.html
+++ b/src/test/resources/manual-test/upload.html
@@ -4,6 +4,8 @@
         function setAction(el){
             document.getElementById('form').action = "http://deasy.dans.knaw.nl:20190/deposit/" +
                el.value +"/file/fixed-file-name"
+//             document.getElementById('uuid').value + "/" +
+//             document.getElementById('path').value
             return true
         }
     </script>
@@ -16,11 +18,15 @@
       method="post"
       enctype="multipart/form-data"
 >
-    <label for="uuid">UUID</label><input id="uuid" type="text" onchange="setAction(this)">
+    <label for="uuid">UUID</label><input id="uuid" type="text" onchange="setAction(this)" style="width:400px">
     <br>
-    <input type="file" id="myFiles" multiple size="50">
+    <!--<label for="path">path</label><input id="path" type="text" onchange="setAction(this)" style="width:400px">-->
+    <!--<br>-->
+    <input type="file" multiple size="50" name="field1">
+    <br>
+    <input type="file" multiple size="50" name="field2">
+    <br>
     <input type="submit"/>
 </form>
-<p>NB: Needs server side implementation of Content-Type multipart/form-data.</p>
 </body>
 </html>

--- a/src/test/resources/manual-test/upload.html
+++ b/src/test/resources/manual-test/upload.html
@@ -2,7 +2,7 @@
 <head>
     <script>
         function setAction(el){
-            document.getElementById('form').action = "http://test.dans.knaw.nl:20190/deposit/" +
+            document.getElementById('form').action = "http://deasy.dans.knaw.nl:20190/deposit/" +
                el.value +"/file/fixed-file-name"
             return true
         }
@@ -12,14 +12,15 @@
 <h1>Manual test for upload.</h1>
 <a href="login.html">login</a>
 <form id="form"
-      action="http://deasy.dans.knaw.nl:20190/deposit/196fb09a-03c5-4951-a308-4879e4b7f2ab/file/some.png"
+      action="http://deasy.dans.knaw.nl:20190/deposit/UUID/file/some.png"
       method="post"
       enctype="multipart/form-data"
 >
+    <label for="uuid">UUID</label><input id="uuid" type="text" onchange="setAction(this)">
+    <br>
     <input type="file" id="myFiles" multiple size="50">
-    <!--<input type="file" id="myFile">-->
     <input type="submit"/>
 </form>
-<p>NB: Needs server side implementation of multipart/form-data.</p>
+<p>NB: Needs server side implementation of Content-Type multipart/form-data.</p>
 </body>
 </html>

--- a/src/test/resources/manual-test/upload.html
+++ b/src/test/resources/manual-test/upload.html
@@ -3,12 +3,15 @@
     <script>
         function setAction(el){
             document.getElementById('form').action = "http://deasy.dans.knaw.nl:20190/deposit/" +
-               el.value +"/file/fixed-file-name"
-//             document.getElementById('uuid').value + "/" +
-//             document.getElementById('path').value
+               document.getElementById('uuid').value + "/file/" +
+               document.getElementById('path').value
             return true
         }
     </script>
+    <style>
+        label {width: 50px}
+        input[type="text"] {width: 200px}
+    </style>
 </head>
 <body>
 <h1>Manual test for upload.</h1>
@@ -18,13 +21,13 @@
       method="post"
       enctype="multipart/form-data"
 >
-    <label for="uuid">UUID</label><input id="uuid" type="text" onchange="setAction(this)" style="width:400px">
+    <label for="uuid">UUID</label><input id="uuid" type="text" onchange="setAction(this)">
     <br>
-    <!--<label for="path">path</label><input id="path" type="text" onchange="setAction(this)" style="width:400px">-->
-    <!--<br>-->
+    <label for="path">path</label><input id="path" type="text" onchange="setAction(this)">
+    <br>
     <input type="file" multiple size="50" name="field1">
     <br>
-    <input type="file" multiple size="50" name="field2">
+    <input type="file" multiple size="5" name="field2">
     <br>
     <input type="submit"/>
 </form>

--- a/src/test/scala/nl.knaw.dans.easy.deposit/servlets/DepositServletErrorSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/servlets/DepositServletErrorSpec.scala
@@ -70,7 +70,7 @@ class DepositServletErrorSpec extends TestSupportFixture with ServletFixture wit
 
   s"put /:uuid/metadata" should "report a lost dataset" in {
     expectsUserFooBar
-    (mockedApp.writeDataMetadataToDeposit(_: DatasetMetadata)(_: String, _: UUID)) expects(*, "foo", uuid) returning
+    (mockedApp.writeDataMetadataToDeposit(_: DatasetMetadata, _: String, _: UUID)) expects(*, "foo", uuid) returning
       Failure(NoSuchDepositException("foo", uuid, new Exception()))
 
     put(

--- a/src/test/scala/nl.knaw.dans.easy.deposit/servlets/DepositServletErrorSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/servlets/DepositServletErrorSpec.scala
@@ -21,13 +21,14 @@ import nl.knaw.dans.easy.deposit._
 import nl.knaw.dans.easy.deposit.authentication.AuthUser.UserState
 import nl.knaw.dans.easy.deposit.authentication.AuthenticationMocker._
 import nl.knaw.dans.easy.deposit.authentication.{ AuthUser, AuthenticationProvider }
-import nl.knaw.dans.easy.deposit.docs.DatasetMetadata
+import nl.knaw.dans.easy.deposit.docs.{ DatasetMetadata, DepositInfo }
+import nl.knaw.dans.lib.error._
 import org.eclipse.jetty.http.HttpStatus._
 import org.scalamock.scalatest.MockFactory
 import org.scalatra.auth.Scentry
 import org.scalatra.test.scalatest.ScalatraSuite
 
-import scala.util.Failure
+import scala.util.{ Failure, Try }
 
 class DepositServletErrorSpec extends TestSupportFixture with ServletFixture with ScalatraSuite with MockFactory {
 

--- a/src/test/scala/nl.knaw.dans.easy.deposit/servlets/IntegrationSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/servlets/IntegrationSpec.scala
@@ -20,7 +20,7 @@ import java.util.UUID
 import nl.knaw.dans.easy.deposit.PidRequesterComponent.PidRequester
 import nl.knaw.dans.easy.deposit.PidRequesterComponent.PidType.PidType
 import nl.knaw.dans.easy.deposit.authentication.AuthenticationMocker._
-import nl.knaw.dans.easy.deposit.docs.{ DatasetMetadata, DepositInfo, JsonUtil }
+import nl.knaw.dans.easy.deposit.docs.{ DatasetMetadata, DepositInfo }
 import nl.knaw.dans.easy.deposit.{ EasyDepositApiApp, _ }
 import nl.knaw.dans.lib.error._
 import org.eclipse.jetty.http.HttpStatus._
@@ -126,14 +126,14 @@ class IntegrationSpec extends TestSupportFixture with ServletFixture with Scalat
 
     // upload the file twice
     expectsUserFooBar
-    post(uri = s"/deposit/$uuid/file/path/to/text.txt", headers = Seq(basicAuthentication), body = randomContent(times)) {
+    put(uri = s"/deposit/$uuid/file/path/to/text.txt", headers = Seq(basicAuthentication), body = randomContent(times)) {
       status shouldBe CREATED_201
       (dataFilesBase / "path" / "to" / "text.txt").size shouldBe expectedContentSize
     }
     expectsUserFooBar
-    post(uri = s"/deposit/$uuid/file/path/to/text.txt", headers = Seq(basicAuthentication), body = "fixed content for a fixed checksum") {
+    put(uri = s"/deposit/$uuid/file/path/to/text.txt", headers = Seq(basicAuthentication), body = "Lorum ipsum") {
       status shouldBe OK_200
-      (dataFilesBase / "path" / "to" / "text.txt").size shouldBe 34
+      (dataFilesBase / "path" / "to" / "text.txt").size shouldBe 11
     }
     expectsUserFooBar
     get(uri = s"/deposit/$uuid/file/path", headers = Seq(basicAuthentication)) {

--- a/src/test/scala/nl.knaw.dans.easy.deposit/servlets/IntegrationSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/servlets/IntegrationSpec.scala
@@ -169,7 +169,7 @@ class IntegrationSpec extends TestSupportFixture with ServletFixture with Scalat
     }
   }
 
-  s"scenario: create - ... - sumbit" should "create submitted dataset copied from a draft" in {
+  s"scenario: create - ... - sumbit" should "create submitted dataset copied from a draft" ignore {
 
     val datasetMetadata = getManualTestResource("datasetmetadata-from-ui-all.json")
     val doi = Try { DatasetMetadata(datasetMetadata).get.identifiers.get.headOption.get.value }
@@ -235,7 +235,7 @@ class IntegrationSpec extends TestSupportFixture with ServletFixture with Scalat
   }
 
 
-  s"scenario: create - POST payload" should "report a missing content disposistion" in {
+  s"scenario: create - POST payload" should "report a missing content disposistion" ignore {
 
     val datasetMetadata = getManualTestResource("datasetmetadata-from-ui-all.json")
     val doi = Try { DatasetMetadata(datasetMetadata).get.identifiers.get.headOption.get.value }

--- a/src/test/scala/nl.knaw.dans.easy.deposit/servlets/IntegrationSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/servlets/IntegrationSpec.scala
@@ -192,32 +192,6 @@ class IntegrationSpec extends TestSupportFixture with ServletFixture with Scalat
       status shouldBe NO_CONTENT_204
     }
 
-    // bad request: filename lacks trailing quote
-    expectsUserFooBar
-    val invalidHeaders = Seq(
-      ("Content-Disposition", """form-data; name="fieldName"; filename="text.txt"""),
-      ("Content-Type", "application/octet-stream"),
-      basicAuthentication
-    )
-    post(uri = s"/deposit/$uuid/file/path/to/", headers = invalidHeaders, body = randomContent(22)) {
-      body shouldBe "Content-Disposition: Unbalanced quoted string"
-      status shouldBe BAD_REQUEST_400
-    }
-
-    // valid file upload
-    expectsUserFooBar
-    val headers = Seq(
-      ("Content-Disposition", """form-data; name="fieldName"; filename="text.txt""""),
-      ("Content-Type", "application/octet-stream"),
-      basicAuthentication
-    )
-    val content = randomContent(22)
-    post(uri = s"/deposit/$uuid/file/path/to/", headers = headers, body = content) {
-      status shouldBe CREATED_201
-    }
-    // path is assembled from uri + header-info:
-    (testDir / "drafts" / "foo" / uuid.toString / "bag/data/path/to/text.txt").contentAsString shouldBe content
-
     // avoid having to mock the pid-service
     (testDir / "drafts" / "foo" / uuid.toString / "deposit.properties").append(s"identifier.doi=$doi")
 
@@ -253,7 +227,7 @@ class IntegrationSpec extends TestSupportFixture with ServletFixture with Scalat
     expectsUserFooBar
     post(uri = s"/deposit/$uuid/file/path/to/", headers = Seq(basicAuthentication), body = randomContent(22)) {
       status shouldBe NOT_IMPLEMENTED_501
-      body shouldBe "Expecting Content-Type: [ application/zip | application/octet-stream | multipart/form-data ]; application/octet-stream with a filename in the 'Content-Disposition'. GOT: None AND None"
+      body shouldBe "Expecting Content-Type[multipart/form-data], got None."
     }
   }
 

--- a/src/test/scala/nl.knaw.dans.easy.deposit/servlets/IntegrationSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/servlets/IntegrationSpec.scala
@@ -252,7 +252,7 @@ class IntegrationSpec extends TestSupportFixture with ServletFixture with Scalat
     expectsUserFooBar
     post(uri = s"/deposit/$uuid/file/path/to/", headers = Seq(basicAuthentication), body = randomContent(22)) {
       status shouldBe BAD_REQUEST_400
-      body shouldBe "Expecting header 'Content-Type: application/zip' or 'Content-Type: application/octet-stream'; the latter with a 'Content-Disposition'. GOT: None AND None"
+      body shouldBe "Expecting header 'Content-Type: application/zip' or 'Content-Type: application/octet-stream'; the latter with a filename in the 'Content-Disposition'. GOT: None AND None"
     }
   }
 

--- a/src/test/scala/nl.knaw.dans.easy.deposit/servlets/IntegrationSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/servlets/IntegrationSpec.scala
@@ -192,10 +192,22 @@ class IntegrationSpec extends TestSupportFixture with ServletFixture with Scalat
       status shouldBe NO_CONTENT_204
     }
 
-    // upload a file
+    // bad request: filename lacks trailing quote
+    expectsUserFooBar
+    val invalidHeaders = Seq(
+      ("Content-Disposition", """form-data; name="fieldName"; filename="text.txt"""),
+      ("Content-Type", "application/octet-stream"),
+      basicAuthentication
+    )
+    post(uri = s"/deposit/$uuid/file/path/to/", headers = invalidHeaders, body = randomContent(22)) {
+      body shouldBe "Content-Disposition: Unbalanced quoted string"
+      status shouldBe BAD_REQUEST_400
+    }
+
+    // valid file upload
     expectsUserFooBar
     val headers = Seq(
-      ("Content-Disposition", "text.txt"),
+      ("Content-Disposition", """form-data; name="fieldName"; filename="text.txt""""),
       ("Content-Type", "application/octet-stream"),
       basicAuthentication
     )

--- a/src/test/scala/nl.knaw.dans.easy.deposit/servlets/IntegrationSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/servlets/IntegrationSpec.scala
@@ -20,7 +20,7 @@ import java.util.UUID
 import nl.knaw.dans.easy.deposit.PidRequesterComponent.PidRequester
 import nl.knaw.dans.easy.deposit.PidRequesterComponent.PidType.PidType
 import nl.knaw.dans.easy.deposit.authentication.AuthenticationMocker._
-import nl.knaw.dans.easy.deposit.docs.{ DatasetMetadata, DepositInfo, JsonUtil }
+import nl.knaw.dans.easy.deposit.docs.{ DatasetMetadata, DepositInfo }
 import nl.knaw.dans.easy.deposit.{ EasyDepositApiApp, _ }
 import nl.knaw.dans.lib.error._
 import org.eclipse.jetty.http.HttpStatus._
@@ -126,12 +126,12 @@ class IntegrationSpec extends TestSupportFixture with ServletFixture with Scalat
 
     // upload the file twice
     expectsUserFooBar
-    post(uri = s"/deposit/$uuid/file/path/to/text.txt", headers = Seq(basicAuthentication), body = randomContent(times)) {
+    put(uri = s"/deposit/$uuid/file/path/to/text.txt", headers = Seq(basicAuthentication), body = randomContent(times)) {
       status shouldBe CREATED_201
       (dataFilesBase / "path" / "to" / "text.txt").size shouldBe expectedContentSize
     }
     expectsUserFooBar
-    post(uri = s"/deposit/$uuid/file/path/to/text.txt", headers = Seq(basicAuthentication), body = randomContent(times)) {
+    put(uri = s"/deposit/$uuid/file/path/to/text.txt", headers = Seq(basicAuthentication), body = randomContent(times)) {
       status shouldBe OK_200
       (dataFilesBase / "path" / "to" / "text.txt").size shouldBe expectedContentSize
     }
@@ -189,9 +189,12 @@ class IntegrationSpec extends TestSupportFixture with ServletFixture with Scalat
 
     // upload a file
     expectsUserFooBar
-    post(uri = s"/deposit/$uuid/file/path/to/text.txt", headers = Seq(basicAuthentication), body = randomContent(22)) {
+    val header = ("Content-Disposition", "text.txt")
+    post(uri = s"/deposit/$uuid/file/path/to/", headers = Seq(header, basicAuthentication), body = randomContent(22)) {
       status shouldBe CREATED_201
     }
+    // path is assembled from uri + header:
+    (testDir / "drafts" / "foo" / uuid.toString / "bag/data/path/to/text.txt").toJava should exist
 
     // avoid having to mock the pid-service
     (testDir / "drafts" / "foo" / uuid.toString / "deposit.properties").append(s"identifier.doi=$doi")

--- a/src/test/scala/nl.knaw.dans.easy.deposit/servlets/IntegrationSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/servlets/IntegrationSpec.scala
@@ -169,7 +169,7 @@ class IntegrationSpec extends TestSupportFixture with ServletFixture with Scalat
     }
   }
 
-  s"scenario: create - ... - sumbit" should "create submitted dataset copied from a draft" ignore {
+  s"scenario: create - ... - sumbit" should "create submitted dataset copied from a draft" in {
 
     val datasetMetadata = getManualTestResource("datasetmetadata-from-ui-all.json")
     val doi = Try { DatasetMetadata(datasetMetadata).get.identifiers.get.headOption.get.value }
@@ -235,7 +235,7 @@ class IntegrationSpec extends TestSupportFixture with ServletFixture with Scalat
   }
 
 
-  s"scenario: create - POST payload" should "report a missing content disposistion" ignore {
+  s"scenario: create - POST payload" should "report a missing content disposistion" in {
 
     val datasetMetadata = getManualTestResource("datasetmetadata-from-ui-all.json")
     val doi = Try { DatasetMetadata(datasetMetadata).get.identifiers.get.headOption.get.value }
@@ -252,8 +252,8 @@ class IntegrationSpec extends TestSupportFixture with ServletFixture with Scalat
     // upload a file
     expectsUserFooBar
     post(uri = s"/deposit/$uuid/file/path/to/", headers = Seq(basicAuthentication), body = randomContent(22)) {
-      status shouldBe BAD_REQUEST_400
-      body shouldBe "Expecting header 'Content-Type: application/zip' or 'Content-Type: application/octet-stream'; the latter with a filename in the 'Content-Disposition'. GOT: None AND None"
+      status shouldBe NOT_IMPLEMENTED_501
+      body shouldBe "Expecting Content-Type: [ application/zip | application/octet-stream | multipart/form-data ]; application/octet-stream with a filename in the 'Content-Disposition'. GOT: None AND None"
     }
   }
 

--- a/src/test/scala/nl.knaw.dans.easy.deposit/servlets/IntegrationSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/servlets/IntegrationSpec.scala
@@ -240,7 +240,7 @@ class IntegrationSpec extends TestSupportFixture with ServletFixture with Scalat
     expectsUserFooBar
     post(uri = s"/deposit/$uuid/file/path/to/", headers = Seq(basicAuthentication), body = randomContent(22)) {
       status shouldBe BAD_REQUEST_400
-      body shouldBe "expecting header 'Content-Type: application/zip' or 'Content-Type: application/octet-stream'; the latter with a 'Content-Disposition'. GOT: None AND None"
+      body shouldBe "Expecting header 'Content-Type: application/zip' or 'Content-Type: application/octet-stream'; the latter with a 'Content-Disposition'. GOT: None AND None"
     }
   }
 

--- a/src/test/scala/nl.knaw.dans.easy.deposit/servlets/IntegrationSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/servlets/IntegrationSpec.scala
@@ -133,7 +133,7 @@ class IntegrationSpec extends TestSupportFixture with ServletFixture with Scalat
     expectsUserFooBar
     put(uri = s"/deposit/$uuid/file/path/to/text.txt", headers = Seq(basicAuthentication), body = "Lorum ipsum") {
       status shouldBe OK_200
-      (dataFilesBase / "path" / "to" / "text.txt").size shouldBe 11
+      (dataFilesBase / "path" / "to" / "text.txt").contentAsString shouldBe "Lorum ipsum"
     }
     expectsUserFooBar
     get(uri = s"/deposit/$uuid/file/path", headers = Seq(basicAuthentication)) {
@@ -211,11 +211,12 @@ class IntegrationSpec extends TestSupportFixture with ServletFixture with Scalat
       ("Content-Type", "application/octet-stream"),
       basicAuthentication
     )
-    post(uri = s"/deposit/$uuid/file/path/to/", headers = headers, body = randomContent(22)) {
+    val content = randomContent(22)
+    post(uri = s"/deposit/$uuid/file/path/to/", headers = headers, body = content) {
       status shouldBe CREATED_201
     }
-    // path is assembled from uri + header:
-    (testDir / "drafts" / "foo" / uuid.toString / "bag/data/path/to/text.txt").toJava should exist
+    // path is assembled from uri + header-info:
+    (testDir / "drafts" / "foo" / uuid.toString / "bag/data/path/to/text.txt").contentAsString shouldBe content
 
     // avoid having to mock the pid-service
     (testDir / "drafts" / "foo" / uuid.toString / "deposit.properties").append(s"identifier.doi=$doi")


### PR DESCRIPTION
Fixes EASY-1657 Implement upload single file with POST directory

#### When applied it will
* interpret the specs as sub-requests of a request with `multipart/form-data`
* `Content-Type` of the sub-requests are still ignored, so zip-files [EASY-1658](https://drivenbydata.atlassian.net/browse/EASY-1658) are uploaded as-is.
* [x] unit tests
* The response code on success is 200-ok as it might be a mix of created and replaced. The specs says 201-created but that applies to subrequests. No specification how to wrap these up in the `multipart/form-data` request.

Some statistics:

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

* see the updated `test/resources/readme.md`
* test both PUT and POST
* test with curl: see this [stack-overflow](https://stackoverflow.com/questions/4238809/example-of-multipart-form-data)
* [x] large files https://github.com/DANS-KNAW/easy-deposit-api/pull/63#issuecomment-413111374

Uploading a file of 540 MB to `deasy` resulted in the browser complaining about "the connection was reset" and the log below (`HttpParser full`, replaced IP addresses with ...). After clearing the `bag/data` folder on the server I could upload it multiple times. Same for 1GB and even the 5GB succeeded on a second attempt. Might have to to with fooling around with the browser's back-button on the test page while changing the file to upload. It looks like a proper reset is not only clear `bag/data` but also POST a small file.

```
[2018-08-23 15:43:42,638] WARN  HttpParser Full for SCEP@747f9023{l(/...:59536)<->r(/...:20190),s=1,open=true,ishut=false,oshut=false,rb=false,wb=false,w=true,i=0r}-{AsyncHttpConnection@67754c1c,g=HttpGenerator{s=0,h=-1,b=-1,c=-1},p=HttpParser{s=-13,l=0,c=-3},r=1}
```
Some statistics of a successful upload of 5GB. Of course statistics with `teasy` would be more realistic that with `deasy`.

```
[2018-08-24 09:10:43,910] INFO  uploading to [/var/opt/dans.knaw.nl/deposit/drafts/user001/196fb09a-03c5-4951-a308-4879e4b7f2ab/bag] of [path/tox/large.txt]
[2018-08-24 09:12:37,632] INFO  created=true user001/196fb09a-03c5-4951-a308-4879e4b7f2ab/path/tox/large.txt
[2018-08-24 09:12:37,633] INFO  POST returned status=200 headers=Map()
-rw-r--r--. 1 easy-deposit-api easy-deposit-api 1663       2018-08-24 09:12:37.624723161 +0200 manifest-sha1.txt
-rw-r--r--. 1 easy-deposit-api easy-deposit-api 5007600000 2018-08-24 09:11:50.768755240 +0200 large.txt

upload:   10:43 tot 11:50 = 1:07
manifest: 11:50 tot 12:37 = 0:47
```

#### Related pull requests on github
~~May cause merge conflicts on IntegrationSpec.java with #62~~ merged
