### PR TITLE
EASY-1661: Return 204 return code for successful login and logout calls

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.deposit/servlets/AuthServlet.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/servlets/AuthServlet.scala
@@ -17,19 +17,19 @@ package nl.knaw.dans.easy.deposit.servlets
 
 import nl.knaw.dans.easy.deposit.EasyDepositApiApp
 import nl.knaw.dans.easy.deposit.authentication.ServletEnhancedLogging._
-import org.scalatra.Ok
+import org.scalatra.NoContent
 
 class AuthServlet(app: EasyDepositApiApp) extends AbstractAuthServlet(app) {
 
   post("/login") {
     login()
-    Ok(s"signed in")
+    NoContent()
       .logResponse
   }
 
   post("/logout") {
     logOut() // destroys the scentry cookie
-    Ok("you are signed out")
+    NoContent()
       .logResponse
   }
 }

--- a/src/main/scala/nl.knaw.dans.easy.deposit/servlets/DepositServlet.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/servlets/DepositServlet.scala
@@ -152,7 +152,7 @@ class DepositServlet(app: EasyDepositApiApp) extends ProtectedServlet(app) {
   private def getUUID: Try[UUID] = Try {
     UUID.fromString(params("uuid"))
   }.recoverWith { case t: Throwable =>
-    Failure(new InvalidDocumentException(s"deposit id: ${ t.getMessage }"))
+    Failure(new InvalidResourceException(s"Invalid deposit id: ${ t.getMessage }"))
   }
 
   private def getPath: Try[Path] = Try {

--- a/src/main/scala/nl.knaw.dans.easy.deposit/servlets/DepositServlet.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/servlets/DepositServlet.scala
@@ -152,7 +152,7 @@ class DepositServlet(app: EasyDepositApiApp) extends ProtectedServlet(app) {
   private def getUUID: Try[UUID] = Try {
     UUID.fromString(params("uuid"))
   }.recoverWith { case t: Throwable =>
-    Failure(new InvalidResourceException(s"Invalid deposit id: ${ t.getMessage }"))
+    Failure(new InvalidDocumentException(s"deposit id: ${ t.getMessage }"))
   }
 
   private def getPath: Try[Path] = Try {

--- a/src/test/scala/nl.knaw.dans.easy.deposit/authentication/AuthTestServlet.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/authentication/AuthTestServlet.scala
@@ -16,18 +16,19 @@
 package nl.knaw.dans.easy.deposit.authentication
 
 import nl.knaw.dans.easy.deposit.authentication.ServletEnhancedLogging._
-import org.scalatra.Ok
+import org.scalatra.NoContent
 
 class AuthTestServlet(authProvider: AuthenticationProvider) extends AbstractTestServlet(authProvider) {
 
+  // TODO: change the code so that the methods in AuthServlet are called instead of duplicating them here
   post("/login") {
     login()
-    Ok(s"signed in").logResponse
+    NoContent().logResponse
   }
 
-  put("/logout") {
+  post("/logout") {
     logOut() // destroys the scentry cookie
-    Ok("you are signed out").logResponse
+    NoContent().logResponse
   }
 }
 

--- a/src/test/scala/nl.knaw.dans.easy.deposit/authentication/SessionSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/authentication/SessionSpec.scala
@@ -49,8 +49,7 @@ class SessionSpec extends TestSupportFixture with ServletFixture with ScalatraSu
       body should startWith("AuthUser(foo,List(),ACTIVE) ")
       body should endWith(" EASY Deposit API Service running")
       header("REMOTE_USER") shouldBe "foo"
-      header("Set-Cookie") should startWith("scentry.auth.default.user=")
-      header("Set-Cookie") shouldNot startWith("scentry.auth.default.user=;") // note the empty value
+      header("Set-Cookie") should startWith regex "scentry.auth.default.user=[^;].+;"
       status shouldBe OK_200
     }
   }

--- a/src/test/scala/nl.knaw.dans.easy.deposit/authentication/SessionSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/authentication/SessionSpec.scala
@@ -129,13 +129,14 @@ class SessionSpec extends TestSupportFixture with ServletFixture with ScalatraSu
       uri = "/auth/login",
       params = Seq(("login", "foo"), ("password", "bar"))
     ) {
-      status shouldBe OK_200
-      body shouldBe "signed in"
-      header("Content-Type") shouldBe "text/plain;charset=UTF-8"
+      status shouldBe NO_CONTENT_204
+      body shouldBe ""
+      header("Content-Type") shouldBe "text/html;charset=UTF-8"
       header("Expires") shouldBe "Thu, 01 Jan 1970 00:00:00 GMT" // page cache
       header("REMOTE_USER") shouldBe "foo"
       val newCookie = header("Set-Cookie")
       newCookie should startWith("scentry.auth.default.user=")
+      newCookie shouldNot startWith("scentry.auth.default.user=;")
       newCookie should include(";Path=/")
       newCookie should include(";HttpOnly")
       cookieAge(newCookie) should be < 1000L
@@ -148,29 +149,30 @@ class SessionSpec extends TestSupportFixture with ServletFixture with ScalatraSu
       uri = "/auth/login",
       headers = Seq(("Authorization", fooBarBasicAuthHeader))
     ) {
-      body shouldBe "signed in"
-      status shouldBe OK_200
-      header("Content-Type") shouldBe "text/plain;charset=UTF-8"
+      body shouldBe ""
+      status shouldBe NO_CONTENT_204
+      header("Content-Type") shouldBe "text/html;charset=UTF-8"
       header("Expires") shouldBe "Thu, 01 Jan 1970 00:00:00 GMT" // page cache
       header("REMOTE_USER") shouldBe "foo"
       val newCookie = header("Set-Cookie")
       newCookie should startWith("scentry.auth.default.user=")
+      newCookie shouldNot startWith("scentry.auth.default.user=;")
       newCookie should include(";Path=/")
       newCookie should include(";HttpOnly")
       cookieAge(newCookie) should be < 1000L
     }
   }
 
-  "put /auth/logout" should "clear the cookie" in {
+  "post /auth/logout" should "clear the cookie" in {
     expectsNoUser
     val jwtCookie = createJWT(AuthUser("foo", state = UserState.active))
 
-    put(
+    post(
       uri = "/auth/logout",
       headers = Seq(("Cookie", s"${ Scentry.scentryAuthKey }=$jwtCookie"))
     ) {
-      status shouldBe OK_200
-      header("Content-Type") shouldBe "text/plain;charset=UTF-8"
+      status shouldBe NO_CONTENT_204
+      header("Content-Type") shouldBe "text/html;charset=UTF-8"
       header("Expires") shouldBe "Thu, 01 Jan 1970 00:00:00 GMT" // page cache
       header("REMOTE_USER") shouldBe ""
       val newCookie = header("Set-Cookie")
@@ -183,14 +185,14 @@ class SessionSpec extends TestSupportFixture with ServletFixture with ScalatraSu
 
   it should "not create a cookie if called with basic authentication" in {
     expectsUserFooBar
-    put(
+    post(
       uri = "/auth/logout",
       headers = Seq(("Authorization", fooBarBasicAuthHeader))
     ) {
-      body shouldBe "you are signed out"
+      body shouldBe ""
       header("REMOTE_USER") shouldBe ""
       header("Set-Cookie") should startWith("scentry.auth.default.user=;")
-      status shouldBe OK_200
+      status shouldBe NO_CONTENT_204
     }
   }
 

--- a/src/test/scala/nl.knaw.dans.easy.deposit/authentication/SessionSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/authentication/SessionSpec.scala
@@ -131,12 +131,10 @@ class SessionSpec extends TestSupportFixture with ServletFixture with ScalatraSu
     ) {
       status shouldBe NO_CONTENT_204
       body shouldBe ""
-      header("Content-Type") shouldBe "text/html;charset=UTF-8"
       header("Expires") shouldBe "Thu, 01 Jan 1970 00:00:00 GMT" // page cache
       header("REMOTE_USER") shouldBe "foo"
       val newCookie = header("Set-Cookie")
-      newCookie should startWith("scentry.auth.default.user=")
-      newCookie shouldNot startWith("scentry.auth.default.user=;")
+      newCookie should startWith regex "scentry.auth.default.user=[^;].+;"
       newCookie should include(";Path=/")
       newCookie should include(";HttpOnly")
       cookieAge(newCookie) should be < 1000L
@@ -151,12 +149,10 @@ class SessionSpec extends TestSupportFixture with ServletFixture with ScalatraSu
     ) {
       body shouldBe ""
       status shouldBe NO_CONTENT_204
-      header("Content-Type") shouldBe "text/html;charset=UTF-8"
       header("Expires") shouldBe "Thu, 01 Jan 1970 00:00:00 GMT" // page cache
       header("REMOTE_USER") shouldBe "foo"
       val newCookie = header("Set-Cookie")
-      newCookie should startWith("scentry.auth.default.user=")
-      newCookie shouldNot startWith("scentry.auth.default.user=;")
+      newCookie should startWith regex "scentry.auth.default.user=[^;].+;"
       newCookie should include(";Path=/")
       newCookie should include(";HttpOnly")
       cookieAge(newCookie) should be < 1000L

--- a/src/test/scala/nl.knaw.dans.easy.deposit/servlets/HappyRoutesSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/servlets/HappyRoutesSpec.scala
@@ -16,14 +16,14 @@
 package nl.knaw.dans.easy.deposit.servlets
 
 import java.nio.file.{ Path, Paths }
-import java.util.{ TimeZone, UUID }
+import java.util.UUID
 
 import nl.knaw.dans.easy.deposit._
 import nl.knaw.dans.easy.deposit.authentication.AuthenticationMocker._
 import nl.knaw.dans.easy.deposit.docs.StateInfo.State._
-import nl.knaw.dans.easy.deposit.docs.{ DatasetMetadata, DepositInfo, StateInfo }
+import nl.knaw.dans.easy.deposit.docs.{ DepositInfo, StateInfo }
 import org.eclipse.jetty.http.HttpStatus._
-import org.joda.time.{ DateTime, DateTimeZone }
+import org.joda.time.DateTime
 import org.scalamock.scalatest.MockFactory
 import org.scalatra.test.scalatest.ScalatraSuite
 
@@ -50,9 +50,10 @@ class HappyRoutesSpec extends TestSupportFixture with ServletFixture with Scalat
       uri = "/auth/login",
       params = Seq(("login", "foo"), ("password", "bar"))
     ) {
-      status shouldBe OK_200
-      body shouldBe "signed in"
+      status shouldBe NO_CONTENT_204
+      body shouldBe ""
       header("Set-Cookie") should startWith("scentry.auth.default.user=") // details in TypicalSessionSpec
+      header("Set-Cookie") shouldNot startWith("scentry.auth.default.user=;")
     }
   }
 


### PR DESCRIPTION
Fixes EASY-1661

#### When applied
* return code for a successful login is 204 
* return code for a successful logout is 204 

Return code when deleting with invalid bag-id should be 400, but is now 404; Return code with an invalid bag-id comes from `DepositServlet`, method `getUUID`.  Simply changing the return code for this case may result in erroneous error-code in other cases => needs to be investigated
