### PR TITLE
NO JIRA. Amended POST API.

### DIFF
--- a/docs/api/api.yml
+++ b/docs/api/api.yml
@@ -1,10 +1,10 @@
 openapi: 3.0.1
 
 servers:
-- description: Debug environment
-  url: http://localhost:20190/
-- description: Local Vagrant machine
-  url: http://test.dans.knaw.nl
+  - description: Debug environment
+    url: http://localhost:20190/
+  - description: Local Vagrant machine
+    url: http://test.dans.knaw.nl
 info:
   description: Public interface for depositing datasets in EASY.
   version: 1.0.0
@@ -109,7 +109,7 @@ paths:
         500:
           $ref: "#/components/responses/InternalServerError"
       security:
-      - BearerAuth: []
+        - BearerAuth: []
 
   /deposit:
     get:
@@ -267,7 +267,7 @@ paths:
         500:
           $ref: "#/components/responses/InternalServerError"
       security:
-      - BearerAuth: []
+        - BearerAuth: []
 
   /deposit/{id}/state:
     get:
@@ -368,12 +368,12 @@ paths:
                 items:
                   $ref: "#/components/schemas/FileInfo"
                 example:
-                - filename: myfile.txt
-                  dirpath: path/to/parent/dir
-                  sha1sum: ab3aa0555f31a8d7809fae4b03a95195edb01f5c
-                - filename: myfile2.txt
-                  dirpath: path/to/parent/dir
-                  sha1sum: ab3aa0555f31a8d7809fae4b03a95195edb01f5d
+                  - filename: myfile.txt
+                    dirpath: path/to/parent/dir
+                    sha1sum: ab3aa0555f31a8d7809fae4b03a95195edb01f5c
+                  - filename: myfile2.txt
+                    dirpath: path/to/parent/dir
+                    sha1sum: ab3aa0555f31a8d7809fae4b03a95195edb01f5d
 
         401:
           $ref: "#/components/responses/Unauthorized"
@@ -386,7 +386,7 @@ paths:
     post:
       tags:
       - directory
-      summary: Adds one or more files or a subdirectory.
+      summary: Adds one or more files.
       description: |
         Depending on the `Content-Type` header one or multiple files can be sent. The files will
         be added in the directory pointed to by `dir_path`.
@@ -482,8 +482,8 @@ paths:
       - file
       summary: Adds or overwrites the specified file in the deposit.
       parameters:
-      - $ref: "#/components/parameters/DepositId"
-      - $ref: "#/components/parameters/FilePath"
+       - $ref: "#/components/parameters/DepositId"
+       - $ref: "#/components/parameters/FilePath"
       description: If any of `file_path`'s parent do not yet exist, they are first created.
       operationId: writeFile
       requestBody:
@@ -491,7 +491,7 @@ paths:
         required: true
         content:
           '*/*':
-            # any media type is accepted, functionally equivalent to `*/*`
+          # any media type is accepted, functionally equivalent to `*/*`
             schema:
               # a binary file of any type
               type: string
@@ -528,8 +528,8 @@ paths:
       - file
       summary: Deletes a file from deposit.
       parameters:
-      - $ref: "#/components/parameters/DepositId"
-      - $ref: "#/components/parameters/FilePath"
+       - $ref: "#/components/parameters/DepositId"
+       - $ref: "#/components/parameters/FilePath"
       operationId: deleteFile
       responses:
         204:
@@ -649,8 +649,8 @@ components:
     UserInfo:
       type: object
       required:
-      - username
-      - lastName
+        - username
+        - lastName
       example:
         username: "user001"
         firstName: "First"
@@ -698,11 +698,11 @@ components:
           format: "date-time"
           description: "Deposit date"
       example:
-        id: "1d946f5b-e53b-4f71-b1f3-7481475d07db"
-        title: My draft deposit
-        state: DRAFT
-        stateDescription: Deposit is open for modification.
-        date: "2018-01-12T10:40:52Z"
+          id: "1d946f5b-e53b-4f71-b1f3-7481475d07db"
+          title: My draft deposit
+          state: DRAFT
+          stateDescription: Deposit is open for modification.
+          date: "2018-01-12T10:40:52Z"
 
     State:
       type: object
@@ -745,8 +745,8 @@ components:
           items:
             type: string
           example:
-          - "Title 1"
-          - "Title 2"
+            - "Title 1"
+            - "Title 2"
         alternativeTitles:
           $ref: "#/components/schemas/StringArray"
         descriptions:
@@ -775,9 +775,9 @@ components:
           type: array
           items:
             oneOf : [
-            {$ref: "#/components/schemas/Relation"},
-            {$ref: "#/components/schemas/QualifiedSchemedValue"}
-            ]
+              {$ref: "#/components/schemas/Relation"},
+              {$ref: "#/components/schemas/QualifiedSchemedValue"}
+              ]
 
         languagesOfFiles:
           type: array
@@ -880,25 +880,25 @@ components:
         organization:
           type: string
       oneOf:
-      - required:
-        - surname
-        - initials
-      - required:
-        - organization
+        - required:
+          - surname
+          - initials
+        - required:
+          - organization
       example:
         titles: Prof Dr
         initials: A
         insertions:
         surname: Einstein
         role:
-        - scheme: datacite:contributorType
-        - key: DataManager
-        - value: "Data Manager"
+          - scheme: datacite:contributorType
+          - key: DataManager
+          - value: "Data Manager"
         ids:
-        - scheme: DAI
-          value: "123456789x"
-        - scheme: ISNI
-          value: "ISNI:000000012281955X"
+          - scheme: DAI
+            value: "123456789x"
+          - scheme: ISNI
+            value: "ISNI:000000012281955X"
         organization: University of Zurich
 
     Date:
@@ -951,10 +951,10 @@ components:
         title:
           type: string
       oneOf:
-      - required:
-        - title
-      - required:
-        - url
+        - required:
+          - title
+        - required:
+          - url
 
     SchemedValue:
       type: object
@@ -973,9 +973,9 @@ components:
       - value
       properties:
         scheme:
-          type: string
+         type: string
         value:
-          type: string
+         type: string
 
     QualifiedSchemedValue:
       type: object

--- a/docs/api/api.yml
+++ b/docs/api/api.yml
@@ -397,7 +397,7 @@ paths:
         unzipped in `dir_path`. For each file in the ZIP file, the path in the deposit will be `dir_path`/`path_in_zip`.
 
         In all other cases the files are all stored in the directory pointed to by `dir_path` and it is not
-        allowed to include any files with `Content-Type: application/zip`. If multiple ZIP Note, that this means that only a flat
+        allowed to include any files with `Content-Type: application/zip`. Note, that this means that only a flat
         list of files can be sent this way, i.e. not including any directory hierarchy.
       parameters:
       - $ref: "#/components/parameters/DepositId"
@@ -415,8 +415,10 @@ paths:
       responses:
         201:
           description: file or subdirectory added
-        400:
+        400.1:
           $ref: "#/components/responses/MalformedZip"
+        400.2:
+          $ref: "#/components/responses/MustBeMultipartFormdata"
         401:
           $ref: "#/components/responses/Unauthorized"
         404:
@@ -646,6 +648,9 @@ components:
 
     MalformedZip:
       description: Bad request. ZIP file is malformed.
+
+    MustBeMultipartFormdata:
+      description: Bad Request. The request body must be multipart/form-data.
 
     ZipFileNotAllowed:
       description: Bad request. Content-Type must not be application/zip.

--- a/docs/api/api.yml
+++ b/docs/api/api.yml
@@ -388,18 +388,17 @@ paths:
       - directory
       summary: Adds one or more files.
       description: |
-        Depending on the `Content-Type` header one or multiple files can be sent. The files will
-        be added in the directory pointed to by `dir_path`.
+        The `Content-Type` must always be `multipart/form-data`, which means the body is formatted using the
+        [multipart media type](https://tools.ietf.org/html/rfc2046.html#section-5.1); each part contains one file.
+        The header area of each part specifies the file name using a `Content-Disposition` header.
 
-        * `application/octet-stream`: the body contains one file. The file name is specified
-          in the `Content-Disposition` header, using the `filename` parameter.
-        * `multipart/form-data`: the body is formatted using the [multipart media type](https://tools.ietf.org/html/rfc2046.html#section-5.1); each part contains one file. The header
-          area of each part specifies the file name using a `Content-Disposition` header. Note,
-          that this means that only a flat list of files can be sent this way, i.e. not including
-          any directory hierarchy.
-        * `application/zip`: the body is a file in ZIP format. This ZIP file can contain a directory
-          hierarchy. The ZIP file will be unzipped in `dir_path`. For each file in the ZIP file,
-          the path in the deposit will be `dir_path`/`path_in_zip`.
+        If the body contains only one part and that part has `Content-Type: application/zip`, then the body
+        is a file in ZIP format. This ZIP file can contain a directory hierarchy. The ZIP file will be
+        unzipped in `dir_path`. For each file in the ZIP file, the path in the deposit will be `dir_path`/`path_in_zip`.
+
+        In all other cases the files are all stored in the directory pointed to by `dir_path` and it is not
+        allowed to include any files with `Content-Type: application/zip`. If multiple ZIP Note, that this means that only a flat
+        list of files can be sent this way, i.e. not including any directory hierarchy.
       parameters:
       - $ref: "#/components/parameters/DepositId"
       - $ref: "#/components/parameters/DirPath"
@@ -407,20 +406,12 @@ paths:
       requestBody:
         required: true
         content:
-          application/octet-stream:
-            schema:
-              type: string
-              format: binary
           multipart/form-data:
             schema:
               type: array
               items:
                 type: string
                 format: binary
-          application/zip:
-            schema:
-              type: string
-              format: binary
       responses:
         201:
           description: file or subdirectory added
@@ -430,6 +421,8 @@ paths:
           $ref: "#/components/responses/Unauthorized"
         404:
           $ref: "#/components/responses/NotFound"
+        409:
+          $ref: "#/components/responses/ConflictZipMustBeOnlyFile"
         500:
           $ref: "#/components/responses/InternalServerError"
       security:
@@ -484,7 +477,9 @@ paths:
       parameters:
        - $ref: "#/components/parameters/DepositId"
        - $ref: "#/components/parameters/FilePath"
-      description: If any of `file_path`'s parent do not yet exist, they are first created.
+      description: |
+        If any of `file_path`'s parent do not yet exist, they are first created. The Content-Type may
+        be anything except `application/zip`.
       operationId: writeFile
       requestBody:
         description: file data
@@ -514,6 +509,8 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/FileInfo"
+        400:
+          $ref: "#/components/responses/ZipFileNotAllowed"
         401:
           $ref: "#/components/responses/Unauthorized"
         404:
@@ -595,11 +592,14 @@ components:
         type: string
 
     ContentDisposition:
-      name: "Content-Disposition; filename"
+      name: "Content-Disposition"
       in: header
       description: |
-        the name to use for the new file in the deposit; required only when sending a
-        single file using `Content-Type: application/octet-stream`.
+        Used to specify the `filename` of a message part. The first parameter is always `form-data`.
+        Additional parameters are case-insensitive and have arguments that use quoted-string syntax
+        after the '=' sign.Multiple parameters are separated by a semi-colon (';').
+      example:
+        '`Content-Disposition: form-data; filename="myfile.txt"`'
       required: true
       schema:
         type: "string"
@@ -628,6 +628,9 @@ components:
         Not found. The client may derive from this response that the containing deposit does
         not exist, either.
 
+    ConflictZipMustBeOnlyFile:
+      description: A multipart/form-data message contained a ZIP part but also other parts.
+
     Gone:
       description: |
         Gone. The metadata is no longer available, because the deposit has been fully processed.
@@ -643,6 +646,9 @@ components:
 
     MalformedZip:
       description: Bad request. ZIP file is malformed.
+
+    ZipFileNotAllowed:
+      description: Bad request. Content-Type must not be application/zip.
 
   schemas:
 

--- a/docs/api/api.yml
+++ b/docs/api/api.yml
@@ -1,10 +1,10 @@
 openapi: 3.0.1
 
 servers:
-  - description: Debug environment
-    url: http://localhost:20190/
-  - description: Local Vagrant machine
-    url: http://test.dans.knaw.nl
+- description: Debug environment
+  url: http://localhost:20190/
+- description: Local Vagrant machine
+  url: http://test.dans.knaw.nl
 info:
   description: Public interface for depositing datasets in EASY.
   version: 1.0.0
@@ -109,7 +109,7 @@ paths:
         500:
           $ref: "#/components/responses/InternalServerError"
       security:
-        - BearerAuth: []
+      - BearerAuth: []
 
   /deposit:
     get:
@@ -267,7 +267,7 @@ paths:
         500:
           $ref: "#/components/responses/InternalServerError"
       security:
-        - BearerAuth: []
+      - BearerAuth: []
 
   /deposit/{id}/state:
     get:
@@ -368,12 +368,12 @@ paths:
                 items:
                   $ref: "#/components/schemas/FileInfo"
                 example:
-                  - filename: myfile.txt
-                    dirpath: path/to/parent/dir
-                    sha1sum: ab3aa0555f31a8d7809fae4b03a95195edb01f5c
-                  - filename: myfile2.txt
-                    dirpath: path/to/parent/dir
-                    sha1sum: ab3aa0555f31a8d7809fae4b03a95195edb01f5d
+                - filename: myfile.txt
+                  dirpath: path/to/parent/dir
+                  sha1sum: ab3aa0555f31a8d7809fae4b03a95195edb01f5c
+                - filename: myfile2.txt
+                  dirpath: path/to/parent/dir
+                  sha1sum: ab3aa0555f31a8d7809fae4b03a95195edb01f5d
 
         401:
           $ref: "#/components/responses/Unauthorized"
@@ -386,13 +386,20 @@ paths:
     post:
       tags:
       - directory
-      summary: Adds a file or a subdirectory.
+      summary: Adds one or more files or a subdirectory.
       description: |
-        Sub request of a request with `Content-Type` value `multipart/form-data`.
-        By default the files listed in the body of the main request are saved in `dir_path` under the file name provided
-        in the `Content-Disposition` header. However, if a file has the extension ZIP, it
-        is extracted in `dir_path` and `Content-Disposition` is ignored (and may be left out).
-        If `dir_path`, or any of its parents do not exist yet, they are first created.
+        Depending on the `Content-Type` header one or multiple files can be sent. The files will
+        be added in the directory pointed to by `dir_path`.
+
+        * `application/octet-stream`: the body contains one file. The file name is specified
+          in the `Content-Disposition` header, using the `filename` parameter.
+        * `multipart/form-data`: the body is formatted using the [multipart media type](https://tools.ietf.org/html/rfc2046.html#section-5.1); each part contains one file. The header
+          area of each part specifies the file name using a `Content-Disposition` header. Note,
+          that this means that only a flat list of files can be sent this way, i.e. not including
+          any directory hierarchy.
+        * `application/zip`: the body is a file in ZIP format. This ZIP file can contain a directory
+          hierarchy. The ZIP file will be unzipped in `dir_path`. For each file in the ZIP file,
+          the path in the deposit will be `dir_path`/`path_in_zip`.
       parameters:
       - $ref: "#/components/parameters/DepositId"
       - $ref: "#/components/parameters/DirPath"
@@ -402,9 +409,14 @@ paths:
         content:
           application/octet-stream:
             schema:
-              # a binary file of any type
               type: string
               format: binary
+          multi-part/formdata:
+            schema:
+              type: array
+              items:
+                type: string
+                format: binary
           application/zip:
             schema:
               type: string
@@ -470,8 +482,8 @@ paths:
       - file
       summary: Adds or overwrites the specified file in the deposit.
       parameters:
-       - $ref: "#/components/parameters/DepositId"
-       - $ref: "#/components/parameters/FilePath"
+      - $ref: "#/components/parameters/DepositId"
+      - $ref: "#/components/parameters/FilePath"
       description: If any of `file_path`'s parent do not yet exist, they are first created.
       operationId: writeFile
       requestBody:
@@ -479,7 +491,7 @@ paths:
         required: true
         content:
           '*/*':
-          # any media type is accepted, functionally equivalent to `*/*`
+            # any media type is accepted, functionally equivalent to `*/*`
             schema:
               # a binary file of any type
               type: string
@@ -516,8 +528,8 @@ paths:
       - file
       summary: Deletes a file from deposit.
       parameters:
-       - $ref: "#/components/parameters/DepositId"
-       - $ref: "#/components/parameters/FilePath"
+      - $ref: "#/components/parameters/DepositId"
+      - $ref: "#/components/parameters/FilePath"
       operationId: deleteFile
       responses:
         204:
@@ -585,7 +597,9 @@ components:
     ContentDisposition:
       name: "Content-Disposition; filename"
       in: header
-      description: the name to use for the new file in the deposit; required unless Content-Type is `application/zip`.
+      description: |
+        the name to use for the new file in the deposit; required only when sending a
+        single file using `Content-Type: application/octet-stream`.
       required: true
       schema:
         type: "string"
@@ -635,8 +649,8 @@ components:
     UserInfo:
       type: object
       required:
-        - username
-        - lastName
+      - username
+      - lastName
       example:
         username: "user001"
         firstName: "First"
@@ -684,11 +698,11 @@ components:
           format: "date-time"
           description: "Deposit date"
       example:
-          id: "1d946f5b-e53b-4f71-b1f3-7481475d07db"
-          title: My draft deposit
-          state: DRAFT
-          stateDescription: Deposit is open for modification.
-          date: "2018-01-12T10:40:52Z"
+        id: "1d946f5b-e53b-4f71-b1f3-7481475d07db"
+        title: My draft deposit
+        state: DRAFT
+        stateDescription: Deposit is open for modification.
+        date: "2018-01-12T10:40:52Z"
 
     State:
       type: object
@@ -731,8 +745,8 @@ components:
           items:
             type: string
           example:
-            - "Title 1"
-            - "Title 2"
+          - "Title 1"
+          - "Title 2"
         alternativeTitles:
           $ref: "#/components/schemas/StringArray"
         descriptions:
@@ -761,9 +775,9 @@ components:
           type: array
           items:
             oneOf : [
-              {$ref: "#/components/schemas/Relation"},
-              {$ref: "#/components/schemas/QualifiedSchemedValue"}
-              ]
+            {$ref: "#/components/schemas/Relation"},
+            {$ref: "#/components/schemas/QualifiedSchemedValue"}
+            ]
 
         languagesOfFiles:
           type: array
@@ -866,25 +880,25 @@ components:
         organization:
           type: string
       oneOf:
-        - required:
-          - surname
-          - initials
-        - required:
-          - organization
+      - required:
+        - surname
+        - initials
+      - required:
+        - organization
       example:
         titles: Prof Dr
         initials: A
         insertions:
         surname: Einstein
         role:
-          - scheme: datacite:contributorType
-          - key: DataManager
-          - value: "Data Manager"
+        - scheme: datacite:contributorType
+        - key: DataManager
+        - value: "Data Manager"
         ids:
-          - scheme: DAI
-            value: "123456789x"
-          - scheme: ISNI
-            value: "ISNI:000000012281955X"
+        - scheme: DAI
+          value: "123456789x"
+        - scheme: ISNI
+          value: "ISNI:000000012281955X"
         organization: University of Zurich
 
     Date:
@@ -937,10 +951,10 @@ components:
         title:
           type: string
       oneOf:
-        - required:
-          - title
-        - required:
-          - url
+      - required:
+        - title
+      - required:
+        - url
 
     SchemedValue:
       type: object
@@ -959,9 +973,9 @@ components:
       - value
       properties:
         scheme:
-         type: string
+          type: string
         value:
-         type: string
+          type: string
 
     QualifiedSchemedValue:
       type: object

--- a/docs/api/api.yml
+++ b/docs/api/api.yml
@@ -411,7 +411,7 @@ paths:
             schema:
               type: string
               format: binary
-          multi-part/formdata:
+          multipart/form-data:
             schema:
               type: array
               items:


### PR DESCRIPTION
The previous version was a bit of a hack, as it documented a part-header at the level where for the rest http-message headers are documented. This is not necessary at all. The Swagger documentation [gives clear guidance on how to document multipart/form-data](https://swagger.io/docs/specification/describing-request-body/file-upload/).

Also, some functionality was specified that I disagree with, like unzipping ZIP-files in a multipart/form-data request and looking at the extension of a file name to determine whether a file is a ZIP. I strongly suggest we try to keep close to standards, best practices and in general using things the way they were intended.

#### When applied it will
* Amend the specs for POST-ing to directories

#### Where should the reviewer @DANS-KNAW/easy start?
`api.yml`

