### PR TITLE
EASY-1681: Return single FileInfo object for GET on specific file

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.deposit/DataFiles.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/DataFiles.scala
@@ -34,6 +34,28 @@ import scala.util.{ Failure, Success, Try }
  */
 case class DataFiles(bag: DansBag) extends DebugEnhancedLogging {
 
+  val dataDir = bag.baseDir / "data"
+
+  /**
+   * Returns 'true' if the path points to a directory.
+   *
+   * @param path a relative path.
+   * @return 'true' if directory, else 'false'
+   */
+  def isDirectory(path: Path): Boolean = {
+    dataDir / path.toString isDirectory
+  }
+
+  /**
+   * Returns contents of a file.
+   *
+   * @param path a relative path to a data file.
+   * @return contents of the file
+   */
+  def fileContents(path: Path): Try[String] = Try {
+    dataDir / path.toString contentAsString
+  }
+
   /**
    * Lists information about the files the directory `path` and its subdirectories.
    * A previous crash during a recursive delete process (deleting a directory),
@@ -44,7 +66,7 @@ case class DataFiles(bag: DansBag) extends DebugEnhancedLogging {
    * @return a list of [[FileInfo]] objects
    */
   def list(path: Path = Paths.get("")): Try[Seq[FileInfo]] = {
-    val parentPath = bag.baseDir / "data" / path.toString
+    val parentPath = dataDir / path.toString
     val manifestMap = bag.payloadManifests
 
     def convert(items: Map[File, String]) = {

--- a/src/main/scala/nl.knaw.dans.easy.deposit/DataFiles.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/DataFiles.scala
@@ -92,10 +92,11 @@ case class DataFiles(bag: DansBag) extends DebugEnhancedLogging {
    */
   def fileInfo(path: Path = Paths.get("")): Try[FileInfo] = {
     val manifestMap = bag.payloadManifests
+    val manifests = manifestMap.get(SHA1).orElse(manifestMap.values.headOption)
     val absolutePath = dataDir / path.toString
-    val fileExists = manifestMap.get(SHA1).orElse(manifestMap.values.headOption).get.contains(absolutePath)
+    val fileExists = manifests.get.contains(absolutePath)
     if (fileExists) {
-      val checksum = manifestMap.get(SHA1).orElse(manifestMap.values.headOption) get absolutePath
+      val checksum = manifests get absolutePath
       Success(FileInfo(path.getFileName.toString, bag.data.relativize(absolutePath), checksum))
     }
     else {

--- a/src/main/scala/nl.knaw.dans.easy.deposit/DataFiles.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/DataFiles.scala
@@ -23,8 +23,8 @@ import nl.knaw.dans.bag.ChecksumAlgorithm.SHA1
 import nl.knaw.dans.bag.DansBag
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
 
-import scala.util.{ Failure, Success, Try }
 import scala.language.postfixOps
+import scala.util.{ Failure, Success, Try }
 
 /**
  * Represents the data files of a deposit. The data files are the content files that the user uploads,
@@ -35,7 +35,7 @@ import scala.language.postfixOps
  */
 case class DataFiles(bag: DansBag) extends DebugEnhancedLogging {
 
-  val dataDir = bag.baseDir / "data"
+  private val dataDir = bag.baseDir / "data"
 
   /**
    * Returns 'true' if the path points to a directory.
@@ -99,7 +99,7 @@ case class DataFiles(bag: DansBag) extends DebugEnhancedLogging {
       Success(FileInfo(path.getFileName.toString, bag.data.relativize(absolutePath), checksum))
     }
     else {
-      Failure((new NoSuchFileException(s"${path.toString}")))
+      Failure(new NoSuchFileException(s"${ path.toString }"))
     }
   }
 

--- a/src/main/scala/nl.knaw.dans.easy.deposit/DataFiles.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/DataFiles.scala
@@ -35,8 +35,6 @@ import scala.util.{ Failure, Success, Try }
  */
 case class DataFiles(bag: DansBag) extends DebugEnhancedLogging {
 
-  private val dataDir = bag.baseDir / "data"
-
   /**
    * Returns 'true' if the path points to a directory.
    *
@@ -44,17 +42,7 @@ case class DataFiles(bag: DansBag) extends DebugEnhancedLogging {
    * @return 'true' if directory, else 'false'
    */
   def isDirectory(path: Path): Boolean = {
-    dataDir / path.toString isDirectory
-  }
-
-  /**
-   * Returns contents of a file.
-   *
-   * @param path a relative path to a data file.
-   * @return contents of the file
-   */
-  def fileContents(path: Path): Try[String] = Try {
-    dataDir / path.toString contentAsString
+    bag.data / path.toString isDirectory
   }
 
   /**
@@ -66,8 +54,8 @@ case class DataFiles(bag: DansBag) extends DebugEnhancedLogging {
    * @param path a relative path into data files directory of the bag.
    * @return a list of [[FileInfo]] objects
    */
-  def fileInfoSeq(path: Path = Paths.get("")): Try[Seq[FileInfo]] = {
-    val parentPath = dataDir / path.toString
+  def list(path: Path = Paths.get("")): Try[Seq[FileInfo]] = {
+    val parentPath = bag.data / path.toString
     val manifestMap = bag.payloadManifests
 
     def convert(items: Map[File, String]) = {
@@ -90,10 +78,10 @@ case class DataFiles(bag: DansBag) extends DebugEnhancedLogging {
    * @param path a relative path into a data files.
    * @return a [[FileInfo]] object
    */
-  def fileInfo(path: Path = Paths.get("")): Try[FileInfo] = {
+  def get(path: Path = Paths.get("")): Try[FileInfo] = {
     val manifestMap = bag.payloadManifests
     val manifests = manifestMap.get(SHA1).orElse(manifestMap.values.headOption)
-    val absolutePath = dataDir / path.toString
+    val absolutePath = bag.data / path.toString
     val fileExists = manifests.get.contains(absolutePath)
     if (fileExists) {
       val checksum = manifests get absolutePath

--- a/src/main/scala/nl.knaw.dans.easy.deposit/DataFiles.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/DataFiles.scala
@@ -66,7 +66,7 @@ case class DataFiles(bag: DansBag) extends DebugEnhancedLogging {
    * @param path a relative path into data files directory of the bag.
    * @return a list of [[FileInfo]] objects
    */
-  def list(path: Path = Paths.get("")): Try[Seq[FileInfo]] = {
+  def fileInfoSeq(path: Path = Paths.get("")): Try[Seq[FileInfo]] = {
     val parentPath = dataDir / path.toString
     val manifestMap = bag.payloadManifests
 
@@ -96,10 +96,10 @@ case class DataFiles(bag: DansBag) extends DebugEnhancedLogging {
     val fileExists = manifestMap.get(SHA1).orElse(manifestMap.values.headOption).get.contains(absolutePath)
     if (fileExists) {
       val checksum = manifestMap.get(SHA1).orElse(manifestMap.values.headOption) get absolutePath
-      Success(FileInfo(path.getFileName.toString, bag.data.relativize(dataDir / path.toString), checksum))
+      Success(FileInfo(path.getFileName.toString, bag.data.relativize(absolutePath), checksum))
     }
     else {
-      Failure((new NoSuchFileException(s"file ${path.getFileName}")))
+      Failure((new NoSuchFileException(s"${path.toString}")))
     }
   }
 

--- a/src/main/scala/nl.knaw.dans.easy.deposit/DataFiles.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/DataFiles.scala
@@ -24,7 +24,7 @@ import nl.knaw.dans.bag.DansBag
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
 
 import scala.util.{ Failure, Success, Try }
-
+import scala.language.postfixOps
 /**
  * Represents the data files of a deposit. The data files are the content files that the user uploads,
  * i.e. the files that are the actual target of preservation. The dataset metadata is ''not'' included

--- a/src/main/scala/nl.knaw.dans.easy.deposit/EasyDepositApiApp.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/EasyDepositApiApp.scala
@@ -209,8 +209,8 @@ class EasyDepositApiApp(configuration: Configuration) extends DebugEnhancedLoggi
    */
   def getFileInfo(user: String, id: UUID, path: Path): Try[Object] = for {
     dataFiles <- getDataFiles(user, id)
-    contents <- if (dataFiles.isDirectory(path)) dataFiles.fileInfoSeq(path)
-                else dataFiles.fileInfo(path)
+    contents <- if (dataFiles.isDirectory(path)) dataFiles.list(path)
+                else dataFiles.get(path)
   } yield contents
 
   /**
@@ -220,7 +220,7 @@ class EasyDepositApiApp(configuration: Configuration) extends DebugEnhancedLoggi
    * @param id   the deposit ID
    * @return
    */
-  def getDataFiles(user: String, id: UUID): Try[DataFiles] = for {
+  private def getDataFiles(user: String, id: UUID): Try[DataFiles] = for {
     deposit <- getDeposit(user, id)
     dataFiles <- deposit.getDataFiles
   } yield dataFiles

--- a/src/main/scala/nl.knaw.dans.easy.deposit/EasyDepositApiApp.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/EasyDepositApiApp.scala
@@ -202,11 +202,11 @@ class EasyDepositApiApp(configuration: Configuration) extends DebugEnhancedLoggi
    * @param id   the deposit ID
    * @return
    */
-  def getDepositFiles(user: String, id: UUID, path: Path = Paths.get("")): Try[Seq[FileInfo]] = for {
+  def getFileInfo(user: String, id: UUID, path: Path = Paths.get("")): Try[Object] = for {
     deposit <- DepositDir.get(draftsDir, user, id)
     dataFiles <- deposit.getDataFiles
-    fileInfos <- dataFiles.list(path)
-  } yield fileInfos
+    fileInfo <- if (dataFiles.isDirectory(path)) dataFiles.list(path) else dataFiles.fileContents(path)
+  } yield fileInfo
 
   /**
    * Writes the given input stream to a location in the deposit's content directory. The specified `path`

--- a/src/main/scala/nl.knaw.dans.easy.deposit/EasyDepositApiApp.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/EasyDepositApiApp.scala
@@ -17,7 +17,7 @@ package nl.knaw.dans.easy.deposit
 
 import java.io.InputStream
 import java.net.URI
-import java.nio.file.{ Path, Paths }
+import java.nio.file.Path
 import java.util.UUID
 
 import better.files.File
@@ -135,8 +135,8 @@ class EasyDepositApiApp(configuration: Configuration) extends DebugEnhancedLoggi
    * 3. The deposit directory will be copied to the staging area.
    * 4. The copy will be moved to the deposit area.
    *
-   * @param user  the user ID
-   * @param id    the deposit ID
+   * @param user      the user ID
+   * @param id        the deposit ID
    * @param stateInfo the state to transition to
    * @return
    */
@@ -200,6 +200,20 @@ class EasyDepositApiApp(configuration: Configuration) extends DebugEnhancedLoggi
   } yield ()
 
   /**
+   * Returns a list of [[FileInfo]] objects if the path points to a directory, else a single [FileInfo] object
+   *
+   * @param user the user ID
+   * @param id   the deposit ID
+   * @param path path to a directory or a file
+   * @return
+   */
+  def getFileInfo(user: String, id: UUID, path: Path): Try[Object] = for {
+    dataFiles <- getDataFiles(user, id)
+    contents <- if (dataFiles.isDirectory(path)) dataFiles.fileInfoSeq(path)
+                else dataFiles.fileInfo(path)
+  } yield contents
+
+  /**
    * Returns dataset files of the deposit
    *
    * @param user the user ID
@@ -227,7 +241,7 @@ class EasyDepositApiApp(configuration: Configuration) extends DebugEnhancedLoggi
    */
   def writeDepositFile(is: => InputStream, user: String, id: UUID, path: Path): Try[Boolean] = for {
     dataFiles <- getDataFiles(user, id)
-    _ = logger.info(s"uploading to [${dataFiles.bag.baseDir}] of [$path]")
+    _ = logger.info(s"uploading to [${ dataFiles.bag.baseDir }] of [$path]")
     created <- dataFiles.write(is, path)
     _ = logger.info(s"created=$created $user/$id/$path")
   } yield created

--- a/src/main/scala/nl.knaw.dans.easy.deposit/servlets/DepositServlet.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/servlets/DepositServlet.scala
@@ -119,7 +119,7 @@ class DepositServlet(app: EasyDepositApiApp)
       uuid <- getUUID
       path <- getPath
       dataFiles <- app.getDataFiles(user.id, uuid)
-      contents <- if (dataFiles.isDirectory(path)) dataFiles.list(path) else dataFiles.fileContents(path)
+      contents <- if (dataFiles.isDirectory(path)) dataFiles.list(path) else dataFiles.fileInfo(path)
     } yield Ok(body = toJson(contents))
       ).getOrRecoverResponse(respond)
   }

--- a/src/main/scala/nl.knaw.dans.easy.deposit/servlets/DepositServlet.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/servlets/DepositServlet.scala
@@ -119,8 +119,8 @@ class DepositServlet(app: EasyDepositApiApp)
     (for {
       uuid <- getUUID
       path <- getPath
-      depositFiles <- app.getDepositFiles(user.id, uuid, path)
-    } yield Ok(body = toJson(depositFiles))
+      contents <- app.getFileInfo(user.id, uuid, path)
+    } yield Ok(body = toJson(contents))
       ).getOrRecoverResponse(respond)
   }
   post("/:uuid/file/*") { //file(s)

--- a/src/main/scala/nl.knaw.dans.easy.deposit/servlets/DepositServlet.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/servlets/DepositServlet.scala
@@ -18,7 +18,6 @@ package nl.knaw.dans.easy.deposit.servlets
 import java.nio.file.{ NoSuchFileException, Path, Paths }
 import java.util.UUID
 
-import better.files.File
 import nl.knaw.dans.easy.deposit.authentication.ServletEnhancedLogging._
 import nl.knaw.dans.easy.deposit.docs.JsonUtil.{ InvalidDocumentException, toJson }
 import nl.knaw.dans.easy.deposit.docs.{ DatasetMetadata, DepositInfo, StateInfo }
@@ -119,7 +118,8 @@ class DepositServlet(app: EasyDepositApiApp)
     (for {
       uuid <- getUUID
       path <- getPath
-      contents <- app.getFileInfo(user.id, uuid, path)
+      dataFiles <- app.getDataFiles(user.id, uuid)
+      contents <- if (dataFiles.isDirectory(path)) dataFiles.list(path) else dataFiles.fileContents(path)
     } yield Ok(body = toJson(contents))
       ).getOrRecoverResponse(respond)
   }

--- a/src/main/scala/nl.knaw.dans.easy.deposit/servlets/DepositServlet.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/servlets/DepositServlet.scala
@@ -119,7 +119,8 @@ class DepositServlet(app: EasyDepositApiApp)
       uuid <- getUUID
       path <- getPath
       dataFiles <- app.getDataFiles(user.id, uuid)
-      contents <- if (dataFiles.isDirectory(path)) dataFiles.list(path) else dataFiles.fileInfo(path)
+      contents <- if (dataFiles.isDirectory(path)) dataFiles.fileInfoSeq(path)
+                  else dataFiles.fileInfo(path)
     } yield Ok(body = toJson(contents))
       ).getOrRecoverResponse(respond)
   }
@@ -222,7 +223,7 @@ class DepositServlet(app: EasyDepositApiApp)
     val fileItems = fileMultiParams.values.flatten
     logger.info(fileItems
       .map(i => s"size=${ i.size } charset=${ i.charset } contentType=${ i.contentType } fieldName=${ i.fieldName } name=${ i.name }")
-      .mkString(s"user=${ user.id }; ${request.uri.getPath}: ", "; ", ".")
+      .mkString(s"user=${ user.id }; ${ request.uri.getPath }: ", "; ", ".")
     )
     fileItems
   }

--- a/src/main/scala/nl.knaw.dans.easy.deposit/servlets/DepositServlet.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/servlets/DepositServlet.scala
@@ -118,9 +118,7 @@ class DepositServlet(app: EasyDepositApiApp)
     (for {
       uuid <- getUUID
       path <- getPath
-      dataFiles <- app.getDataFiles(user.id, uuid)
-      contents <- if (dataFiles.isDirectory(path)) dataFiles.fileInfoSeq(path)
-                  else dataFiles.fileInfo(path)
+      contents <- app.getFileInfo(user.id, uuid, path)
     } yield Ok(body = toJson(contents))
       ).getOrRecoverResponse(respond)
   }

--- a/src/test/scala/nl.knaw.dans.easy.deposit/DataFilesSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/DataFilesSpec.scala
@@ -108,13 +108,13 @@ class DataFilesSpec extends TestSupportFixture {
     val dataFiles = DataFiles(bag)
     val path2 = Paths.get("folder2")
 
-    dataFiles.fileInfoSeq(path2) should matchPattern {
+    dataFiles.list(path2) should matchPattern {
       case Success(Seq(FileInfo("4.txt", p, _))) if p == path2 => // no order problem as the next cases would have
     }
-    dataFiles.fileInfoSeq(Paths.get("folder1")) should matchPattern {
+    dataFiles.list(Paths.get("folder1")) should matchPattern {
       case Success(Seq(_, _)) =>
     }
-    dataFiles.fileInfoSeq(Paths.get("")) should matchPattern {
+    dataFiles.list(Paths.get("")) should matchPattern {
       case Success(Seq(_, _, _, _)) =>
     }
   }
@@ -128,7 +128,7 @@ class DataFilesSpec extends TestSupportFixture {
     val dataFiles = DataFiles(bag)
     val path = Paths.get("folder1/2.txt")
 
-    dataFiles.fileInfo(path) should matchPattern {
+    dataFiles.get(path) should matchPattern {
       case Success(FileInfo("2.txt", path, _)) =>
     }
   }

--- a/src/test/scala/nl.knaw.dans.easy.deposit/DataFilesSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/DataFilesSpec.scala
@@ -97,7 +97,7 @@ class DataFilesSpec extends TestSupportFixture {
     }
   }
 
-  "list" should "return the proper number of files" in {
+  "fileInfoSeq" should "return the proper number of files" in {
     val bag = DansV0Bag
       .empty(testDir / "testBag").getOrRecover(fail("could not create test bag", _))
       .addPayloadFile(randomContent)(_ / "1.txt").getOrRecover(payloadFailure)
@@ -108,14 +108,28 @@ class DataFilesSpec extends TestSupportFixture {
     val dataFiles = DataFiles(bag)
     val path2 = Paths.get("folder2")
 
-    dataFiles.list(path2) should matchPattern {
+    dataFiles.fileInfoSeq(path2) should matchPattern {
       case Success(Seq(FileInfo("4.txt", p, _))) if p == path2 => // no order problem as the next cases would have
     }
-    dataFiles.list(Paths.get("folder1")) should matchPattern {
+    dataFiles.fileInfoSeq(Paths.get("folder1")) should matchPattern {
       case Success(Seq(_, _)) =>
     }
-    dataFiles.list(Paths.get("")) should matchPattern {
+    dataFiles.fileInfoSeq(Paths.get("")) should matchPattern {
       case Success(Seq(_, _, _, _)) =>
+    }
+  }
+
+  "fileInfo" should "return proper information about the file" in {
+    val bag = DansV0Bag
+      .empty(testDir / "testBag").getOrRecover(fail("could not create test bag", _))
+      .addPayloadFile(randomContent)(_ / "1.txt").getOrRecover(payloadFailure)
+      .addPayloadFile(randomContent)(_ / "folder1/2.txt").getOrRecover(payloadFailure)
+    bag.save()
+    val dataFiles = DataFiles(bag)
+    val path = Paths.get("folder1/2.txt")
+
+    dataFiles.fileInfo(path) should matchPattern {
+      case Success(FileInfo("2.txt", path, _)) =>
     }
   }
 

--- a/src/test/scala/nl.knaw.dans.easy.deposit/TestSupportFixture.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/TestSupportFixture.scala
@@ -19,9 +19,12 @@ import java.util.{ Base64, TimeZone, UUID }
 
 import better.files.File
 import better.files.File._
+import nl.knaw.dans.bag.DansBag
+import nl.knaw.dans.bag.v0.DansV0Bag
 import nl.knaw.dans.easy.deposit.authentication.AuthenticationMocker.mockedAuthenticationProvider
 import nl.knaw.dans.easy.deposit.authentication.TokenSupport.TokenConfig
 import nl.knaw.dans.easy.deposit.authentication.{ AuthConfig, AuthUser, AuthenticationProvider, TokenSupport }
+import nl.knaw.dans.easy.deposit.docs.DepositInfo
 import org.apache.commons.configuration.PropertiesConfiguration
 import org.joda.time.{ DateTime, DateTimeUtils, DateTimeZone }
 import org.scalatest._
@@ -67,6 +70,13 @@ trait TestSupportFixture extends FlatSpec with Matchers with Inside with BeforeA
       addProperty("users.ldap-admin-password", "-")
       addProperty("users.ldap-user-id-attr-name", "-")
     })
+  }
+
+  def dansBag: DansBag = {
+    val depositInfo = DepositInfo()
+    val deposit = DepositDir(testDir, "foo", depositInfo.id)
+    val depositDir = deposit.baseDir / "foo" / depositInfo.id.toString
+    DansV0Bag.empty(depositDir / "bag").getOrElse(null)
   }
 
   private def testSubDir(drafts: String) = {

--- a/src/test/scala/nl.knaw.dans.easy.deposit/servlets/HappyRoutesSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/servlets/HappyRoutesSpec.scala
@@ -33,8 +33,6 @@ class HappyRoutesSpec extends TestSupportFixture with ServletFixture with Scalat
 
   private class MockedApp extends EasyDepositApiApp(minimalAppConfig)
   private val mockedApp = mock[MockedApp]
-  private class MockedDataFiles extends DataFiles(dansBag)
-  private val mockedDataFiles = mock[MockedDataFiles]
   mountServlets(mockedApp, mockedAuthenticationProvider)
 
   "get /" should "be ok" in {
@@ -150,11 +148,7 @@ class HappyRoutesSpec extends TestSupportFixture with ServletFixture with Scalat
 
   s"get /deposit/:uuid/file/path/to/directory" should "return FileInfo" in {
     expectsUserFooBar
-    (mockedApp.getDataFiles(_: String, _: UUID)) expects("foo", uuid) returning
-      Try(mockedDataFiles)
-    (mockedDataFiles.isDirectory(_: Path)) expects * returning
-      true
-    (mockedDataFiles.fileInfoSeq(_: Path)) expects * returning
+    (mockedApp.getFileInfo(_: String, _: UUID, _: Path)) expects("foo", uuid, *) returning
       Success(Seq(FileInfo("a.txt", Paths.get("files/a.txt"), "x")))
 
     get(
@@ -168,11 +162,7 @@ class HappyRoutesSpec extends TestSupportFixture with ServletFixture with Scalat
 
   s"get /deposit/:uuid/file/a.txt" should "return the contents of the file" in {
     expectsUserFooBar
-    (mockedApp.getDataFiles(_: String, _: UUID)) expects("foo", uuid) returning
-      Try(mockedDataFiles)
-    (mockedDataFiles.isDirectory(_: Path)) expects * returning
-      false
-    (mockedDataFiles.fileInfo(_: Path)) expects * returning
+    (mockedApp.getFileInfo(_: String, _: UUID, _: Path)) expects("foo", uuid, *) returning
       Success(FileInfo("a.txt", Paths.get("files/a.txt"), "x"))
 
     get(

--- a/src/test/scala/nl.knaw.dans.easy.deposit/servlets/HappyRoutesSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/servlets/HappyRoutesSpec.scala
@@ -154,7 +154,7 @@ class HappyRoutesSpec extends TestSupportFixture with ServletFixture with Scalat
       Try(mockedDataFiles)
     (mockedDataFiles.isDirectory(_: Path)) expects * returning
       true
-    (mockedDataFiles.list(_: Path)) expects * returning
+    (mockedDataFiles.fileInfoSeq(_: Path)) expects * returning
       Success(Seq(FileInfo("a.txt", Paths.get("files/a.txt"), "x")))
 
     get(

--- a/src/test/scala/nl.knaw.dans.easy.deposit/servlets/HappyRoutesSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/servlets/HappyRoutesSpec.scala
@@ -148,7 +148,7 @@ class HappyRoutesSpec extends TestSupportFixture with ServletFixture with Scalat
 
   s"get /deposit/:uuid/file/a.txt" should "return FileInfo" in {
     expectsUserFooBar
-    (mockedApp.getDepositFiles(_: String, _: UUID, _: Path)) expects("foo", uuid, *) returning
+    (mockedApp.getFileInfo(_: String, _: UUID, _: Path)) expects("foo", uuid, *) returning
       Success(Seq(FileInfo("a.txt", Paths.get("files/a.txt"), "x")))
 
     get(

--- a/src/test/scala/nl.knaw.dans.easy.deposit/servlets/HappyRoutesSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/servlets/HappyRoutesSpec.scala
@@ -172,14 +172,14 @@ class HappyRoutesSpec extends TestSupportFixture with ServletFixture with Scalat
       Try(mockedDataFiles)
     (mockedDataFiles.isDirectory(_: Path)) expects * returning
       false
-    (mockedDataFiles.fileContents(_: Path)) expects * returning
-      Success("this is the file contents")
+    (mockedDataFiles.fileInfo(_: Path)) expects * returning
+      Success(FileInfo("a.txt", Paths.get("files/a.txt"), "x"))
 
     get(
       uri = s"/deposit/$uuid/file/a.txt",
       headers = Seq(("Authorization", fooBarBasicAuthHeader))
     ) {
-      body.replaceAll("\"", "") shouldBe "this is the file contents"
+      body shouldBe s"""{"fileName":"a.txt","dirPath":"files/a.txt","sha1sum":"x"}"""
       status shouldBe OK_200
     }
   }

--- a/src/test/scala/nl.knaw.dans.easy.deposit/servlets/IntegrationSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/servlets/IntegrationSpec.scala
@@ -121,23 +121,16 @@ class IntegrationSpec extends TestSupportFixture with ServletFixture with Scalat
       new String(bodyBytes)
     }
     val uuid = DepositInfo(responseBody).map(_.id.toString).getOrRecover(e => fail(e.toString, e))
-
     val dataFilesBase = DepositDir(testDir / "drafts", "foo", UUID.fromString(uuid)).getDataFiles.get.bag.data
-    val times = 500
-    val expectedContentSize = 37 * times - 1
 
-    // upload the file twice
-    expectsUserFooBar
-    val content = randomContent(times)
-    put(uri = s"/deposit/$uuid/file/path/to/text.txt", headers = Seq(basicAuthentication), body = content) {
-      status shouldBe CREATED_201
-      (dataFilesBase / "path" / "to" / "text.txt").contentAsString shouldBe content
-    }
+    // upload the file
     expectsUserFooBar
     put(uri = s"/deposit/$uuid/file/path/to/text.txt", headers = Seq(basicAuthentication), body = "Lorum ipsum") {
-      status shouldBe OK_200
+      status shouldBe CREATED_201
       (dataFilesBase / "path" / "to" / "text.txt").contentAsString shouldBe "Lorum ipsum"
     }
+
+    // get the file information
     expectsUserFooBar
     get(uri = s"/deposit/$uuid/file/path", headers = Seq(basicAuthentication)) {
       status shouldBe OK_200
@@ -156,7 +149,6 @@ class IntegrationSpec extends TestSupportFixture with ServletFixture with Scalat
 
     val dataFilesBase = DepositDir(testDir / "drafts", "foo", UUID.fromString(uuid)).getDataFiles.get.bag.data
     val times = 500
-    val expectedContentSize = 37 * times - 1
 
     // upload the file twice
     expectsUserFooBar
@@ -282,9 +274,6 @@ class IntegrationSpec extends TestSupportFixture with ServletFixture with Scalat
   s"scenario: create - POST payload" should "report a missing content disposistion" in {
 
     val datasetMetadata = getManualTestResource("datasetmetadata-from-ui-all.json")
-    val doi = Try { DatasetMetadata(datasetMetadata).get.identifiers.get.headOption.get.value }
-      .getOrRecover(e => fail("could not get DOI from test input", e))
-    (testDir / "easy-ingest-flow-inbox").createDirectories()
 
     // create dataset
     expectsUserFooBar

--- a/src/test/scala/nl.knaw.dans.easy.deposit/servlets/IntegrationSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/servlets/IntegrationSpec.scala
@@ -15,9 +15,7 @@
  */
 package nl.knaw.dans.easy.deposit.servlets
 
-import java.nio.file.Files
 import java.nio.file.Files.setPosixFilePermissions
-import java.nio.file.attribute.PosixFilePermissions
 import java.nio.file.attribute.PosixFilePermissions.fromString
 import java.util.UUID
 


### PR DESCRIPTION
Fixes EASY-1681

#### When applied it will
* return information about a file when the path in GET /deposit/{id}/file/{path} points to a file

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### Related pull requests on github
repo                       | PR                | note
-------------------------- | ----------------- | ----
easy-                      | [PR#](PRlink)     | ..
