### PR TITLE
EASY-1744 move unzipped files to draft bag, not copy (again) from unzip-staging

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -108,7 +108,6 @@
         <dependency>
             <groupId>com.github.pathikrit</groupId>
             <artifactId>better-files_2.12</artifactId>
-            <version>3.4.0</version>
         </dependency>
         <dependency>
             <groupId>com.pauldijou</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
         <dependency>
             <groupId>nl.knaw.dans.lib</groupId>
             <artifactId>dans-bag-lib_2.12</artifactId>
-            <version>1.0.0-beta-2</version>
+            <version>1.0.0-beta-3</version>
         </dependency>
         <dependency>
             <groupId>com.jsuereth</groupId>

--- a/src/main/scala/nl.knaw.dans.easy.deposit/DepositDir.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/DepositDir.scala
@@ -16,7 +16,7 @@
 package nl.knaw.dans.easy.deposit
 
 import java.io.FileNotFoundException
-import java.nio.file.NoSuchFileException
+import java.nio.file.{ NoSuchFileException, Paths }
 import java.util.UUID
 
 import better.files._
@@ -261,7 +261,7 @@ object DepositDir {
       _ <- Try { depositDir.createDirectories }
       bag <- DansV0Bag.empty(depositDir / "bag")
       _ = bag.withEasyUserAccount(deposit.user)
-      _ <- bag.addTagFile("{}".asInputStream)(_ / "metadata" / "dataset.json")
+      _ <- bag.addTagFile("{}".asInputStream, Paths.get("metadata/dataset.json"))
       _ <- bag.save()
       _ <- createDepositProperties(user, depositInfo, deposit)
     } yield deposit

--- a/src/main/scala/nl.knaw.dans.easy.deposit/EasyDepositApiApp.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/EasyDepositApiApp.scala
@@ -17,11 +17,11 @@ package nl.knaw.dans.easy.deposit
 
 import java.io.InputStream
 import java.net.URI
-import java.nio.file.{ Path, Paths }
+import java.nio.file.Path
 import java.util.UUID
 
 import better.files.File.temporaryDirectory
-import better.files.{ File, ManagedResource }
+import better.files.{ Dispose, File }
 import nl.knaw.dans.easy.deposit.PidRequesterComponent.PidRequester
 import nl.knaw.dans.easy.deposit.authentication.LdapAuthentication
 import nl.knaw.dans.easy.deposit.docs.StateInfo.State
@@ -247,7 +247,7 @@ class EasyDepositApiApp(configuration: Configuration) extends DebugEnhancedLoggi
     _ = logger.info(s"created=$created $user/$id/$path")
   } yield created
 
-  def stageFiles(userId: String, id: UUID, destination: Path): Try[(ManagedResource[File], StagedFilesTarget)] = for {
+  def stageFiles(userId: String, id: UUID, destination: Path): Try[(Dispose[File], StagedFilesTarget)] = for {
     deposit <- DepositDir.get(draftsDir, userId, id)
     dataFiles <- deposit.getDataFiles
     stagingDir = temporaryDirectory(s"$userId-$id-", Some(uploadStagingDir.createDirectories()))

--- a/src/main/scala/nl.knaw.dans.easy.deposit/StagedFilesTarget.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/StagedFilesTarget.scala
@@ -22,6 +22,7 @@ import nl.knaw.dans.bag.DansBag
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
 
 import scala.util.{ Success, Try }
+import nl.knaw.dans.bag.ImportOption.{ ATOMIC_MOVE, COPY, ImportOption, MOVE }
 
 /**
  * @param draftBag    the bag that receives the staged files as payload
@@ -46,13 +47,12 @@ case class StagedFilesTarget(draftBag: DansBag, destination: Path) extends Debug
         _ <- if (isPayload) draftBag.removePayloadFile(bagRelativePath)
              else if (isFetchItem) draftBag.removeFetchItem(bagRelativePath)
              else Success(draftBag.save())
-        _ <- draftBag.addPayloadFile(file, bagRelativePath)
+        _ <- draftBag.addPayloadFile(file, bagRelativePath)(ATOMIC_MOVE)
       } yield ()
     }
 
     stagingDir
-      .walk()
-      .filter(!_.isDirectory)
+      .list
       .map(moveToDraft)
       .find(_.isFailure)
       .getOrElse(draftBag.save)

--- a/src/test/scala/nl.knaw.dans.easy.deposit/DataFilesSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/DataFilesSpec.scala
@@ -100,10 +100,10 @@ class DataFilesSpec extends TestSupportFixture {
   "fileInfoSeq" should "return the proper number of files" in {
     val bag = DansV0Bag
       .empty(testDir / "testBag").getOrRecover(fail("could not create test bag", _))
-      .addPayloadFile(randomContent)(_ / "1.txt").getOrRecover(payloadFailure)
-      .addPayloadFile(randomContent)(_ / "folder1/2.txt").getOrRecover(payloadFailure)
-      .addPayloadFile(randomContent)(_ / "folder1/3.txt").getOrRecover(payloadFailure)
-      .addPayloadFile(randomContent)(_ / "folder2/4.txt").getOrRecover(payloadFailure)
+      .addPayloadFile(randomContent, Paths.get("1.txt")).getOrRecover(payloadFailure)
+      .addPayloadFile(randomContent, Paths.get("folder1/2.txt")).getOrRecover(payloadFailure)
+      .addPayloadFile(randomContent, Paths.get("folder1/3.txt")).getOrRecover(payloadFailure)
+      .addPayloadFile(randomContent, Paths.get("folder2/4.txt")).getOrRecover(payloadFailure)
     bag.save()
     val dataFiles = DataFiles(bag)
     val path2 = Paths.get("folder2")
@@ -122,14 +122,14 @@ class DataFilesSpec extends TestSupportFixture {
   "fileInfo" should "return proper information about the file" in {
     val bag = DansV0Bag
       .empty(testDir / "testBag").getOrRecover(fail("could not create test bag", _))
-      .addPayloadFile(randomContent)(_ / "1.txt").getOrRecover(payloadFailure)
-      .addPayloadFile(randomContent)(_ / "folder1/2.txt").getOrRecover(payloadFailure)
+      .addPayloadFile(randomContent, Paths.get("1.txt")).getOrRecover(payloadFailure)
+      .addPayloadFile(randomContent, Paths.get("folder1/2.txt")).getOrRecover(payloadFailure)
     bag.save()
     val dataFiles = DataFiles(bag)
     val path = Paths.get("folder1/2.txt")
 
     dataFiles.get(path) should matchPattern {
-      case Success(FileInfo("2.txt", path, _)) =>
+      case Success(FileInfo("2.txt", `path`, _)) =>
     }
   }
 

--- a/src/test/scala/nl.knaw.dans.easy.deposit/SubmitterSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/SubmitterSpec.scala
@@ -15,6 +15,8 @@
  */
 package nl.knaw.dans.easy.deposit
 
+import java.nio.file.Paths
+
 import nl.knaw.dans.easy.deposit.docs.StateInfo.State
 import nl.knaw.dans.easy.deposit.docs.{ DatasetMetadata, StateInfo }
 import nl.knaw.dans.lib.error._
@@ -41,8 +43,8 @@ class SubmitterSpec extends TestSupportFixture with MockFactory {
     val bag = getBag(depositDir)
     val bagDir = bag.baseDir
     (bagDir.parent / "deposit.properties").append(s"identifier.doi=$doi")
-    bag.addPayloadFile("".asInputStream)(_ / "text.txt")
-    bag.addPayloadFile("Lorum ipsum".asInputStream)(_ / "folder/text.txt")
+    bag.addPayloadFile("".asInputStream, Paths.get("text.txt"))
+    bag.addPayloadFile("Lorum ipsum".asInputStream, Paths.get("folder/text.txt"))
     bag.save()
     (testDir / "submitted").createDirectories()
 
@@ -95,7 +97,7 @@ class SubmitterSpec extends TestSupportFixture with MockFactory {
     val depositDir = createDeposit(datasetMetadata)
     val bag = getBag(depositDir)
     (bag.baseDir.parent / "deposit.properties").append(s"identifier.doi=$doi")
-    bag.addPayloadFile("lorum ipsum".asInputStream)(_ / "file.txt")
+    bag.addPayloadFile("lorum ipsum".asInputStream, Paths.get("file.txt"))
     bag.save()
     (testDir / "submitted").createDirectories()
 
@@ -112,7 +114,7 @@ class SubmitterSpec extends TestSupportFixture with MockFactory {
     val depositDir = createDeposit(datasetMetadata)
     val bag = getBag(depositDir)
     (bag.baseDir.parent / "deposit.properties").append(s"identifier.doi=$doi")
-    bag.addPayloadFile("lorum ipsum".asInputStream)(_ / "file.txt")
+    bag.addPayloadFile("lorum ipsum".asInputStream, Paths.get("file.txt"))
     bag.save()
     (testDir / "submitted").createDirectories()
 


### PR DESCRIPTION
Fixes EASY-1744

#### When applied it will
* move unzipped files to draft bag, not copy (again) from unzip-staging
* 
* 

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### Related pull requests on github
repo                       | PR                | note
-------------------------- | ----------------- | ----
easy-                      | [PR#](PRlink)     | ..
