### PR TITLE
Easy 1781

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.deposit/DepositDir.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/DepositDir.scala
@@ -276,6 +276,7 @@ object DepositDir {
       addProperty("curation.required", "yes")
       addProperty("curation.performed", "no")
       addProperty("bag-store.bag-id", depositInfo.id)
+      addProperty("identifier.doi.registered", "no")
     }.save(depositDir.depositPropertiesFile.toJava)
   }
 }

--- a/src/test/scala/nl.knaw.dans.easy.deposit/DepositDirSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/DepositDirSpec.scala
@@ -140,7 +140,8 @@ class DepositDirSpec extends TestSupportFixture with MockFactory {
 
     // preconditions
     mdFile.contentAsString shouldBe "{}"
-    oldDepositProperties should not include "identifier.doi"
+    oldDepositProperties should include("identifier.doi.registered = no")
+    oldDepositProperties should not include "identifier.doi = "
     val pidMocker = mock[PidRequester]
     (pidMocker.requestPid(_: PidType)) expects * once() returning Success(doi)
 

--- a/src/test/scala/nl.knaw.dans.easy.deposit/DepositDirSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/DepositDirSpec.scala
@@ -142,7 +142,6 @@ class DepositDirSpec extends TestSupportFixture with MockFactory {
     mdFile.contentAsString shouldBe "{}"
     oldDepositProperties should include("identifier.doi.registered = no")
     oldDepositProperties should not include "identifier.doi = "
-
     val pidMocker = mock[PidRequester]
     (pidMocker.requestPid(_: PidType)) expects * once() returning Success(doi)
 

--- a/src/test/scala/nl.knaw.dans.easy.deposit/DepositDirSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/DepositDirSpec.scala
@@ -142,6 +142,7 @@ class DepositDirSpec extends TestSupportFixture with MockFactory {
     mdFile.contentAsString shouldBe "{}"
     oldDepositProperties should include("identifier.doi.registered = no")
     oldDepositProperties should not include "identifier.doi = "
+
     val pidMocker = mock[PidRequester]
     (pidMocker.requestPid(_: PidType)) expects * once() returning Success(doi)
 


### PR DESCRIPTION
Fixes EASY-1781

#### When applied it will
* add the line identifier.doi.registered=no in the deposit.properties file of new deposits

#### Where should the reviewer @DANS-KNAW/easy start?

DepositDir class

#### How should this be manually tested?

create new deposit and verify that the field is added to the properties file

