### PR TITLE
EASY-1658 check DOI at PUT of DatasetMetadata, not just at submit

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.deposit/DepositDir.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/DepositDir.scala
@@ -203,8 +203,7 @@ case class DepositDir private(baseDir: File, user: String, id: UUID) extends Deb
   private def doisMatch(dm: DatasetMetadata, doi: Option[String]) = {
     if (doi == dm.doi) Success(())
     else {
-      val e = new Exception(s"DOI in datasetmetadata.json [${ dm.doi }] does not equal DOI in deposit.properties [$doi]")
-      Failure(CorruptDepositException(user, id.toString, e))
+      Failure(BadDoiException(dm, doi))
     }
   }
 }

--- a/src/main/scala/nl.knaw.dans.easy.deposit/EasyDepositApiApp.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/EasyDepositApiApp.scala
@@ -174,6 +174,16 @@ class EasyDepositApiApp(configuration: Configuration) extends DebugEnhancedLoggi
   } yield doi
 
   /**
+   * @param user the user ID
+   * @param id   the deposit ID
+   * @return Failure(BadDoiException) if the DOI in the DatasetMetadata does not equal the DOI in the dataset properties (both may be absent)
+   */
+  def checkDoi(user: String, id: UUID, dm: DatasetMetadata): Try[Unit] = for {
+    deposit <- getDeposit(user, id)
+    _ <- deposit.sameDOIs(dm)
+  } yield ()
+
+  /**
    * Returns the dataset metadata from `dataset.xml`.
    *
    * @param user the user ID

--- a/src/main/scala/nl.knaw.dans.easy.deposit/package.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/package.scala
@@ -21,6 +21,8 @@ import java.nio.file.{ Path, Paths }
 import java.util.UUID
 
 import nl.knaw.dans.bag.v0.DansV0Bag
+import nl.knaw.dans.easy.deposit.docs.DatasetMetadata
+import nl.knaw.dans.easy.deposit.docs.JsonUtil.InvalidDocumentException
 import nl.knaw.dans.easy.deposit.docs.StateInfo.State.State
 
 import scala.util.Try
@@ -35,6 +37,9 @@ package object deposit {
 
   case class CorruptDepositException(user: String, id: String, cause: Throwable)
     extends DepositException(s"Invalid deposit uuid $id for user $user: ${ cause.getMessage }", cause)
+
+  case class BadDoiException(md: DatasetMetadata, propsDOI: Option[String])
+    extends InvalidDocumentException(s"DOI in datasetmetadata.json [${ md.doi }] does not equal DOI in deposit.properties [$propsDOI]")
 
   case class IllegalStateTransitionException(user: String, id: UUID, oldState: State, newState: State)
     extends DepositException(s"Cannot transition from $oldState to $newState (deposit id: $id, user: $user)", null)

--- a/src/main/scala/nl.knaw.dans.easy.deposit/servlets/DepositServlet.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/servlets/DepositServlet.scala
@@ -90,6 +90,7 @@ class DepositServlet(app: EasyDepositApiApp)
       uuid <- getUUID
       managedIS <- getRequestBodyAsManagedInputStream
       datasetMetadata <- managedIS.apply(is => DatasetMetadata(is))
+      _ <- app.checkDoi(user.id, uuid, datasetMetadata)
       _ <- app.writeDataMetadataToDeposit(datasetMetadata, user.id, uuid)
     } yield NoContent()
       ).getOrRecoverResponse(respond)

--- a/src/test/scala/nl.knaw.dans.easy.deposit/SubmitterSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/SubmitterSpec.scala
@@ -140,7 +140,7 @@ class SubmitterSpec extends TestSupportFixture with MockFactory {
 
     assumeSchemaAvailable
     new Submitter(testDir / "staged", testDir / "submitted").submit(depositDir) should matchPattern {
-      case Failure(e: CorruptDepositException) if e.getMessage.endsWith(
+      case Failure(e: BadDoiException) if e.getMessage.endsWith(
         s"DOI in datasetmetadata.json [${ datasetMetadata.doi }] does not equal DOI in deposit.properties [None]"
       ) =>
     }

--- a/src/test/scala/nl.knaw.dans.easy.deposit/servlets/DepositServletErrorSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/servlets/DepositServletErrorSpec.scala
@@ -21,14 +21,13 @@ import nl.knaw.dans.easy.deposit._
 import nl.knaw.dans.easy.deposit.authentication.AuthUser.UserState
 import nl.knaw.dans.easy.deposit.authentication.AuthenticationMocker._
 import nl.knaw.dans.easy.deposit.authentication.{ AuthUser, AuthenticationProvider }
-import nl.knaw.dans.easy.deposit.docs.{ DatasetMetadata, DepositInfo }
-import nl.knaw.dans.lib.error._
+import nl.knaw.dans.easy.deposit.docs.DatasetMetadata
 import org.eclipse.jetty.http.HttpStatus._
 import org.scalamock.scalatest.MockFactory
 import org.scalatra.auth.Scentry
 import org.scalatra.test.scalatest.ScalatraSuite
 
-import scala.util.{ Failure, Try }
+import scala.util.Failure
 
 class DepositServletErrorSpec extends TestSupportFixture with ServletFixture with ScalatraSuite with MockFactory {
 
@@ -72,7 +71,7 @@ class DepositServletErrorSpec extends TestSupportFixture with ServletFixture wit
   s"put /:uuid/metadata" should "report a lost dataset" in {
     assumeSchemaAvailable
     expectsUserFooBar
-    (mockedApp.writeDataMetadataToDeposit(_: DatasetMetadata, _: String, _: UUID)) expects(*, "foo", uuid) returning
+    (mockedApp.checkDoi(_: String, _: UUID, _: DatasetMetadata)) expects("foo", uuid, *) returning
       Failure(NoSuchDepositException("foo", uuid, new Exception()))
 
     put(


### PR DESCRIPTION
Fixes EASY-1658 check DOI at PUT of DatasetMetadata, not just at submit

#### When applied it will
* 
* 
* 

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

* [ ] See `src/test/resources/manual-test/readme.md`

#### Related pull requests on github
repo                       | PR                | note
-------------------------- | ----------------- | ----
easy-                      | [PR#](PRlink)     | ..
