### PR TITLE
part of EASY-1794 : no camel case for FileInfo fields

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.deposit/package.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/package.scala
@@ -46,11 +46,11 @@ package object deposit {
   /**
    * Information about a file in the deposit
    *
-   * @param fileName the simple filename of the file
-   * @param dirPath  path of the containing directory, relative to the content base directory
+   * @param filename the simple filename of the file
+   * @param dirpath  path of the containing directory, relative to the content base directory
    * @param sha1sum  the SHA-1 checksum of the file data
    */
-  case class FileInfo(fileName: String, dirPath: Path, sha1sum: String)
+  case class FileInfo(filename: String, dirpath: Path, sha1sum: String)
 
   val prologue = """<?xml version='1.0' encoding='UTF-8'?>"""
 

--- a/src/test/scala/nl.knaw.dans.easy.deposit/docs/JsonUtilSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/docs/JsonUtilSpec.scala
@@ -37,7 +37,7 @@ class JsonUtilSpec extends TestSupportFixture {
       typeOf[DepositInfo],
       typeOf[StateInfo],
       typeOf[UserInfo],
-      typeOf[FileInfo]
+      typeOf[FileInfo],
     )
     val definedEnumerations = types.flatMap(_.companion.decls
       .filter(_.typeSignature <:< typeOf[Enumeration])

--- a/src/test/scala/nl.knaw.dans.easy.deposit/docs/JsonUtilSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/docs/JsonUtilSpec.scala
@@ -15,7 +15,10 @@
  */
 package nl.knaw.dans.easy.deposit.docs
 
-import nl.knaw.dans.easy.deposit.TestSupportFixture
+import java.nio.file.Paths
+
+import nl.knaw.dans.easy.deposit.docs.JsonUtil._
+import nl.knaw.dans.easy.deposit.{ FileInfo, TestSupportFixture }
 
 import scala.reflect.runtime.universe.typeOf
 
@@ -24,7 +27,7 @@ class JsonUtilSpec extends TestSupportFixture {
   "enum values" should "be unique across all defined enums" in {
     // see https://github.com/json4s/json4s/issues/142
 
-    val values = JsonUtil.enumerations.flatMap(_.values.map(_.toString))
+    val values = enumerations.flatMap(_.values.map(_.toString))
     values shouldBe values.distinct
   }
 
@@ -33,15 +36,21 @@ class JsonUtilSpec extends TestSupportFixture {
       typeOf[DatasetMetadata],
       typeOf[DepositInfo],
       typeOf[StateInfo],
-      typeOf[UserInfo]
+      typeOf[UserInfo],
+      typeOf[FileInfo]
     )
     val definedEnumerations = types.flatMap(_.companion.decls
       .filter(_.typeSignature <:< typeOf[Enumeration])
       .map(_.name.toString))
 
-    val registeredEnumerations = JsonUtil.enumerations
+    val registeredEnumerations = enumerations
       .map(_.getClass.getSimpleName.stripSuffix("$"))
 
     registeredEnumerations should contain allElementsOf definedEnumerations
+  }
+
+  "FileInfo" should "serialize with lower case, not camel case" in {
+    val fileInfo = FileInfo("test.txt", Paths.get("a/b"), "abc123")
+    toJson(fileInfo) shouldBe """{"filename":"test.txt","dirpath":"a/b","sha1sum":"abc123"}"""
   }
 }

--- a/src/test/scala/nl.knaw.dans.easy.deposit/servlets/HappyRoutesSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/servlets/HappyRoutesSpec.scala
@@ -155,7 +155,7 @@ class HappyRoutesSpec extends TestSupportFixture with ServletFixture with Scalat
       uri = s"/deposit/$uuid/file/path/to/directory",
       headers = Seq(("Authorization", fooBarBasicAuthHeader))
     ) {
-      body shouldBe s"""[{"fileName":"a.txt","dirPath":"files/a.txt","sha1sum":"x"}]"""
+      body shouldBe s"""[{"filename":"a.txt","dirpath":"files/a.txt","sha1sum":"x"}]"""
       status shouldBe OK_200
     }
   }
@@ -169,7 +169,7 @@ class HappyRoutesSpec extends TestSupportFixture with ServletFixture with Scalat
       uri = s"/deposit/$uuid/file/a.txt",
       headers = Seq(("Authorization", fooBarBasicAuthHeader))
     ) {
-      body shouldBe s"""{"fileName":"a.txt","dirPath":"files/a.txt","sha1sum":"x"}"""
+      body shouldBe s"""{"filename":"a.txt","dirpath":"files/a.txt","sha1sum":"x"}"""
       status shouldBe OK_200
     }
   }

--- a/src/test/scala/nl.knaw.dans.easy.deposit/servlets/IntegrationSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/servlets/IntegrationSpec.scala
@@ -152,7 +152,7 @@ class IntegrationSpec extends TestSupportFixture with ServletFixture with Scalat
       (dataFilesBase / "path" / "to" / "text.txt").contentAsString shouldBe "Lorum ipsum"
     }
 
-    val expectedItem = """{"fileName":"text.txt","dirPath":"path/to/text.txt","sha1sum":"c5b8de8cc3587aef4e118a481115391033621e06"}"""
+    val expectedItem = """{"filename":"text.txt","dirpath":"path/to/text.txt","sha1sum":"c5b8de8cc3587aef4e118a481115391033621e06"}"""
     val expectedListItem = expectedItem.replace("/text.txt", "")
 
     // get file


### PR DESCRIPTION
Fixes a part of EASY-1794

#### When applied it will
* no longer have camel case fields for FileInfo
* 
* 

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### Related pull requests on github
repo                       | PR                | note
-------------------------- | ----------------- | ----
easy-                      | [PR#](PRlink)     | ..
