### PR TITLE
ISSUE-1815 FileInfo should not have file name in path

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.deposit/DataFiles.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/DataFiles.scala
@@ -59,6 +59,10 @@ case class DataFiles(bag: DansBag) extends DebugEnhancedLogging {
     val parentPath = bag.data / path.toString
     val manifestMap = bag.payloadManifests
 
+    def toFileInfo(file: File, checksum: String): FileInfo = {
+      FileInfo(file.name, bag.data.relativize(file.parent), checksum)
+    }
+
     def convert(items: Map[File, String]) = {
       items
         .withFilter(_._1.isChildOf(parentPath))
@@ -86,15 +90,11 @@ case class DataFiles(bag: DansBag) extends DebugEnhancedLogging {
     val fileExists = manifests.get.contains(absolutePath)
     if (fileExists) {
       val checksum = manifests get absolutePath
-      Success(FileInfo(path.getFileName.toString, bag.data.relativize(absolutePath), checksum))
+      Success(FileInfo(path.getFileName.toString, bag.data.relativize(absolutePath.parent), checksum))
     }
     else {
       Failure(new NoSuchFileException(s"${ path.toString }"))
     }
-  }
-
-  private def toFileInfo(file: File, checksum: String): FileInfo = {
-    FileInfo(file.name, bag.data.relativize(file.parent), checksum)
   }
 
   /**

--- a/src/test/scala/nl.knaw.dans.easy.deposit/DataFilesSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/DataFilesSpec.scala
@@ -108,10 +108,8 @@ class DataFilesSpec extends TestSupportFixture {
       .addPayloadFile(randomContent, Paths.get("folder2/4.txt")).getOrRecover(payloadFailure)
     bag.save()
     val dataFiles = DataFiles(bag)
-    val path2 = Paths.get("folder2")
-
-    dataFiles.list(path2) should matchPattern {
-      case Success(Seq(FileInfo("4.txt", p, _))) if p == path2 => // no order problem as the next cases would have
+    dataFiles.list(Paths.get("folder2")) should matchPattern {
+      case Success(Seq(_))=>
     }
     dataFiles.list(Paths.get("folder1")) should matchPattern {
       case Success(Seq(_, _)) =>
@@ -121,17 +119,29 @@ class DataFilesSpec extends TestSupportFixture {
     }
   }
 
-  "fileInfo" should "return proper information about the file" in {
+  "fileInfo" should "contain proper information about the files" in {
+    val sha1 = "a57ec0c3239f30b29f1e9270581be50a70c74c04"
+    val sha2 = "815bc8056fe15e00f24514051f1d06016852360c"
     val bag = DansV0Bag
       .empty(testDir / "testBag").getOrRecover(fail("could not create test bag", _))
-      .addPayloadFile(randomContent, Paths.get("1.txt")).getOrRecover(payloadFailure)
-      .addPayloadFile(randomContent, Paths.get("folder1/2.txt")).getOrRecover(payloadFailure)
+      .addPayloadFile("lorum ipsum".inputStream, Paths.get("some/1.txt")).getOrRecover(payloadFailure)
+      .addPayloadFile("doler it".inputStream, Paths.get("some/folder/2.txt")).getOrRecover(payloadFailure)
     bag.save()
     val dataFiles = DataFiles(bag)
-    val path = Paths.get("folder1/2.txt")
-
-    dataFiles.get(path) should matchPattern {
-      case Success(FileInfo("2.txt", `path`, _)) =>
+    inside (dataFiles.list()) {
+      case Success(infos: Seq[_]) => infos should contain theSameElementsAs Seq(
+        FileInfo("1.txt",Paths.get("some/"),sha1),
+        FileInfo("2.txt",Paths.get("some/folder"),sha2),
+      )
+    }
+    dataFiles.get(Paths.get("some/folder/2.txt")) should matchPattern {
+      case Success(FileInfo("2.txt", p, _)) if p.toString == "some/folder"=>
+    }
+    inside (dataFiles.list(Paths.get("some"))) {
+      case Success(infos: Seq[_]) => infos should contain theSameElementsAs Seq(
+        FileInfo("1.txt",Paths.get(""),sha1),
+        FileInfo("2.txt",Paths.get("folder"),sha2),
+      )
     }
   }
 

--- a/src/test/scala/nl.knaw.dans.easy.deposit/logging/Mocker.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/logging/Mocker.scala
@@ -28,7 +28,7 @@ object Mocker extends MockFactory {
     headers.foreach { case (key: String, values: Seq[String]) =>
       response.getHeaders _ expects key anyNumberOfTimes() returning values.asJava
     }
-    response.getHeaderNames _ expects() anyNumberOfTimes() returning headers.keys.toSeq.asJava
+    (() => response.getHeaderNames) expects() anyNumberOfTimes() returning headers.keys.toSeq.asJava
     response
   }
 
@@ -38,7 +38,7 @@ object Mocker extends MockFactory {
     headers.foreach { case (key: String, values: Seq[String]) =>
       request.getHeaders _ expects key anyNumberOfTimes() returning values.iterator.asJavaEnumeration
     }
-    request.getHeaderNames _ expects() anyNumberOfTimes() returning headers.keys.iterator.asJavaEnumeration
+    (() => request.getHeaderNames) expects() anyNumberOfTimes() returning headers.keys.iterator.asJavaEnumeration
     request
   }
 }

--- a/src/test/scala/nl.knaw.dans.easy.deposit/logging/RequestLogFormatterSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/logging/RequestLogFormatterSpec.scala
@@ -114,11 +114,11 @@ class RequestLogFormatterSpec extends TestSupportFixture with MockFactory {
       "HTTP_AUTHORIZATION" -> Seq("basic 123x_"),
       "foo" -> Seq("bar")
     ))
-    request.getMethod _ expects() anyNumberOfTimes() returning
+    (() => request.getMethod) expects() anyNumberOfTimes() returning
       "GET"
-    request.getRequestURL _ expects() anyNumberOfTimes() returning
+    (() => request.getRequestURL) expects() anyNumberOfTimes() returning
       new StringBuffer("http://does.not.exist.dans.knaw.nl")
-    request.getRemoteAddr _ expects() anyNumberOfTimes() returning
+    (() => request.getRemoteAddr) expects() anyNumberOfTimes() returning
       "12.34.56.78"
     request
   }

--- a/src/test/scala/nl.knaw.dans.easy.deposit/logging/ResponseLogFormatterSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/logging/ResponseLogFormatterSpec.scala
@@ -56,7 +56,7 @@ class ResponseLogFormatterSpec extends TestSupportFixture with MockFactory {
 
   private def mockRequest = {
     val req = mock[HttpServletRequest]
-    req.getMethod _ expects() returning "GET" anyNumberOfTimes()
+    (() => req.getMethod) expects() returning "GET" anyNumberOfTimes()
     req
   }
 }

--- a/src/test/scala/nl.knaw.dans.easy.deposit/servlets/HappyRoutesSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/servlets/HappyRoutesSpec.scala
@@ -149,13 +149,13 @@ class HappyRoutesSpec extends TestSupportFixture with ServletFixture with Scalat
   s"get /deposit/:uuid/file/path/to/directory" should "return a list with one FileInfo object in json format" in {
     authMocker.expectsUserFooBar
     (mockedApp.getFileInfo(_: String, _: UUID, _: Path)) expects("foo", uuid, *) returning
-      Success(Seq(FileInfo("a.txt", Paths.get("files/a.txt"), "x")))
+      Success(Seq(FileInfo("a.txt", Paths.get("files"), "x")))
 
     get(
       uri = s"/deposit/$uuid/file/path/to/directory",
       headers = Seq(("Authorization", fooBarBasicAuthHeader))
     ) {
-      body shouldBe s"""[{"filename":"a.txt","dirpath":"files/a.txt","sha1sum":"x"}]"""
+      body shouldBe s"""[{"filename":"a.txt","dirpath":"files","sha1sum":"x"}]"""
       status shouldBe OK_200
     }
   }
@@ -163,13 +163,13 @@ class HappyRoutesSpec extends TestSupportFixture with ServletFixture with Scalat
   s"get /deposit/:uuid/file/a.txt" should "return a FileInfo object in json format" in {
     authMocker.expectsUserFooBar
     (mockedApp.getFileInfo(_: String, _: UUID, _: Path)) expects("foo", uuid, *) returning
-      Success(FileInfo("a.txt", Paths.get("files/a.txt"), "x"))
+      Success(FileInfo("a.txt", Paths.get("files"), "x"))
 
     get(
       uri = s"/deposit/$uuid/file/a.txt",
       headers = Seq(("Authorization", fooBarBasicAuthHeader))
     ) {
-      body shouldBe s"""{"filename":"a.txt","dirpath":"files/a.txt","sha1sum":"x"}"""
+      body shouldBe s"""{"filename":"a.txt","dirpath":"files","sha1sum":"x"}"""
       status shouldBe OK_200
     }
   }

--- a/src/test/scala/nl.knaw.dans.easy.deposit/servlets/RichFileItemsSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/servlets/RichFileItemsSpec.scala
@@ -67,7 +67,8 @@ class RichFileItemsSpec extends TestSupportFixture with MockFactory {
       "application/x-zip",
       "application/x-gzip",
     ).map(mockFileItem(s"some.thing", _))
-    fileItems.map { Iterator(_)
+    fileItems.map {
+      Iterator(_)
         .buffered
         .nextAsZipIfOnlyOne
         .map(_.isDefined)
@@ -119,12 +120,12 @@ class RichFileItemsSpec extends TestSupportFixture with MockFactory {
 
   private def mockFileItem(fileName: String, contentType: String = null) = {
     val mocked = mock[Part]
-    mocked.getSize _ expects() returning 20 anyNumberOfTimes()
-    mocked.getName _ expects() returning "formFieldName" anyNumberOfTimes()
+    (() => mocked.getSize) expects() returning 20 anyNumberOfTimes()
+    (() => mocked.getName) expects() returning "formFieldName" anyNumberOfTimes()
     mocked.getHeader _ expects "content-disposition" returning "filename=" + fileName anyNumberOfTimes()
     mocked.getHeader _ expects "content-type" returning contentType anyNumberOfTimes()
-    mocked.getContentType _ expects() returning contentType anyNumberOfTimes()
-    mocked.getInputStream _ expects() returning new ByteArrayInputStream("Lorem ipsum est".getBytes(StandardCharsets.UTF_8)) anyNumberOfTimes()
+    (() => mocked.getContentType) expects() returning contentType anyNumberOfTimes()
+    (() => mocked.getInputStream) expects() returning new ByteArrayInputStream("Lorem ipsum est".getBytes(StandardCharsets.UTF_8)) anyNumberOfTimes()
     FileItem(mocked)
   }
 }


### PR DESCRIPTION
Fixes part of ISSUE-1815 FileInfo should not have file name in path

#### When applied it will
* 
* 
* 

#### Where should the reviewer @DANS-KNAW/easy start?

`DataFilesSpec.fileInfo`

#### How should this be manually tested?

#### Related pull requests on github
repo                       | PR                | note
-------------------------- | ----------------- | ----
easy-                      | [PR#](PRlink)     | ..
