### PR TITLE
EASY-1762 new deposit property

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.deposit/DepositDir.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/DepositDir.scala
@@ -274,6 +274,7 @@ object DepositDir {
       addProperty("curation.performed", "no")
       addProperty("bag-store.bag-id", depositInfo.id)
       addProperty("identifier.doi.registered", "no")
+      addProperty("identifier.dans-doi.action", "create")
     }.save(depositDir.depositPropertiesFile.toJava)
   }
 }

--- a/src/main/scala/nl.knaw.dans.easy.deposit/DepositDir.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/DepositDir.scala
@@ -273,7 +273,7 @@ object DepositDir {
       addProperty("curation.required", "yes")
       addProperty("curation.performed", "no")
       addProperty("bag-store.bag-id", depositInfo.id)
-      addProperty("identifier.doi.registered", "no")
+      addProperty("identifier.dans-doi.registered", "no")
       addProperty("identifier.dans-doi.action", "create")
     }.save(depositDir.depositPropertiesFile.toJava)
   }

--- a/src/test/scala/nl.knaw.dans.easy.deposit/DepositDirSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/DepositDirSpec.scala
@@ -73,7 +73,8 @@ class DepositDirSpec extends TestSupportFixture with MockFactory {
           "identifier.doi.registered" -> "no",
           "creation.timestamp" -> "2018-03-22T20:43:01.000Z",
           "bag-store.bag-id" -> d.id.toString,
-          "state.description" -> "Deposit is open for changes."
+          "state.description" -> "Deposit is open for changes.",
+          "identifier.dans-doi.action" -> "create",
         )
     }
   }

--- a/src/test/scala/nl.knaw.dans.easy.deposit/DepositDirSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/DepositDirSpec.scala
@@ -70,7 +70,7 @@ class DepositDirSpec extends TestSupportFixture with MockFactory {
           "depositor.userId" -> "user001",
           "curation.performed" -> "no",
           "curation.required" -> "yes",
-          "identifier.doi.registered" -> "no",
+          "identifier.dans-doi.registered" -> "no",
           "creation.timestamp" -> "2018-03-22T20:43:01.000Z",
           "bag-store.bag-id" -> d.id.toString,
           "state.description" -> "Deposit is open for changes.",


### PR DESCRIPTION
Fixes EASY-1762

#### When applied it will
* create deposits with property `identifier.dans-doi.action = create`
* 
* 

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

Create a deposit, examine the properties. Details:
https://github.com/DANS-KNAW/easy-deposit-api/blob/master/src/test/resources/manual-test/readme.md

#### Related pull requests on github
https://github.com/DANS-KNAW/easy-ingest-flow/pull/87 should not be deployed before this one
