### PR TITLE
EASY-1829 & EASY-1794 :  explicit content type & upload response codes

### DIFF
--- a/docs/api/api.yml
+++ b/docs/api/api.yml
@@ -507,12 +507,6 @@ paths:
               type: string
               format: binary
       responses:
-        200:
-          description: Updated existing file.
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/FileInfo"
         201:
           description: Created new file.
           headers:
@@ -524,6 +518,8 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/FileInfo"
+        204:
+          description: Updated existing file.
         400:
           $ref: "#/components/responses/ZipFileNotAllowed"
         401:

--- a/src/main/scala/nl.knaw.dans.easy.deposit/servlets/package.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/servlets/package.scala
@@ -37,14 +37,17 @@ package object servlets extends DebugEnhancedLogging {
   private val post = "-compress(ed)?"
   private val contentTypeZipPattern = s"application/(($pre($post)?)|(x$post))"
 
+  val contentTypeJson: (String, String) = "content-type" -> "application/json;charset=UTF-8"
+  val contentTypePlainText: (String, String) = "content-type" -> "text/plain;charset=UTF-8"
+
   def notExpectedExceptionResponse(t: Throwable): ActionResult = {
     logger.error(s"Not expected exception: ${ t.getMessage }", t)
-    InternalServerError("Internal Server Error")
+    InternalServerError("Internal Server Error", Map(contentTypePlainText))
   }
 
   def badDocResponse(t: Throwable): ActionResult = {
     logger.error(t.getMessage)
-    BadRequest(s"Bad Request. ${ t.getMessage }")
+    BadRequest(s"Bad Request. ${ t.getMessage }", Map(contentTypePlainText))
   }
 
   implicit class RichManagedZipInputStream(val zipInputStream: ManagedResource[ZipInputStream]) extends AnyVal {

--- a/src/test/scala/nl.knaw.dans.easy.deposit/servlets/UploadSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/servlets/UploadSpec.scala
@@ -294,7 +294,6 @@ class UploadSpec extends DepositServletFixture {
     }
   }
 
-
   s"PUT" should "return 201 for a new respectively 204 for a replaced file" in {
     val uuid = createDeposit
 

--- a/src/test/scala/nl.knaw.dans.easy.deposit/servlets/UploadSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/servlets/UploadSpec.scala
@@ -218,7 +218,7 @@ class UploadSpec extends DepositServletFixture {
       files = Seq(("formFieldName", (testDir / "input/1.zip").toJava))
     ) {
       body shouldBe ""
-      status shouldBe OK_200
+      status shouldBe CREATED_201
       absoluteTarget.walk().map(_.name).toList should contain theSameElementsAs List(
         "data", "login.html", "readme.md", "__MACOSX", "._login.html", "upload.html"
       )

--- a/src/test/scala/nl.knaw.dans.easy.deposit/servlets/UploadSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/servlets/UploadSpec.scala
@@ -49,7 +49,7 @@ class UploadSpec extends DepositServletFixture {
       files = bodyParts
     ) {
       body shouldBe ""
-      status shouldBe OK_200
+      status shouldBe CREATED_201
       val bagDir = testDir / "drafts/foo" / uuid.toString / "bag"
       val uploaded = (bagDir / "data" / relativeTarget).list
       uploaded.size shouldBe bodyParts.size
@@ -181,7 +181,7 @@ class UploadSpec extends DepositServletFixture {
       files = Seq(("formFieldName", (testDir / "input/1.zip").toJava))
     ) {
       body shouldBe ""
-      status shouldBe OK_200
+      status shouldBe CREATED_201
       absoluteTarget.walk().map(_.name).toList should contain theSameElementsAs List(
         "dir", "login.html", "readme.md", "__MACOSX", "._login.html", "upload.html"
       )
@@ -246,7 +246,7 @@ class UploadSpec extends DepositServletFixture {
     }
   }
 
-  s"PUT" should "return 201 for a new respectively 200 for a replaced file" in {
+  s"PUT" should "return 201 for a new respectively 204 for a replaced file" in {
     val uuid = createDeposit
 
     val bagBase = DepositDir(testDir / "drafts", "foo", UUID.fromString(uuid.toString)).getDataFiles.get.bag
@@ -270,7 +270,7 @@ class UploadSpec extends DepositServletFixture {
       headers = Seq(fooBarBasicAuthHeader),
       body = shortContent
     ) {
-      status shouldBe OK_200
+      status shouldBe NO_CONTENT_204
       (bagBase / "data/path/to/text.txt").contentAsString shouldBe shortContent
       (bagBase / "manifest-sha1.txt").contentAsString shouldBe "c5b8de8cc3587aef4e118a481115391033621e06  data/path/to/text.txt\n"
     }


### PR DESCRIPTION
Fixes
* EASY-1829 - explicit content type header when a response has a body
* EASY-1794 - #86 did not include the original objective of the issue:
  When uploading/deleting files, do not return a file listing

#### When applied it will
* have changes in the swagger documentation: OK -> no-content (when updating an existing file)
* 
* 

#### Where should the reviewer @DANS-KNAW/easy start?

Is the following description adequate for upload of multiple files via either a zip or multiple body parts?
https://github.com/DANS-KNAW/easy-deposit-api/blob/b962a26bdac7b26b6f1def50cff8508f5c6d54e4/docs/api/api.yml#L425-L426

#### How should this be manually tested?

#### Related pull requests on github
repo                       | PR                | note
-------------------------- | ----------------- | ----
easy-                      | [PR#](PRlink)     | ..
