### PR TITLE
EASY-1554 PR #65 added a dir to application.properties but forgot debug-set-env

### DIFF
--- a/debug-init-env.sh
+++ b/debug-init-env.sh
@@ -20,5 +20,6 @@ TEMPDIR=data
 touch $TEMPDIR/easy-deposit-api.log
 mkdir $TEMPDIR/drafts
 mkdir $TEMPDIR/stage
+mkdir $TEMPDIR/stage-upload
 mkdir $TEMPDIR/easy-ingest-flow-inbox
 echo "OK"


### PR DESCRIPTION
post merge Fix of EASY-1554
#65 added a dir to application.properties but forgot debug-set-env

#### When applied it will
stumbled on it while debugging #94 (caused by #89, solved by #95)
found the solution when reviewing easy-bag-index PR-32


#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### Related pull requests on github
repo                       | PR                | note
-------------------------- | ----------------- | ----
easy-                      | [PR#](PRlink)     | ..
