### PR TITLE
EASY-1820 : increment version of agreements.xsd due to rename

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.deposit/docs/AgreementsXml.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/docs/AgreementsXml.scala
@@ -22,7 +22,7 @@ import scala.xml.Elem
 
 object AgreementsXml extends SchemedXml {
   override protected val schemaNameSpace = "http://easy.dans.knaw.nl/schemas/bag/metadata/agreements/"
-  override protected val schemaLocation = "https://easy.dans.knaw.nl/schemas/bag/metadata/agreements/2018/05/agreements.xsd"
+  override protected val schemaLocation = "https://easy.dans.knaw.nl/schemas/bag/metadata/agreements/2018/12/agreements.xsd"
 
   def apply(userId: String, dateSubmitted: DateTime, dm: DatasetMetadata): Try[Elem] = {
     for {
@@ -37,7 +37,7 @@ object AgreementsXml extends SchemedXml {
         <licenseAgreement>
           <depositorId>{userId}</depositorId>
           <dcterms:dateAccepted>{dateSubmitted}</dcterms:dateAccepted>
-          <licenseAgreementAccepted>{dm.acceptDepositAgreement}</licenseAgreementAccepted>
+          <depositAgreementAccepted>{dm.acceptDepositAgreement}</depositAgreementAccepted>
         </licenseAgreement>
         <personalDataStatement>
           <signerId>{userId}</signerId>

--- a/src/main/scala/nl.knaw.dans.easy.deposit/docs/AgreementsXml.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/docs/AgreementsXml.scala
@@ -34,11 +34,11 @@ object AgreementsXml extends SchemedXml {
           xmlns:dcterms="http://purl.org/dc/terms/"
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xsi:schemaLocation={s"$schemaNameSpace $schemaLocation"}>
-        <licenseAgreement>
+        <depositAgreement>
           <depositorId>{userId}</depositorId>
           <dcterms:dateAccepted>{dateSubmitted}</dcterms:dateAccepted>
           <depositAgreementAccepted>{dm.acceptDepositAgreement}</depositAgreementAccepted>
-        </licenseAgreement>
+        </depositAgreement>
         <personalDataStatement>
           <signerId>{userId}</signerId>
           <dateSigned>{dateSubmitted}</dateSigned>


### PR DESCRIPTION
Fixes EASY-1820 : increment agreements.xsd version (rename licenseAgreement -> depositAgreement)

#### When applied it will
* 
* 
* 

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### Related pull requests on github

deploy together with:
* https://github.com/DANS-KNAW/easy-specs/pull/63
* https://github.com/DANS-KNAW/easy-validate-dans-bag/pull/47
