### PR TITLE
EASY-1726 drop group-access from deposit-api

### DIFF
--- a/docs/api/api.yml
+++ b/docs/api/api.yml
@@ -872,12 +872,7 @@ components:
           type: string
           enum:
           - OPEN_ACCESS
-          - OPEN_ACCESS_FOR_REGISTERED_USERS
-          - GROUP_ACCESS
           - REQUEST_PERMISSION
-          - NO_ACCESS
-        group:
-          type: string
 
     Author:
       type: object

--- a/src/main/scala/nl.knaw.dans.easy.deposit/authentication/AuthUser.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/authentication/AuthUser.scala
@@ -23,7 +23,6 @@ import scala.util.{ Failure, Try }
 
 /** A user with minimal properties: just for identification and authorisation */
 case class AuthUser(id: String,
-                    groups: Seq[String] = Seq.empty,
                     state: UserState
                    )
 
@@ -46,16 +45,13 @@ object AuthUser {
       attributes.getOrElse("uid", Seq.empty)
         .headOption // mandatory: https://github.com/DANS-KNAW/dans.easy-ldap-dir/blob/f17c391/files/easy-schema.ldif#L83-L84
         .getOrElse(""),
-      attributes.getOrElse("easyGroups", Seq.empty),
       attributes.getOrElse("dansState", Seq.empty)
         .headOption.map(value => UserState.withName(value))
         .getOrElse(UserState.blocked)
     )
   }
 
-  private class ActiveAuthUser(id: String,
-                               groups: Seq[String] = Seq.empty
-                              ) extends AuthUser(id, groups, UserState.active)
+  private class ActiveAuthUser(id: String) extends AuthUser(id, UserState.active)
 
   private implicit val jsonFormats: Formats = new DefaultFormats {}
 

--- a/src/main/scala/nl.knaw.dans.easy.deposit/docs/UserInfo.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/docs/UserInfo.scala
@@ -24,7 +24,6 @@ case class UserInfo(userName: String,
                     firstName: Option[String] = None,
                     prefix: Option[String] = None,
                     lastName: String,
-                    groups: Option[Seq[String]] = None
                    )
 object UserInfo {
   def apply(input: JsonInput): Try[UserInfo] = input.deserialize[UserInfo]
@@ -42,8 +41,6 @@ object UserInfo {
       prefix = attributes.get("dansPrefixes").map(s => s.mkString(" ")),
 
       lastName = attributes.getOrElse("sn", Seq.empty).headOption.getOrElse(""),
-
-      groups = attributes.get("easyGroups")
     )
   }
 }

--- a/src/main/scala/nl.knaw.dans.easy.deposit/docs/dm/AccessCategory.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/docs/dm/AccessCategory.scala
@@ -20,11 +20,7 @@ import nl.knaw.dans.easy.deposit.docs.dm.AccessCategory.AccessCategory
 object AccessCategory extends Enumeration {
   type AccessCategory = Value
   val open: AccessCategory = Value("OPEN_ACCESS")
-  val openForRegisteredUsers: AccessCategory = Value("OPEN_ACCESS_FOR_REGISTERED_USERS")
-  val restrictedGroup: AccessCategory = Value("GROUP_ACCESS")
   val restrictedRequest: AccessCategory = Value("REQUEST_PERMISSION")
-  val otherAccess: AccessCategory = Value("NO_ACCESS")
-  // TODO drop some as in https://github.com/DANS-KNAW/easy-deposit-ui/pull/81
 }
 
 case class AccessRights(category: AccessCategory,

--- a/src/main/scala/nl.knaw.dans.easy.deposit/docs/dm/AccessCategory.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/docs/dm/AccessCategory.scala
@@ -23,6 +23,4 @@ object AccessCategory extends Enumeration {
   val restrictedRequest: AccessCategory = Value("REQUEST_PERMISSION")
 }
 
-case class AccessRights(category: AccessCategory,
-                        group: Option[String], // TODO fix unit tests to drop this too
-                       )
+case class AccessRights(category: AccessCategory)

--- a/src/test/resources/manual-test/datasetmetadata-from-ui-some.json
+++ b/src/test/resources/manual-test/datasetmetadata-from-ui-some.json
@@ -38,20 +38,19 @@
   "dates": [
     {
       "scheme": "dcterms:W3CDTF",
-      "value": "2018-03-19",
+      "value": "2018-03-19T01:00:00+01:00",
       "qualifier": "dcterms:created"
     },
     {
       "scheme": "dcterms:W3CDTF",
-      "value": "2018-05-14",
+      "value": "2018-05-14T01:00:00+02:00",
       "qualifier": "dcterms:available"
     }
   ],
   "accessRights": {
-    "category": "GROUP_ACCESS",
-    "group": "archaeology"
+    "category": "REQUEST_PERMISSION"
   },
-  "license": "DANS-CONDITIONS-OF-USE",
+  "license": "http://creativecommons.org/publicdomain/zero/1.0",
   "privacySensitiveDataPresent": "yes",
   "acceptDepositAgreement": false
 }

--- a/src/test/resources/manual-test/datasetmetadata.json
+++ b/src/test/resources/manual-test/datasetmetadata.json
@@ -117,8 +117,7 @@
     "string"
   ],
   "accessRights": {
-    "category": "OPEN_ACCESS",
-    "group": "string"
+    "category": "OPEN_ACCESS"
   },
   "license": "string",
   "types": [

--- a/src/test/resources/manual-test/issue-1538.json
+++ b/src/test/resources/manual-test/issue-1538.json
@@ -143,8 +143,7 @@
   "instructionsForReuse": ["how to use this data"],
   "publishers": ["publisher1"],
   "accessRights": {
-    "category": "GROUP_ACCESS",
-    "group": "Archaelogy"
+    "category": "OPEN_ACCESS"
   },
   "license": "http://license/cc",
   "types": [

--- a/src/test/scala/nl.knaw.dans.easy.deposit/StagedFilesTargetSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/StagedFilesTargetSpec.scala
@@ -70,7 +70,7 @@ class StagedFilesTargetSpec extends TestSupportFixture {
   it should "not replace a fetch file" in {
     (stagedDir / "some.thing").createFile().write("new content")
     val url = new URL("https://raw.githubusercontent.com/DANS-KNAW/easy-deposit-api/master/README.md")
-    assume(DDM.triedSchema.isAvailble)
+    assume(DDM.triedSchema.isAvailable)
     val bag = newEmptyBag.addFetchItem(url, Paths.get("path/to/some.thing")).getOrRecover(e => fail(e))
     bag.save()
     bag.data.list.size shouldBe 0

--- a/src/test/scala/nl.knaw.dans.easy.deposit/SubmitterSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/SubmitterSpec.scala
@@ -55,7 +55,7 @@ class SubmitterSpec extends TestSupportFixture with MockFactory {
       case Success(StateInfo(State.draft, "Deposit is open for changes.")) =>
     }
 
-    assume(DDM.triedSchema.isAvailble)
+    assume(DDM.triedSchema.isAvailable)
     // the test
     new Submitter(testDir / "staged", testDir / "submitted")
       .submit(depositDir) should matchPattern { case Success(()) => }
@@ -86,7 +86,7 @@ class SubmitterSpec extends TestSupportFixture with MockFactory {
     (bagDir.parent / "deposit.properties").append(s"identifier.doi=$doi")
     (testDir / "submitted").createDirectories()
 
-    assume(DDM.triedSchema.isAvailble)
+    assume(DDM.triedSchema.isAvailable)
     new Submitter(testDir / "staged", testDir / "submitted")
       .submit(depositDir) should matchPattern { case Success(()) => }
 
@@ -105,7 +105,7 @@ class SubmitterSpec extends TestSupportFixture with MockFactory {
     // add file to manifest that does not exist
     (bag.baseDir / "manifest-sha1.txt").append("chk file")
 
-    assume(DDM.triedSchema.isAvailble)
+    assume(DDM.triedSchema.isAvailable)
     new Submitter(testDir / "staged", testDir / "submitted").submit(depositDir) should matchPattern {
       case Failure(e) if e.getMessage == s"invalid bag, missing [files, checksums]: [Set($testDir/drafts/user/${ depositDir.id }/bag/file), Set()]" =>
     }
@@ -124,7 +124,7 @@ class SubmitterSpec extends TestSupportFixture with MockFactory {
     manifest.write(manifest.contentAsString.replaceAll(" +", "xxx  "))
 
     val checksum = "a57ec0c3239f30b29f1e9270581be50a70c74c04"
-    assume(DDM.triedSchema.isAvailble)
+    assume(DDM.triedSchema.isAvailable)
     new Submitter(testDir / "staged", testDir / "submitted").submit(depositDir) should matchPattern {
       case Failure(e)
         if e.getMessage == s"staged and draft bag [${ bag.baseDir.parent }] have different payload manifest elements: (Set((data/file.txt,$checksum)),Set((data/file.txt,${ checksum }xxx)))" =>

--- a/src/test/scala/nl.knaw.dans.easy.deposit/authentication/LdapAuthenticationSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/authentication/LdapAuthenticationSpec.scala
@@ -48,11 +48,10 @@ class LdapAuthenticationSpec extends TestSupportFixture with MockFactory {
       expectLdapAttributes(new BasicAttributes() {
         put("dansState", "ACTIVE")
         put("uid", "someone")
-        put("easyGroups", "abc")
       })
     })
     authentication.authenticate("someone", "somepassword") should matchPattern {
-      case Success(Some(AuthUser("someone", Seq("abc"), UserState.active))) =>
+      case Success(Some(AuthUser("someone", UserState.active))) =>
     }
   }
 
@@ -105,14 +104,11 @@ class LdapAuthenticationSpec extends TestSupportFixture with MockFactory {
         put("dansPrefixes", "van")
         get("dansPrefixes").add("den")
         put("sn", "Berg")
-        put("easyGroups", "Archeology")
-        get("easyGroups").add("History")
       })
     })
     inside(authentication.getUser("someone")) {
       case Success(user) => // just sampling the result
         user("dansPrefixes").toArray shouldBe Array("van", "den")
-        user("easyGroups").toArray shouldBe Array("Archeology", "History")
     }
   }
 }

--- a/src/test/scala/nl.knaw.dans.easy.deposit/authentication/SessionSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/authentication/SessionSpec.scala
@@ -45,7 +45,7 @@ class SessionSpec extends TestSupportFixture with ServletFixture with ScalatraSu
       uri = "/deposit",
       headers = Seq(fooBarBasicAuthHeader)
     ) {
-      body should startWith("AuthUser(foo,List(),ACTIVE) ")
+      body should startWith("AuthUser(foo,ACTIVE) ")
       body should endWith(" EASY Deposit API Service running")
       header("REMOTE_USER") shouldBe "foo"
       header("Set-Cookie") should startWith regex "scentry.auth.default.user=[^;].+;"
@@ -63,7 +63,7 @@ class SessionSpec extends TestSupportFixture with ServletFixture with ScalatraSu
     ) {
       status shouldBe OK_200
       Option(header("REMOTE_USER")) shouldBe None
-      body should startWith("AuthUser(foo,List(),ACTIVE) ")
+      body should startWith("AuthUser(foo,ACTIVE) ")
       body should endWith(" EASY Deposit API Service running")
     }
   }

--- a/src/test/scala/nl.knaw.dans.easy.deposit/docs/AgreementsSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/docs/AgreementsSpec.scala
@@ -46,7 +46,7 @@ class AgreementsSpec extends TestSupportFixture {
     ) should matchPattern { case Failure(InvalidDocumentException(_, e)) if e.getMessage == "Please set PrivacySensitiveDataPresent" => }
   }
   "schema validation" should "succeed" in {
-    assume(AgreementsXml.triedSchema.isAvailble)
+    assume(AgreementsXml.triedSchema.isAvailable)
     AgreementsXml(
       "user",
       DateTime.now,
@@ -57,7 +57,7 @@ class AgreementsSpec extends TestSupportFixture {
     ).flatMap(AgreementsXml.validate) should matchPattern { case Success(_) => }
   }
   it should "complain about missing user" in {
-    assume(AgreementsXml.triedSchema.isAvailble)
+    assume(AgreementsXml.triedSchema.isAvailable)
     AgreementsXml(
       null,
       DateTime.now,

--- a/src/test/scala/nl.knaw.dans.easy.deposit/docs/DDMSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/docs/DDMSpec.scala
@@ -588,7 +588,7 @@ class DDMSpec extends TestSupportFixture with DdmBehavior {
 
   private implicit class RichDatasetMetadata(input: MinimalDatasetMetadata) {
     def causesInvalidDocumentException(expectedMessage: String): Assertion = {
-      assume(DDM.triedSchema.isAvailble)
+      assume(DDM.triedSchema.isAvailable)
       DDM(input) should matchPattern {
         case Failure(InvalidDocumentException("DatasetMetadata", t)) if t.getMessage == expectedMessage =>
       }
@@ -616,13 +616,13 @@ trait DdmBehavior {
     lazy val triedDDM = DDM(datasetMetadata)
 
     if (expectedDdmContent.nonEmpty) it should "generate expected DDM" in {
-      assume(DDM.triedSchema.isAvailble)
+      assume(DDM.triedSchema.isAvailable)
       prettyPrinter.format(subset(triedDDM.getOrRecover(e => fail(e)))) shouldBe
         prettyPrinter.format(emptyDDM.copy(child = expectedDdmContent))
     }
 
     it should "generate valid DDM" in {
-      assume(DDM.triedSchema.isAvailble)
+      assume(DDM.triedSchema.isAvailable)
       triedDDM shouldBe a[Success[_]]
     }
   }

--- a/src/test/scala/nl.knaw.dans.easy.deposit/docs/DatasetMetadataSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/docs/DatasetMetadataSpec.scala
@@ -46,7 +46,8 @@ class DatasetMetadataSpec extends TestSupportFixture {
   }
 
   it should "not fail for UI test data (some fields)" in {
-    // https://github.com/DANS-KNAW/easy-deposit-ui/blob/81b21a08ce1a8a3d86ef74148c1e024188080e10/src/test/typescript/mockserver/metadata.ts#L586-L642
+    // https://github.com/DANS-KNAW/easy-deposit-ui/blob/f0d74722b36997389462b7bdd8191f5743aef45f/src/test/typescript/mockserver/metadata.ts#L597-L652
+    // added:  "acceptDepositAgreement": false
     roundTripTest("datasetmetadata-from-ui-some.json")
   }
 

--- a/src/test/scala/nl.knaw.dans.easy.deposit/docs/FilesXmlSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/docs/FilesXmlSpec.scala
@@ -43,7 +43,7 @@ class FilesXmlSpec extends TestSupportFixture {
     (testDir / "data" / "test.txt").touch()
     (testDir / "data" / "folder" / "test.xml").touch()
 
-    assume(FilesXml.triedSchema.isAvailble)
+    assume(FilesXml.triedSchema.isAvailable)
     val xml = createFilesXml
     (xml \ "file").toList.sortBy(_.attribute("filepath").toString) shouldBe
         <file filepath="data/folder/test.xml">

--- a/src/test/scala/nl.knaw.dans.easy.deposit/docs/MinimalDatasetMetadata.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/docs/MinimalDatasetMetadata.scala
@@ -51,7 +51,7 @@ class MinimalDatasetMetadata(
                               instructionsForReuse: Option[Seq[String]] = None,
                               publishers: Option[Seq[String]] = None,
                               accessRights: Option[AccessRights] = Some(
-                                AccessRights(category = AccessCategory.open, group = None)
+                                AccessRights(category = AccessCategory.open)
                               ),
                               license: Option[String] = None,
                               typesDcmi: Option[Seq[String]] = None,

--- a/src/test/scala/nl.knaw.dans.easy.deposit/docs/package.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/docs/package.scala
@@ -28,7 +28,7 @@ package object docs extends DebugEnhancedLogging {
   val prettyPrinter: PrettyPrinter = new scala.xml.PrettyPrinter(1024, 2)
 
   implicit class triedSchemaExtension(val triedSchema: Try[Schema]) extends AnyVal {
-    def isAvailble: Boolean = {
+    def isAvailable: Boolean = {
       triedSchema match {
         case Failure(e: SAXParseException) if e.getCause.isInstanceOf[UnknownHostException] => false
         case _ => true

--- a/src/test/scala/nl.knaw.dans.easy.deposit/servlets/DepositServletErrorSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/servlets/DepositServletErrorSpec.scala
@@ -66,7 +66,7 @@ class DepositServletErrorSpec extends TestSupportFixture with ServletFixture wit
   }
 
   s"get /:uuid/metadata" should "report a corrupt dataset" in {
-    assume(DDM.triedSchema.isAvailble)
+    assume(DDM.triedSchema.isAvailable)
     (mockedApp.getDatasetMetadataForDeposit(_: String, _: UUID)) expects("foo", uuid) returning
       Failure(CorruptDepositException("foo", uuid.toString, new Exception("invalid json")))
 

--- a/src/test/scala/nl.knaw.dans.easy.deposit/servlets/DoiSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/servlets/DoiSpec.scala
@@ -106,7 +106,7 @@ class DoiSpec extends DepositServletFixture {
   }
 
   "PUT /deposit/{id}/state" should "succeed when DOI's are equal" in {
-    assume(DDM.triedSchema.isAvailble)
+    assume(DDM.triedSchema.isAvailable)
     val uuid = createDeposit
     propsFile(uuid).append(doiProperty)
     jsonFile(uuid).write(s"""{$doiForJson,$mandatoryOnSubmit}""")

--- a/src/test/scala/nl.knaw.dans.easy.deposit/servlets/DoiSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/servlets/DoiSpec.scala
@@ -37,7 +37,7 @@ class DoiSpec extends DepositServletFixture {
        |    { "scheme": "dcterms:W3CDTF", "value": "2018-05-31", "qualifier": "dcterms:created" },
        |  ],
        |  "audiences": [ { "scheme": "string", "value": "string", "key": "D33000" } ],
-       |  "accessRights": {"category": "OPEN_ACCESS", "group": "string"},
+       |  "accessRights": {"category": "OPEN_ACCESS"},
        |  "privacySensitiveDataPresent": "no",
        |  "acceptDepositAgreement": true,
        |""".stripMargin

--- a/src/test/scala/nl.knaw.dans.easy.deposit/servlets/HappyRoutesSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/servlets/HappyRoutesSpec.scala
@@ -104,13 +104,12 @@ class HappyRoutesSpec extends TestSupportFixture with ServletFixture with Scalat
       "cn" -> Seq("Jan"),
       "dansPrefixes" -> Seq("van", "den"),
       "sn" -> Seq("Berg"),
-      "easyGroups" -> Seq("Archeology", "History")
     ))
     get(
       uri = "/user",
       headers = Seq(fooBarBasicAuthHeader)
     ) {
-      body shouldBe """{"userName":"foo","firstName":"Jan","prefix":"van den","lastName":"Berg","groups":["Archeology","History"]}"""
+      body shouldBe """{"userName":"foo","firstName":"Jan","prefix":"van den","lastName":"Berg"}"""
       status shouldBe OK_200
     }
   }

--- a/src/test/scala/nl.knaw.dans.easy.deposit/servlets/HappyRoutesSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/servlets/HappyRoutesSpec.scala
@@ -174,7 +174,7 @@ class HappyRoutesSpec extends TestSupportFixture with ServletFixture with Scalat
   }
 
   "put /deposit/:uuid/metadata" should "reject invalid datasetmetadata.json" in {
-    assume(DDM.triedSchema.isAvailble)
+    assume(DDM.triedSchema.isAvailable)
     authMocker.expectsUserFooBar
 
     put(

--- a/src/test/scala/nl.knaw.dans.easy.deposit/servlets/IntegrationSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/servlets/IntegrationSpec.scala
@@ -51,7 +51,7 @@ class IntegrationSpec extends TestSupportFixture with ServletFixture with Scalat
     val metadataURI = s"/deposit/$uuid/metadata"
 
     // create dataset metadata
-    assume(DDM.triedSchema.isAvailble)
+    assume(DDM.triedSchema.isAvailable)
     authMocker.expectsUserFooBar
     put(
       metadataURI, headers = Seq(fooBarBasicAuthHeader),
@@ -86,7 +86,7 @@ class IntegrationSpec extends TestSupportFixture with ServletFixture with Scalat
     val metadataURI = s"/deposit/$uuid/metadata"
 
     // create dataset metadata
-    assume(DDM.triedSchema.isAvailble)
+    assume(DDM.triedSchema.isAvailable)
     authMocker.expectsUserFooBar
     put(
       metadataURI, headers = Seq(fooBarBasicAuthHeader),
@@ -214,7 +214,7 @@ class IntegrationSpec extends TestSupportFixture with ServletFixture with Scalat
     (depositDir / "deposit.properties").append(s"identifier.doi=$doi")
 
     // upload dataset metadata
-    assume(DDM.triedSchema.isAvailble)
+    assume(DDM.triedSchema.isAvailable)
     authMocker.expectsUserFooBar
     put(
       uri = s"/deposit/$uuid/metadata",
@@ -254,7 +254,7 @@ class IntegrationSpec extends TestSupportFixture with ServletFixture with Scalat
 
     val uuid = DepositInfo(responseBody).map(_.id.toString).getOrRecover(e => fail(e.toString, e))
     // upload dataset metadata
-    assume(DDM.triedSchema.isAvailble)
+    assume(DDM.triedSchema.isAvailable)
     authMocker.expectsUserFooBar
     put(
       uri = s"/deposit/$uuid/metadata",


### PR DESCRIPTION
Fixes EASY-1726 drop group-access from deposit-api

#### When applied it will
* no longer provide groups in UserInfo
* only support `AccessRights.category` = REQUEST_PERMISSION / OPEN_ACCESS (as in the ui) 
* no longer accept `AccessRight.group` in dataset metadata

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

Try the following commands before and after deploy

    curl -i -u digger001:digger001 'http://deasy.dans.knaw.nl:20190/user'
    curl -i -u user001:user001 --data '{"accessRights": {"category":"OPEN_ACCESS","group": "string"  }}' -X PUT 'http://deasy.dans.knaw.nl:20190/deposit/UUID/metadata

* the first command will no longer return `"groups":["Archeology"]`
* the second command will no longer succeed
* login with the ui should still succeed ans show the usual info

#### Related pull requests on github
repo                       | PR                | note
-------------------------- | ----------------- | ----
easy-                      | [PR#](PRlink)     | ..
