### PR TITLE
EASY-1854: rename unauthenticated challenge for BasicAuth

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.deposit/authentication/EasyBasicAuthStrategy.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/authentication/EasyBasicAuthStrategy.scala
@@ -17,8 +17,8 @@ package nl.knaw.dans.easy.deposit.authentication
 
 import javax.servlet.http.{ HttpServletRequest, HttpServletResponse }
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
-import org.scalatra.ScalatraBase
 import org.scalatra.auth.strategy.BasicAuthStrategy
+import org.scalatra.{ ScalatraBase, Unauthorized }
 
 object EasyBasicAuthStrategy {}
 
@@ -45,4 +45,16 @@ class EasyBasicAuthStrategy(protected override val app: ScalatraBase,
                          (implicit request: HttpServletRequest, response: HttpServletResponse): String = {
     user.id
   }
+
+  override def unauthenticated()(implicit request: HttpServletRequest, response: HttpServletResponse): Unit = {
+    val response = Unauthorized(headers = Map("WWW-Authenticate" -> challenge))
+
+    // TODO @jo-pol this requires a `.logResponse` instead of this info log!
+    logger.info(s"unauthenticated response ${ response.headers }")
+    app halt response
+  }
+
+  // we need to change the challenge's name to disable the browser's default login prompt
+  // http://voidcanvas.com/how-to-disable-browsers-default-login-prompt-on-401-response/
+  override protected def challenge: String = "x" + super.challenge
 }

--- a/src/main/scala/nl.knaw.dans.easy.deposit/authentication/LdapAuthentication.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/authentication/LdapAuthentication.scala
@@ -55,10 +55,7 @@ trait LdapAuthentication extends DebugEnhancedLogging {
     def authenticate(userName: String, password: String): Try[Option[AuthUser]] = {
       findUser(userName, userContextProperties(userName, password))
         .doIfFailure { case t => logger.error(s"authentication of [$userName] failed with $t", t) }
-        .map(_
-          .map(props => AuthUser(props))
-          .find(_.state == UserState.active)
-        )
+        .map(_.map(props => AuthUser(props)).find(_.state == UserState.active))
     }
 
     private def findUser(searchedUserName: String, contextProperties: util.Hashtable[String, String]) = {

--- a/src/main/scala/nl.knaw.dans.easy.deposit/authentication/LdapAuthentication.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/authentication/LdapAuthentication.scala
@@ -55,7 +55,7 @@ trait LdapAuthentication extends DebugEnhancedLogging {
     def authenticate(userName: String, password: String): Try[Option[AuthUser]] = {
       findUser(userName, userContextProperties(userName, password))
         .doIfFailure { case t => logger.error(s"authentication of [$userName] failed with $t", t) }
-        .map(_.map(props => AuthUser(props)).find(_.state == UserState.active))
+        .map(_.map(AuthUser(_)).find(_.state == UserState.active))
     }
 
     private def findUser(searchedUserName: String, contextProperties: util.Hashtable[String, String]) = {


### PR DESCRIPTION
Fixes EASY-1854

#### When applied it will
* rename the challenge for unauthenticated response in BasicAuth to make sure the default browser login popup screen doesn't appear

@DANS-KNAW/easy for review

#### Steps to reproduce the original situation
* start a `deasy` machine with `easy-deposit-api` deployed (a version from before this PR)
* go to http://deasy.dans.knaw.nl/deposit/login in your favorite browser
* type an incorrect username/password combination
* click login
* **Now you should see the browser's default login popup.**

![kapture 2019-01-24 at 9 16 29](https://user-images.githubusercontent.com/5938204/51664084-d8028c80-1fb8-11e9-9709-736d15fb011e.gif)
