### PR TITLE
EASY-1747 postpone validation to submit (authors only)

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.deposit/docs/DatasetMetadata.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/docs/DatasetMetadata.scala
@@ -78,8 +78,9 @@ case class DatasetMetadata(private val identifiers: Option[Seq[SchemedValue]] = 
   atMostOne(datesCreated)
   atMostOne(datesAvailable)
 
+  private lazy val authors: Seq[Author] = (contributors.toSeq ++ creators.toSeq).flatten
   // duplicates for plain strings in dcterms (which has no place for IDs as contributors/creators do)
-  lazy val rightsHolders: Seq[String] = (contributors.toSeq ++ creators.toSeq).flatten
+  lazy val rightsHolders: Seq[String] = authors
     .withFilter(_.isRightsHolder)
     .map(_.toString)
 
@@ -97,6 +98,11 @@ case class DatasetMetadata(private val identifiers: Option[Seq[SchemedValue]] = 
   def setDoi(value: String): DatasetMetadata = {
     val ids = identifiers.getOrElse(Seq.empty).filterNot(_.scheme == doiScheme)
     this.copy(identifiers = Some(ids :+ SchemedValue(doiScheme, value)))
+  }
+
+  /** Validations as far as not covered by DDM schema validation. */
+  private[docs] def validate(): Try[Unit] = {
+    Author.validate(authors)
   }
 }
 

--- a/src/main/scala/nl.knaw.dans.easy.deposit/docs/dm/Author.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/docs/dm/Author.scala
@@ -16,7 +16,6 @@
 package nl.knaw.dans.easy.deposit.docs.dm
 
 import nl.knaw.dans.easy.deposit.docs.DatasetMetadata.{ SchemedKeyValue, SchemedValue }
-import nl.knaw.dans.easy.deposit.docs.StringUtils._
 import nl.knaw.dans.lib.string._
 
 case class Author(titles: Option[String] = None,
@@ -27,16 +26,11 @@ case class Author(titles: Option[String] = None,
                   ids: Option[Seq[SchemedValue]] = None,
                   organization: Option[String] = None,
                  ) extends Requirements {
-  private val hasMandatory: Boolean = organization.isProvided || (surname.isProvided && initials.isProvided)
-  private val hasRedundant: Boolean = !surname.isProvided && (titles.isProvided || insertions.isProvided)
   private val incompleteMsg = "Author needs one of (organisation | surname and initials)"
-  private val redundantMsg = "Author has no surname so neither titles nor insertions"
-  require(hasMandatory, buildMsg(incompleteMsg))
-  require(!hasRedundant, buildMsg(redundantMsg))
 
   def isRightsHolder: Boolean = role.exists(_.key == "RightsHolder")
 
-  override def toString: String = {
+  override def toString: String = { // for <dcterms:rightsHolder>
     def name = Seq(titles, initials, insertions, surname)
       .collect { case Some(s) if !s.isBlank => s }
       .mkString(" ")
@@ -45,7 +39,6 @@ case class Author(titles: Option[String] = None,
       case (Some(_), Some(org)) => s"$name ($org)"
       case (None, Some(org)) => org
       case (Some(_), None) => name
-      // only when requires is implemented incorrect:
       case (None, None) => throw new IllegalArgumentException(buildMsg(incompleteMsg))
     }
   }

--- a/src/test/scala/nl.knaw.dans.easy.deposit/docs/DatasetMetadataSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/docs/DatasetMetadataSpec.scala
@@ -214,26 +214,6 @@ class DatasetMetadataSpec extends TestSupportFixture {
     DatasetMetadata("""{ "contributors": [ { "organization": "University of Zurich" } ] }""") shouldBe a[Success[_]]
   }
 
-  it should "reject an author without initials" in {
-    """{ "contributors": [ { "surname": "Einstein" } ] }"""
-      .causesInvalidDocumentException("""requirement failed: Author needs one of (organisation | surname and initials); got {"surname":"Einstein"} Author""")
-  }
-
-  it should "reject an author without surname" in {
-    """{ "contributors": [ { "initials": "A" } ] }"""
-      .causesInvalidDocumentException("""requirement failed: Author needs one of (organisation | surname and initials); got {"initials":"A"} Author""")
-  }
-
-  it should "reject an organisation with titles" in {
-    """{ "contributors": [ { "surname": "", "titles": "A", "organization": "University of Zurich" } ] }"""
-      .causesInvalidDocumentException( """requirement failed: Author has no surname so neither titles nor insertions; got {"titles":"A","surname":"","organization":"University of Zurich"} Author""")
-  }
-
-  it should "reject an organisation with insertions" in {
-    """{ "contributors": [ { "insertions": "van der", "organization": "University of Zurich" } ] }"""
-      .causesInvalidDocumentException("""requirement failed: Author has no surname so neither titles nor insertions; got {"insertions":"van der","organization":"University of Zurich"} Author""")
-  }
-
   "DatasetMetadata.dates" should "reject dcterms:dateSubmitted" in {
     """{"dates": [{ "qualifier": "dcterms:dateSubmitted", "value": "2018-12", "scheme": "dcterms:W3CDTF" }]}"""
       .causesInvalidDocumentException("""requirement failed: No dcterms:dateSubmitted allowed; got [{"scheme":"dcterms:W3CDTF","value":"2018-12","qualifier":"dcterms:dateSubmitted"}]""")

--- a/src/test/scala/nl.knaw.dans.easy.deposit/servlets/ValidationSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/servlets/ValidationSpec.scala
@@ -21,9 +21,10 @@ import nl.knaw.dans.easy.deposit.docs.dm.Author
 import nl.knaw.dans.lib.error._
 import org.eclipse.jetty.http.HttpStatus._
 import org.scalatest.Assertion
+import org.scalatest.exceptions.TestFailedException
 import org.xml.sax.SAXParseException
 
-import scala.util.Failure
+import scala.util.{ Failure, Success }
 
 class ValidationSpec extends DepositServletFixture {
 
@@ -132,12 +133,22 @@ class ValidationSpec extends DepositServletFixture {
     }
   }
 
-  private def parse(input: String) = {
+  "PUT(metadata) and PUT(submitted)" should "succeed for the base object for each test" in {
+    DDM(mandatoryOnSubmit) shouldBe a[Success[_]]
+  }
+
+  /**
+   * @param input json object with metadata fragment under test
+   * @return To be injected into a valid-for-submission instance
+   * @throws TestFailedException when the test data can't be deserialized
+   *                             and thus would be rejected by PUT(metadata).
+   */
+  private def parse(input: String): DatasetMetadata = {
     DatasetMetadata(input)
       .getOrRecover(e => fail(s"loading test data failed: ${ e.getMessage }; $input", e))
   }
 
-  // makes sure we only get errors on the field under test
+  /** Tests inject parsed input into this object to check error handling. */
   private val mandatoryOnSubmit = DatasetMetadata(
     """{
       |  "titles": ["blabla"],

--- a/src/test/scala/nl.knaw.dans.easy.deposit/servlets/ValidationSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/servlets/ValidationSpec.scala
@@ -64,7 +64,7 @@ class ValidationSpec extends DepositServletFixture {
 
   it should "fail for an author with just a last name" in {
     DDM(mandatoryOnSubmit.copy(
-      creators = parse("""{ "creators": [ { "surname": "Einstein" }]}""").creators
+      creators = parse("""{ "creators": [ { "surname": "Einstein", "initials": "  " }]}""").creators
     )) should matchPattern {
       case Failure(InvalidDocumentException("DatasetMetadata", cause: SAXParseException))
         if cause.getMessage.contains("'dcx-dai:author' is not complete")
@@ -75,7 +75,7 @@ class ValidationSpec extends DepositServletFixture {
 
   it should "fail for an author with just initials" in {
     DDM(mandatoryOnSubmit.copy(
-      creators = parse("""{ "creators": [ { "initials": "A" }]}""").creators
+      creators = parse("""{ "creators": [ { "surname": "  ", "initials": "A" }]}""").creators
     )) should matchPattern {
       case Failure(InvalidDocumentException("DatasetMetadata", cause: SAXParseException))
         if cause.getMessage.contains("'dcx-dai:creatorDetails' is not complete") =>
@@ -210,7 +210,7 @@ class ValidationSpec extends DepositServletFixture {
       creators = parse(
         """{ "creators": [
           |  { "titles": "Baron", "insertions": "van", "organization": "Nyenrode" },
-          |  { "organization": "Harvard" }
+          |  { "organization": "Harvard", "insertions": "  ", "surname": "  " }
           |  { "titles": "Sir", "organization": "Oxbridge" }
           |  { "titles": "Mr" }
           |  { "insertions": "von", "organization": "ETH Zurich" },

--- a/src/test/scala/nl.knaw.dans.easy.deposit/servlets/ValidationSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/servlets/ValidationSpec.scala
@@ -35,10 +35,11 @@ class ValidationSpec extends DepositServletFixture {
       |  "accessRights": {"category": "OPEN_ACCESS"},
       |  "privacySensitiveDataPresent": "no",
       |  "acceptDepositAgreement": true,
-      |}""".stripMargin).getOrElse(fail("loading test data failed"))
+      |}""".stripMargin
+  ).getOrElse(fail("loading test data failed"))
 
 
-  "PUT(metadata) should succeed, PUT(submitted)" should "fail for an empty contributor" in {
+  "PUT(metadata) should succeed with incomplete authors, PUT(submitted)" should "fail for an empty contributor" in {
     def checkSubmitResponse = {
       body should include("The content of element 'dcx-dai:contributorDetails' is not complete")
       // a client has no which one in the list is violating the requirements
@@ -70,12 +71,51 @@ class ValidationSpec extends DepositServletFixture {
   it should "fail for an author with just a last name" in {
     def checkSubmitResponse = {
       body should include("The content of element 'dcx-dai:author' is not complete")
-      // a client has no clue this is about a creator or contributor
+      // a client has no clue this is about a creator or contributor, let alone which one
       status shouldBe BAD_REQUEST_400
     }
 
     saveAndSubmit(checkSubmitResponse _, mandatoryOnSubmit.copy(
       creators = Some(Seq(Author(surname = Some("Somebody"))))
+    ))
+  }
+
+  it should "fail for an author with just initials" in {
+    def checkSubmitResponse = {
+      body should include("The content of element 'dcx-dai:creatorDetails' is not complete")
+      status shouldBe BAD_REQUEST_400
+    }
+
+    saveAndSubmit(checkSubmitResponse _, mandatoryOnSubmit.copy(
+      creators = Some(Seq(Author(initials = Some("S."))))
+    ))
+  }
+
+  it should "fail for an organisation with insertions" in pendingUntilFixed { // TODO fix schema?
+    def checkSubmitResponse = {
+      body should include("The content of element 'dcx-dai:creatorDetails' is not complete")
+      status shouldBe BAD_REQUEST_400
+    }
+
+    saveAndSubmit(checkSubmitResponse _, mandatoryOnSubmit.copy(
+      creators = Some(Seq(Author(
+        insertions = Some("von"),
+        organization = Some("ETH Zurich"),
+      )))
+    ))
+  }
+
+  it should "fail for an organisation with titles" in pendingUntilFixed {
+    def checkSubmitResponse = {
+      body should include("The content of element 'dcx-dai:creatorDetails' is not complete")
+      status shouldBe BAD_REQUEST_400
+    }
+
+    saveAndSubmit(checkSubmitResponse _, mandatoryOnSubmit.copy(
+      creators = Some(Seq(Author(
+        insertions = Some("Sir"),
+        organization = Some("Oxbridge"),
+      )))
     ))
   }
 

--- a/src/test/scala/nl.knaw.dans.easy.deposit/servlets/ValidationSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/servlets/ValidationSpec.scala
@@ -1,0 +1,109 @@
+/**
+ * Copyright (C) 2018 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.easy.deposit.servlets
+
+import nl.knaw.dans.easy.deposit.docs._
+import nl.knaw.dans.easy.deposit.docs.dm.Author
+import org.eclipse.jetty.http.HttpStatus._
+import org.scalatest.Assertion
+
+class ValidationSpec extends DepositServletFixture {
+
+  private val mandatoryOnSubmit = DatasetMetadata(
+    """{
+      |  "titles": ["blabla"],
+      |  "descriptions": ["rababera"],
+      |  "creators": [ { "initials": "A", "surname": "Einstein", } ],
+      |  "dates": [
+      |    { "scheme": "dcterms:W3CDTF", "value": "2018-05-31", "qualifier": "dcterms:available" },
+      |    { "scheme": "dcterms:W3CDTF", "value": "2018-05-31", "qualifier": "dcterms:created" },
+      |  ],
+      |  "audiences": [ { "scheme": "string", "value": "string", "key": "D33000" } ],
+      |  "accessRights": {"category": "OPEN_ACCESS"},
+      |  "privacySensitiveDataPresent": "no",
+      |  "acceptDepositAgreement": true,
+      |}""".stripMargin).getOrElse(fail("loading test data failed"))
+
+
+  "PUT(metadata) should succeed, PUT(submitted)" should "fail for an empty contributor" in {
+    def checkSubmitResponse = {
+      body should include("The content of element 'dcx-dai:contributorDetails' is not complete")
+      // a client has no which one in the list is violating the requirements
+      status shouldBe BAD_REQUEST_400
+    }
+
+    saveAndSubmit(checkSubmitResponse _, mandatoryOnSubmit.copy(
+      contributors = Some(Seq(
+        Author(initials = Some("A.S."), surname = Some("Terix")),
+        Author(),
+      )),
+    ))
+  }
+
+  it should "fail for an empty creator" in {
+    def checkSubmitResponse = {
+      body should include("The content of element 'dcx-dai:creatorDetails' is not complete")
+      body shouldNot include("The content of element 'dcx-dai:contributorDetails' is not complete")
+      // a client has no clue about the second violation on contributorDetails
+      status shouldBe BAD_REQUEST_400
+    }
+
+    saveAndSubmit(checkSubmitResponse _, mandatoryOnSubmit.copy(
+      creators = Some(Seq(Author())),
+      contributors = Some(Seq(Author())),
+    ))
+  }
+
+  it should "fail for an author with just a last name" in {
+    def checkSubmitResponse = {
+      body should include("The content of element 'dcx-dai:author' is not complete")
+      // a client has no clue this is about a creator or contributor
+      status shouldBe BAD_REQUEST_400
+    }
+
+    saveAndSubmit(checkSubmitResponse _, mandatoryOnSubmit.copy(
+      creators = Some(Seq(Author(surname = Some("Somebody"))))
+    ))
+  }
+
+  private def saveAndSubmit(checkSubmitResponse: () => Assertion,
+                            metadata: DatasetMetadata
+                           ) = {
+    val uuid = createDeposit
+
+    put(
+      uri = s"/deposit/$uuid/metadata",
+      headers = Seq(fooBarBasicAuthHeader),
+      body = JsonUtil.toJson(metadata)
+    ) { status shouldBe NO_CONTENT_204 }
+
+    mockDoiRequest("10.17632/DANS.6wg5xccnjd.1") once()
+    get( // added to metadata.json and deposit.properties
+      // note that a client would need this DOI in the metadata for each next put
+      uri = s"/deposit/$uuid/doi",
+      headers = Seq(fooBarBasicAuthHeader)
+    ) { status shouldBe OK_200 }
+
+    assume(DDM.triedSchema.isAvailable)
+    put(
+      uri = s"/deposit/$uuid/state",
+      headers = Seq(fooBarBasicAuthHeader),
+      body = """{"state":"SUBMITTED","stateDescription":"blabla"}"""
+    ) {
+      checkSubmitResponse()
+    }
+  }
+}


### PR DESCRIPTION
Fixes EASY-1747 postpone validation to submit (so far authors only)

#### When applied it will
* no longer cause validation errors on authors (creators/contributors and the rights-holders among them) when saving metadata
* postponing validation of schemed objects _inside and outside_ authors is still out of scope for this pull request
* friendly error messages are kept out of scope, see [EASY-1905](https://drivenbydata.atlassian.net/browse/EASY-1905) therefore submission relies on schema validation for now unless something would not be covered.

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### Related pull requests on github
repo                       | PR                | note
-------------------------- | ----------------- | ----
easy-                      | [PR#](PRlink)     | ..
