### PR TITLE
EASY-1747 postpone validation to submit (dates)

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.deposit/docs/DDM.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/docs/DDM.scala
@@ -20,6 +20,7 @@ import java.net.UnknownHostException
 import nl.knaw.dans.easy.deposit.docs.DatasetMetadata._
 import nl.knaw.dans.easy.deposit.docs.JsonUtil.InvalidDocumentException
 import nl.knaw.dans.easy.deposit.docs.StringUtils._
+import nl.knaw.dans.easy.deposit.docs.dm.DateQualifier.DateQualifier
 import nl.knaw.dans.easy.deposit.docs.dm._
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
 import nl.knaw.dans.lib.string._
@@ -161,22 +162,15 @@ object DDM extends SchemedXml with DebugEnhancedLogging {
   private implicit class RichElem(val elem: Elem) extends AnyVal {
     /** @param str the desired label, optionally with name space prefix */
     @throws[InvalidDocumentException]("when str is not a valid XML label (has more than one ':')")
-    def withLabel(str: String): Elem = {
-      str.split(":") match {
-        case Array(label) => elem.copy(label = label)
-        case Array(prefix, label) => elem.copy(prefix = prefix, label = label)
-        case a => throw invalidDatasetMetadataException(new IllegalArgumentException(
-          s"expecting (label) or (prefix:label); got [${ a.mkString(":") }] to adjust the <${ elem.label }> of ${ trim(elem) }"
-        ))
-      }
-    }
+    def withLabel(str: String): Elem = withLabel(Some(str))
 
-    def withLabel[T](someEnum: Option[T]): Elem = {
-      someEnum.map(_.toString.split(":")) match {
+    @throws[InvalidDocumentException]("when maybeVal does not contain a valid XML label (its .toString has more than one ':')")
+    def withLabel[T](maybeVal: Option[T]): Elem = {
+      maybeVal.map(_.toString.split(":")) match {
         case Some(Array(label)) => elem.copy(label = label)
         case Some(Array(prefix, label)) => elem.copy(prefix = prefix, label = label)
         case a => throw invalidDatasetMetadataException(new IllegalArgumentException(
-          s"expecting Some(label) or Some(prefix:label); got [$a] to adjust the <${ elem.label }> of ${ trim(elem) }"
+          s"expecting (label) or (prefix:label); got [${a.map(_.mkString(":"))}] to adjust the <${ elem.label }> of ${ trim(elem) }"
         ))
       }
     }

--- a/src/main/scala/nl.knaw.dans.easy.deposit/docs/DDM.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/docs/DDM.scala
@@ -20,7 +20,6 @@ import java.net.UnknownHostException
 import nl.knaw.dans.easy.deposit.docs.DatasetMetadata._
 import nl.knaw.dans.easy.deposit.docs.JsonUtil.InvalidDocumentException
 import nl.knaw.dans.easy.deposit.docs.StringUtils._
-import nl.knaw.dans.easy.deposit.docs.dm.DateQualifier.DateQualifier
 import nl.knaw.dans.easy.deposit.docs.dm._
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
 import nl.knaw.dans.lib.string._
@@ -49,11 +48,11 @@ object DDM extends SchemedXml with DebugEnhancedLogging {
       xsi:schemaLocation={s"$schemaNameSpace $schemaLocation"}
     >
       <ddm:profile>
-        { dm.titles.getNonEmpty.map(src => <dc:title xml:lang={ lang }>{ src }</dc:title>) }
-        { dm.descriptions.getNonEmpty.map(src => <dcterms:description xml:lang={ lang }>{ src }</dcterms:description>) }
+        { dm.titles.getNonEmpty.map(str => <dc:title xml:lang={ lang }>{ str }</dc:title>) }
+        { dm.descriptions.getNonEmpty.map(str => <dcterms:description xml:lang={ lang }>{ str }</dcterms:description>) }
         { dm.creators.getNonEmpty.map(author => <dcx-dai:creatorDetails>{ details(author, lang) }</dcx-dai:creatorDetails>) }
-        { dm.datesCreated.map(src => <ddm:created>{ src.value.getOrElse("") }</ddm:created>) }
-        { dm.datesAvailable.map(src => <ddm:available>{ src.value.getOrElse("") }</ddm:available>) }
+        { dm.datesCreated.toSeq.flatMap(_.value).map(str => <ddm:created>{ str }</ddm:created>) }
+        { dm.datesAvailable.toSeq.flatMap(_.value).map(str => <ddm:available>{ str }</ddm:available>) }
         { dm.audiences.getNonEmpty.map(src => <ddm:audience>{ src.key }</ddm:audience>) }
         { dm.accessRights.toSeq.map(src => <ddm:accessRights>{ src.category.toString }</ddm:accessRights>) }
       </ddm:profile>
@@ -170,7 +169,7 @@ object DDM extends SchemedXml with DebugEnhancedLogging {
         case Some(Array(label)) => elem.copy(label = label)
         case Some(Array(prefix, label)) => elem.copy(prefix = prefix, label = label)
         case a => throw invalidDatasetMetadataException(new IllegalArgumentException(
-          s"expecting (label) or (prefix:label); got [${a.map(_.mkString(":"))}] to adjust the <${ elem.label }> of ${ trim(elem) }"
+          s"expecting (label) or (prefix:label); got [${ a.map(_.mkString(":")) }] to adjust the <${ elem.label }> of ${ trim(elem) }"
         ))
       }
     }

--- a/src/main/scala/nl.knaw.dans.easy.deposit/docs/DDM.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/docs/DDM.scala
@@ -69,7 +69,7 @@ object DDM extends SchemedXml with DebugEnhancedLogging {
         { dm.subjects.getNonEmpty.map(details(_, "subject", lang)) }
         { dm.temporalCoverages.getNonEmpty.map(details(_, "temporal", lang)) }
         { dm.spatialCoverages.getNonEmpty.map(details(_, "spatial", lang)) }
-        { dm.otherDates.map(date => <label xsi:type={ date.schemeAsString }>{ date.value.getOrElse("") }</label>.withLabel(date.qualifier.toString)) }
+        { dm.otherDates.map(date => <label xsi:type={ date.schemeAsString }>{ date.value.getOrElse("") }</label>.withLabel(date.qualifier)) }
         { dm.spatialPoints.getNonEmpty.map(point => <dcx-gml:spatial srsName={ point.srsName }>{ details(point) }</dcx-gml:spatial>) }
         { dm.spatialBoxes.getNonEmpty.map(point => <dcx-gml:spatial>{ details(point) }</dcx-gml:spatial>) }
         { dm.license.getNonEmpty.map(str => <dcterms:license>{ str }</dcterms:license>) /* xsi:type="dcterms:URI" not supported by json */ }
@@ -165,8 +165,18 @@ object DDM extends SchemedXml with DebugEnhancedLogging {
       str.split(":") match {
         case Array(label) => elem.copy(label = label)
         case Array(prefix, label) => elem.copy(prefix = prefix, label = label)
-        case a => throw invalidDatasetMetadataException(new Exception(
+        case a => throw invalidDatasetMetadataException(new IllegalArgumentException(
           s"expecting (label) or (prefix:label); got [${ a.mkString(":") }] to adjust the <${ elem.label }> of ${ trim(elem) }"
+        ))
+      }
+    }
+
+    def withLabel[T](someEnum: Option[T]): Elem = {
+      someEnum.map(_.toString.split(":")) match {
+        case Some(Array(label)) => elem.copy(label = label)
+        case Some(Array(prefix, label)) => elem.copy(prefix = prefix, label = label)
+        case a => throw invalidDatasetMetadataException(new IllegalArgumentException(
+          s"expecting Some(label) or Some(prefix:label); got [$a] to adjust the <${ elem.label }> of ${ trim(elem) }"
         ))
       }
     }

--- a/src/main/scala/nl.knaw.dans.easy.deposit/docs/DDM.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/docs/DDM.scala
@@ -51,8 +51,8 @@ object DDM extends SchemedXml with DebugEnhancedLogging {
         { dm.titles.getNonEmpty.map(src => <dc:title xml:lang={ lang }>{ src }</dc:title>) }
         { dm.descriptions.getNonEmpty.map(src => <dcterms:description xml:lang={ lang }>{ src }</dcterms:description>) }
         { dm.creators.getNonEmpty.map(author => <dcx-dai:creatorDetails>{ details(author, lang) }</dcx-dai:creatorDetails>) }
-        { dm.datesCreated.map(src => <ddm:created>{ src.value }</ddm:created>) }
-        { dm.datesAvailable.map(src => <ddm:available>{ src.value }</ddm:available>) }
+        { dm.datesCreated.map(src => <ddm:created>{ src.value.getOrElse("") }</ddm:created>) }
+        { dm.datesAvailable.map(src => <ddm:available>{ src.value.getOrElse("") }</ddm:available>) }
         { dm.audiences.getNonEmpty.map(src => <ddm:audience>{ src.key }</ddm:audience>) }
         { dm.accessRights.toSeq.map(src => <ddm:accessRights>{ src.category.toString }</ddm:accessRights>) }
       </ddm:profile>
@@ -69,7 +69,7 @@ object DDM extends SchemedXml with DebugEnhancedLogging {
         { dm.subjects.getNonEmpty.map(details(_, "subject", lang)) }
         { dm.temporalCoverages.getNonEmpty.map(details(_, "temporal", lang)) }
         { dm.spatialCoverages.getNonEmpty.map(details(_, "spatial", lang)) }
-        { dm.otherDates.map(date => <label xsi:type={ date.schemeAsString }>{ date.value }</label>.withLabel(date.qualifier.toString)) }
+        { dm.otherDates.map(date => <label xsi:type={ date.schemeAsString }>{ date.value.getOrElse("") }</label>.withLabel(date.qualifier.toString)) }
         { dm.spatialPoints.getNonEmpty.map(point => <dcx-gml:spatial srsName={ point.srsName }>{ details(point) }</dcx-gml:spatial>) }
         { dm.spatialBoxes.getNonEmpty.map(point => <dcx-gml:spatial>{ details(point) }</dcx-gml:spatial>) }
         { dm.license.getNonEmpty.map(str => <dcterms:license>{ str }</dcterms:license>) /* xsi:type="dcterms:URI" not supported by json */ }

--- a/src/main/scala/nl.knaw.dans.easy.deposit/docs/DatasetMetadata.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/docs/DatasetMetadata.scala
@@ -67,11 +67,11 @@ case class DatasetMetadata(private val identifiers: Option[Seq[SchemedValue]] = 
                                                  else Failure(missingValue("AcceptDepositAgreement"))
 
   //// dates
-  private val specialDateQualifiers = Seq(DateQualifier.created, DateQualifier.available)
+  private val specialDateQualifiers = Seq(DateQualifier.created, DateQualifier.available).map(Some(_))
   private val (specialDates, plainDates) = dates.toSeq.flatten
     .partition(date => specialDateQualifiers.contains(date.qualifier))
   val (datesCreated, datesAvailable) = specialDates
-    .partition(_.qualifier == DateQualifier.created)
+    .partition(_.qualifier.contains(DateQualifier.created))
   val otherDates: Seq[Date] = plainDates :+ dateSubmitted()
   // N.B: with lazy values JsonUtil.deserialize would not throw exceptions
   notAllowed(DateQualifier.dateSubmitted, plainDates)

--- a/src/main/scala/nl.knaw.dans.easy.deposit/docs/JsonUtil.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/docs/JsonUtil.scala
@@ -121,7 +121,7 @@ object JsonUtil {
     private def rejectNotExpectedContent[T](parsed: JValue, extracted: T): Try[Unit] = {
       decompose(extracted) diff parsed match {
         case Diff(_, JNothing, _) => Success(())
-        case Diff(_, ignored, _) => Failure(new Exception(s"don't recognize ${ write(ignored) }"))
+        case Diff(_, ignored, _) => Failure(new IllegalArgumentException(s"don't recognize ${ write(ignored) }"))
       }
     }
 

--- a/src/main/scala/nl.knaw.dans.easy.deposit/docs/dm/Date.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/docs/dm/Date.scala
@@ -50,7 +50,7 @@ case class Date(
 }
 
 object Date {
-  def dateSubmitted(): Date = Date(
+  private def dateSubmitted: Date = Date(
     Some(DateScheme.W3CDTF.toString),
     Some(DateTime.now().toString(ISODateTimeFormat.date())),
     Some(DateQualifier.dateSubmitted)
@@ -62,7 +62,7 @@ object Date {
      */
     private[docs] def separate = {
       dates.getOrElse(Seq.empty)
-        .foldLeft((Option.empty[Date], Option.empty[Date], Seq(dateSubmitted()))) {
+        .foldLeft((Option.empty[Date], Option.empty[Date], Seq(dateSubmitted))) {
           // @formatter:off
           case ((_,           _,             _     ),      Date(_, _, Some(q@DateQualifier.dateSubmitted))) => invalidQualifier(q)
           case ((None,        dateAvailable, others), date@Date(_, _, Some(  DateQualifier.created))      ) => (Some(date),  dateAvailable, others)

--- a/src/main/scala/nl.knaw.dans.easy.deposit/docs/dm/Date.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/docs/dm/Date.scala
@@ -42,17 +42,15 @@ object DateScheme extends Enumeration {
 case class Date(
                  override val scheme: Option[String],
                  value: Option[String],
-                 qualifier: DateQualifier,
+                 qualifier: Option[DateQualifier],
                ) extends PossiblySchemed with Requirements {
-  requireNonEmptyString(value)
-  requireNonEmptyString(value)
 }
 
 object Date {
   def dateSubmitted(): Date = Date(
     Some(DateScheme.W3CDTF.toString),
     Some(DateTime.now().toString(ISODateTimeFormat.date())),
-    DateQualifier.dateSubmitted
+    Some(DateQualifier.dateSubmitted)
   )
 
   def atMostOne(dates: Seq[Date]): Unit = {
@@ -60,6 +58,6 @@ object Date {
   }
 
   def notAllowed(qualifier: DateQualifier, dates: Seq[Date]): Unit = {
-    require(!dates.exists(_.qualifier == qualifier), s"No $qualifier allowed; got ${ toJson(dates) }")
+    require(!dates.exists(_.qualifier.contains(qualifier)), s"No $qualifier allowed; got ${ toJson(dates) }")
   }
 }

--- a/src/main/scala/nl.knaw.dans.easy.deposit/docs/dm/Date.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/docs/dm/Date.scala
@@ -15,11 +15,14 @@
  */
 package nl.knaw.dans.easy.deposit.docs.dm
 
+import javax.xml.validation.Schema
 import nl.knaw.dans.easy.deposit.docs.DatasetMetadata.PossiblySchemed
 import nl.knaw.dans.easy.deposit.docs.JsonUtil.toJson
 import nl.knaw.dans.easy.deposit.docs.dm.DateQualifier.DateQualifier
 import org.joda.time.DateTime
 import org.joda.time.format.ISODateTimeFormat
+
+import scala.util.Try
 
 object DateQualifier extends Enumeration {
   type DateQualifier = Value
@@ -53,11 +56,30 @@ object Date {
     Some(DateQualifier.dateSubmitted)
   )
 
-  def atMostOne(dates: Seq[Date]): Unit = {
-    require(dates.size <= 1, s"At most one allowed; got ${ toJson(dates) }")
-  }
+  implicit class DatesExtension(val dates: Option[Seq[Date]]) extends AnyVal {
+    /**
+     * @return (dateCreated, dateAvailable, plainDates)
+     */
+    private[docs] def separate = {
+      dates.getOrElse(Seq.empty)
+        .foldLeft((Option.empty[Date], Option.empty[Date], Seq(dateSubmitted()))) {
+          // @formatter:off
+          case ((_,           _,             _     ),      Date(_, _, Some(q@DateQualifier.dateSubmitted))) => invalidQualifier(q)
+          case ((None,        dateAvailable, others), date@Date(_, _, Some(  DateQualifier.created))      ) => (Some(date),  dateAvailable, others)
+          case ((Some(dc),    _,             _     ), date@Date(_, _, Some(  DateQualifier.created))      ) => duplicateDates(Seq(dc, date))
+          case ((dateCreated, None,          others), date@Date(_, _, Some(  DateQualifier.available))    ) => (dateCreated, Some(date),    others)
+          case ((_,           Some(da),      _     ), date@Date(_, _, Some(  DateQualifier.available))    ) => duplicateDates(Seq(da, date))
+          case ((dateCreated, dateAvailable, others), date@Date(_, _, _)                                  ) => (dateCreated, dateAvailable, others :+ date)
+          // @formatter:on
+        }
+    }
 
-  def notAllowed(qualifier: DateQualifier, dates: Seq[Date]): Unit = {
-    require(!dates.exists(_.qualifier.contains(qualifier)), s"No $qualifier allowed; got ${ toJson(dates) }")
+    private def duplicateDates(dates: Seq[Date]) = {
+      throw new IllegalArgumentException(s"requirement failed: At most one allowed; got ${ toJson(dates) }")
+    }
+
+    private def invalidQualifier(q: DateQualifier) = {
+      throw new IllegalArgumentException(s"requirement failed: No $q allowed; got ${ toJson(dates) }")
+    }
   }
 }

--- a/src/main/scala/nl.knaw.dans.easy.deposit/docs/dm/Date.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/docs/dm/Date.scala
@@ -41,7 +41,7 @@ object DateScheme extends Enumeration {
 
 case class Date(
                  override val scheme: Option[String],
-                 value: String,
+                 value: Option[String],
                  qualifier: DateQualifier,
                ) extends PossiblySchemed with Requirements {
   requireNonEmptyString(value)
@@ -51,7 +51,7 @@ case class Date(
 object Date {
   def dateSubmitted(): Date = Date(
     Some(DateScheme.W3CDTF.toString),
-    DateTime.now().toString(ISODateTimeFormat.date()),
+    Some(DateTime.now().toString(ISODateTimeFormat.date())),
     DateQualifier.dateSubmitted
   )
 

--- a/src/test/resources/logback.xml
+++ b/src/test/resources/logback.xml
@@ -12,7 +12,7 @@
     </root>
 
     <!-- Set log level during test with system property, e.g., mvn test -DLOG_LEVEL=debug -->
-    <logger name="nl.knaw.dans.easy" level="${LOG_LEVEL:-off}" />
-    <logger name="org.scalatest" level="info" />
+    <logger name="nl.knaw.dans.easy" level="trace"/>
+    <logger name="org.scalatest" level="info"/>
 
 </configuration>

--- a/src/test/resources/logback.xml
+++ b/src/test/resources/logback.xml
@@ -12,7 +12,7 @@
     </root>
 
     <!-- Set log level during test with system property, e.g., mvn test -DLOG_LEVEL=debug -->
-    <logger name="nl.knaw.dans.easy" level="trace"/>
-    <logger name="org.scalatest" level="info"/>
+    <logger name="nl.knaw.dans.easy" level="${LOG_LEVEL:-off}" />
+    <logger name="org.scalatest" level="info" />
 
 </configuration>

--- a/src/test/scala/nl.knaw.dans.easy.deposit/docs/DDMSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/docs/DDMSpec.scala
@@ -205,7 +205,7 @@ class DDMSpec extends TestSupportFixture with DdmBehavior {
     val date = "2018-06-14"
     val dates = DateQualifier.values.toSeq
       .withFilter(_ != DateQualifier.dateSubmitted)
-      .map { qualifier => Date(Some(W3CDTF.toString), date, qualifier) }
+      .map { qualifier => Date(Some(W3CDTF.toString), Some(date), qualifier) }
     validDatasetMetadata(
       input = Try(new MinimalDatasetMetadata(dates = Some(dates))),
       subset = actualDDM => dcmiMetadata(actualDDM),
@@ -225,21 +225,21 @@ class DDMSpec extends TestSupportFixture with DdmBehavior {
     )
   }
 
-  private val dateAvailable2018 = Date(scheme = None, value = "2018", DateQualifier.available)
+  private val dateAvailable2018 = Date(scheme = None, value = Some("2018"), DateQualifier.available)
   "minimal with various types of dates" should behave like {
     // with and without qualifier, varying precision
     val dates = Some(Seq(
-      Date(scheme = None, value = "2018", DateQualifier.created),
+      Date(scheme = None, value = Some("2018"), DateQualifier.created),
       dateAvailable2018,
-      Date(scheme = None, value = "Groundhog day", DateQualifier.dateAccepted),
-      Date(scheme = None, value = "Groundhog day", DateQualifier.dateCopyrighted),
-      Date(scheme = None, value = "Groundhog day", DateQualifier.issued),
-      Date(scheme = None, value = "Groundhog day", DateQualifier.modified),
-      Date(scheme = None, value = "Groundhog day", DateQualifier.valid),
-      Date(scheme = Some(W3CDTF.toString), value = "2018", DateQualifier.valid),
-      Date(scheme = Some(W3CDTF.toString), value = "2018-12", DateQualifier.valid),
-      Date(scheme = Some(W3CDTF.toString), value = "2018-12-09T08:15:30-05:00", DateQualifier.valid),
-      Date(scheme = Some(W3CDTF.toString), value = "2018-12-09T13:15:30Z", DateQualifier.valid),
+      Date(scheme = None, value = Some("Groundhog day"), DateQualifier.dateAccepted),
+      Date(scheme = None, value = Some("Groundhog day"), DateQualifier.dateCopyrighted),
+      Date(scheme = None, value = Some("Groundhog day"), DateQualifier.issued),
+      Date(scheme = None, value = Some("Groundhog day"), DateQualifier.modified),
+      Date(scheme = None, value = Some("Groundhog day"), DateQualifier.valid),
+      Date(scheme = Some(W3CDTF.toString), value = Some("2018"), DateQualifier.valid),
+      Date(scheme = Some(W3CDTF.toString), value = Some("2018-12"), DateQualifier.valid),
+      Date(scheme = Some(W3CDTF.toString), value = Some("2018-12-09T08:15:30-05:00"), DateQualifier.valid),
+      Date(scheme = Some(W3CDTF.toString), value = Some("2018-12-09T13:15:30Z"), DateQualifier.valid),
     ))
     validDatasetMetadata(
       input = Try(new MinimalDatasetMetadata(dates = dates)),
@@ -263,7 +263,7 @@ class DDMSpec extends TestSupportFixture with DdmBehavior {
 
   "MinimalDatasetMetadata" should "fail when given a dateTimeFormat with little z for zone" in {
     val invalidDates = Some(Seq(
-      Date(scheme = Some(W3CDTF.toString), value = "2018-12-09T13:15:30z", DateQualifier.created), // small z for zone is not valid
+      Date(scheme = Some(W3CDTF.toString), value = Some("2018-12-09T13:15:30z"), DateQualifier.created), // small z for zone is not valid
       dateAvailable2018,
     ))
     new MinimalDatasetMetadata(dates = invalidDates)
@@ -272,7 +272,7 @@ class DDMSpec extends TestSupportFixture with DdmBehavior {
 
   it should "fail when given a dateTimeFormat with zone, where zone part is without a semi colon" in {
     val invalidDates = Some(Seq(
-      Date(scheme = Some(W3CDTF.toString), value = "2018-12-09T13:15:30+1000", DateQualifier.created), // small z for zone is not valid
+      Date(scheme = Some(W3CDTF.toString), value = Some("2018-12-09T13:15:30+1000"), DateQualifier.created), // small z for zone is not valid
       dateAvailable2018,
     ))
     new MinimalDatasetMetadata(dates = invalidDates)
@@ -281,7 +281,7 @@ class DDMSpec extends TestSupportFixture with DdmBehavior {
 
   it should "fail when give a dateTimeFormat with zone, where zone part is without minutes" in {
     val invalidDates = Some(Seq(
-      Date(scheme = Some(W3CDTF.toString), value = "2018-12-09T13:15:30-05", DateQualifier.created), // small z for zone is not valid
+      Date(scheme = Some(W3CDTF.toString), value = Some("2018-12-09T13:15:30-05"), DateQualifier.created), // small z for zone is not valid
       dateAvailable2018,
     ))
     new MinimalDatasetMetadata(dates = invalidDates)

--- a/src/test/scala/nl.knaw.dans.easy.deposit/docs/DDMSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/docs/DDMSpec.scala
@@ -205,7 +205,7 @@ class DDMSpec extends TestSupportFixture with DdmBehavior {
     val date = "2018-06-14"
     val dates = DateQualifier.values.toSeq
       .withFilter(_ != DateQualifier.dateSubmitted)
-      .map { qualifier => Date(Some(W3CDTF.toString), Some(date), qualifier) }
+      .map { qualifier => Date(Some(W3CDTF.toString), Some(date), Some(qualifier)) }
     validDatasetMetadata(
       input = Try(new MinimalDatasetMetadata(dates = Some(dates))),
       subset = actualDDM => dcmiMetadata(actualDDM),
@@ -225,21 +225,21 @@ class DDMSpec extends TestSupportFixture with DdmBehavior {
     )
   }
 
-  private val dateAvailable2018 = Date(scheme = None, value = Some("2018"), DateQualifier.available)
+  private val dateAvailable2018 = Date(scheme = None, value = Some("2018"), Some(DateQualifier.available))
   "minimal with various types of dates" should behave like {
     // with and without qualifier, varying precision
     val dates = Some(Seq(
-      Date(scheme = None, value = Some("2018"), DateQualifier.created),
+      Date(scheme = None, value = Some("2018"), Some(DateQualifier.created)),
       dateAvailable2018,
-      Date(scheme = None, value = Some("Groundhog day"), DateQualifier.dateAccepted),
-      Date(scheme = None, value = Some("Groundhog day"), DateQualifier.dateCopyrighted),
-      Date(scheme = None, value = Some("Groundhog day"), DateQualifier.issued),
-      Date(scheme = None, value = Some("Groundhog day"), DateQualifier.modified),
-      Date(scheme = None, value = Some("Groundhog day"), DateQualifier.valid),
-      Date(scheme = Some(W3CDTF.toString), value = Some("2018"), DateQualifier.valid),
-      Date(scheme = Some(W3CDTF.toString), value = Some("2018-12"), DateQualifier.valid),
-      Date(scheme = Some(W3CDTF.toString), value = Some("2018-12-09T08:15:30-05:00"), DateQualifier.valid),
-      Date(scheme = Some(W3CDTF.toString), value = Some("2018-12-09T13:15:30Z"), DateQualifier.valid),
+      Date(scheme = None, value = Some("Groundhog day"), Some(DateQualifier.dateAccepted)),
+      Date(scheme = None, value = Some("Groundhog day"), Some(DateQualifier.dateCopyrighted)),
+      Date(scheme = None, value = Some("Groundhog day"), Some(DateQualifier.issued)),
+      Date(scheme = None, value = Some("Groundhog day"), Some(DateQualifier.modified)),
+      Date(scheme = None, value = Some("Groundhog day"), Some(DateQualifier.valid)),
+      Date(scheme = Some(W3CDTF.toString), value = Some("2018"), Some(DateQualifier.valid)),
+      Date(scheme = Some(W3CDTF.toString), value = Some("2018-12"), Some(DateQualifier.valid)),
+      Date(scheme = Some(W3CDTF.toString), value = Some("2018-12-09T08:15:30-05:00"), Some(DateQualifier.valid)),
+      Date(scheme = Some(W3CDTF.toString), value = Some("2018-12-09T13:15:30Z"), Some(DateQualifier.valid)),
     ))
     validDatasetMetadata(
       input = Try(new MinimalDatasetMetadata(dates = dates)),
@@ -263,7 +263,7 @@ class DDMSpec extends TestSupportFixture with DdmBehavior {
 
   "MinimalDatasetMetadata" should "fail when given a dateTimeFormat with little z for zone" in {
     val invalidDates = Some(Seq(
-      Date(scheme = Some(W3CDTF.toString), value = Some("2018-12-09T13:15:30z"), DateQualifier.created), // small z for zone is not valid
+      Date(scheme = Some(W3CDTF.toString), value = Some("2018-12-09T13:15:30z"), Some(DateQualifier.created)), // small z for zone is not valid
       dateAvailable2018,
     ))
     new MinimalDatasetMetadata(dates = invalidDates)
@@ -272,7 +272,7 @@ class DDMSpec extends TestSupportFixture with DdmBehavior {
 
   it should "fail when given a dateTimeFormat with zone, where zone part is without a semi colon" in {
     val invalidDates = Some(Seq(
-      Date(scheme = Some(W3CDTF.toString), value = Some("2018-12-09T13:15:30+1000"), DateQualifier.created), // small z for zone is not valid
+      Date(scheme = Some(W3CDTF.toString), value = Some("2018-12-09T13:15:30+1000"), Some(DateQualifier.created)), // small z for zone is not valid
       dateAvailable2018,
     ))
     new MinimalDatasetMetadata(dates = invalidDates)
@@ -281,7 +281,7 @@ class DDMSpec extends TestSupportFixture with DdmBehavior {
 
   it should "fail when give a dateTimeFormat with zone, where zone part is without minutes" in {
     val invalidDates = Some(Seq(
-      Date(scheme = Some(W3CDTF.toString), value = Some("2018-12-09T13:15:30-05"), DateQualifier.created), // small z for zone is not valid
+      Date(scheme = Some(W3CDTF.toString), value = Some("2018-12-09T13:15:30-05"), Some(DateQualifier.created)), // small z for zone is not valid
       dateAvailable2018,
     ))
     new MinimalDatasetMetadata(dates = invalidDates)

--- a/src/test/scala/nl.knaw.dans.easy.deposit/docs/DDMSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/docs/DDMSpec.scala
@@ -156,7 +156,7 @@ class DDMSpec extends TestSupportFixture with DdmBehavior {
       ids = Some(Seq(SchemedValue("dcx-dai:ISNI", "ISNI:000000012281955X")))
     )
     new MinimalDatasetMetadata(contributors = Some(Seq(author))).causesInvalidDocumentException(
-      "expecting (label) or (prefix:label); got [dcx-dai:dcx-dai:ISNI] to adjust the <label> of <label>ISNI:000000012281955X</label>"
+      "expecting (label) or (prefix:label); got [Some(dcx-dai:dcx-dai:ISNI)] to adjust the <label> of <label>ISNI:000000012281955X</label>"
     )
   }
 

--- a/src/test/scala/nl.knaw.dans.easy.deposit/docs/DDMSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/docs/DDMSpec.scala
@@ -214,13 +214,13 @@ class DDMSpec extends TestSupportFixture with DdmBehavior {
         // dateCreated and dateAvailable are documented with the pure minimal test
         <ddm:dcmiMetadata>
           <dcterms:identifier xsi:type="id-type:DOI">mocked-DOI</dcterms:identifier>
+          <dcterms:dateSubmitted xsi:type="dcterms:W3CDTF">2018-03-22</dcterms:dateSubmitted>
           <dc:date xsi:type="dcterms:W3CDTF">{ date }</dc:date>
           <dcterms:dateAccepted xsi:type="dcterms:W3CDTF">{ date }</dcterms:dateAccepted>
           <dcterms:dateCopyrighted xsi:type="dcterms:W3CDTF">{ date }</dcterms:dateCopyrighted>
           <dcterms:issued xsi:type="dcterms:W3CDTF">{ date }</dcterms:issued>
           <dcterms:modified xsi:type="dcterms:W3CDTF">{ date }</dcterms:modified>
           <dcterms:valid xsi:type="dcterms:W3CDTF">{ date }</dcterms:valid>
-          <dcterms:dateSubmitted xsi:type="dcterms:W3CDTF">2018-03-22</dcterms:dateSubmitted>
         </ddm:dcmiMetadata>
     )
   }
@@ -247,6 +247,7 @@ class DDMSpec extends TestSupportFixture with DdmBehavior {
       expectedDdmContent =
         <ddm:dcmiMetadata>
           <dcterms:identifier xsi:type="id-type:DOI">mocked-DOI</dcterms:identifier>
+          <dcterms:dateSubmitted xsi:type="dcterms:W3CDTF">{ nowYMD }</dcterms:dateSubmitted>
           <dcterms:dateAccepted>Groundhog day</dcterms:dateAccepted>
           <dcterms:dateCopyrighted>Groundhog day</dcterms:dateCopyrighted>
           <dcterms:issued>Groundhog day</dcterms:issued>
@@ -256,7 +257,6 @@ class DDMSpec extends TestSupportFixture with DdmBehavior {
           <dcterms:valid xsi:type="dcterms:W3CDTF">2018-12</dcterms:valid>
           <dcterms:valid xsi:type="dcterms:W3CDTF">2018-12-09T08:15:30-05:00</dcterms:valid>
           <dcterms:valid xsi:type="dcterms:W3CDTF">2018-12-09T13:15:30Z</dcterms:valid>
-          <dcterms:dateSubmitted xsi:type="dcterms:W3CDTF">{ nowYMD }</dcterms:dateSubmitted>
         </ddm:dcmiMetadata>
     )
   }
@@ -538,11 +538,11 @@ class DDMSpec extends TestSupportFixture with DdmBehavior {
         <dcterms:spatial xsi:type="dcterms:ISO3166">NLD</dcterms:spatial>
         <dcterms:spatial xml:lang="nld">Haringvliet</dcterms:spatial>
         <dcterms:spatial xml:lang="nld">Grevelingenmeer</dcterms:spatial>
+        <dcterms:dateSubmitted xsi:type="dcterms:W3CDTF">2018-03-22</dcterms:dateSubmitted>
         <dcterms:dateCopyrighted xsi:type="dcterms:W3CDTF">2018-03-18</dcterms:dateCopyrighted>
         <dcterms:valid xsi:type="dcterms:W3CDTF">2018-03-17</dcterms:valid>
         <dcterms:modified>2018-02-02</dcterms:modified>
         <dcterms:issued>Groundhog day</dcterms:issued>
-        <dcterms:dateSubmitted xsi:type="dcterms:W3CDTF">2018-03-22</dcterms:dateSubmitted>
         <dcx-gml:spatial srsName="http://www.opengis.net/def/crs/EPSG/0/28992">
           <Point xmlns="http://www.opengis.net/gml">
             <pos>12 34</pos>

--- a/src/test/scala/nl.knaw.dans.easy.deposit/docs/DDMSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/docs/DDMSpec.scala
@@ -156,7 +156,7 @@ class DDMSpec extends TestSupportFixture with DdmBehavior {
       ids = Some(Seq(SchemedValue("dcx-dai:ISNI", "ISNI:000000012281955X")))
     )
     new MinimalDatasetMetadata(contributors = Some(Seq(author))).causesInvalidDocumentException(
-      "expecting (label) or (prefix:label); got [Some(dcx-dai:dcx-dai:ISNI)] to adjust the <label> of <label>ISNI:000000012281955X</label>"
+      "expecting (label) or (prefix:label); got [dcx-dai:dcx-dai:ISNI] to adjust the <label> of <label>ISNI:000000012281955X</label>"
     )
   }
 

--- a/src/test/scala/nl.knaw.dans.easy.deposit/docs/DatasetMetadataSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/docs/DatasetMetadataSpec.scala
@@ -117,13 +117,12 @@ class DatasetMetadataSpec extends TestSupportFixture {
     )
   }
 
-  it should "reject multiple dates created" in {
-    """{ "dates": [
-      |   { "value": "2018", "qualifier": "dcterms:created" },
-      |   { "value": "2017", "qualifier": "dcterms:created" },
-      | ]
-      |}""".stripMargin
-      .causesInvalidDocumentException("""requirement failed: At most one allowed; got [{"value":"2018","qualifier":"dcterms:created"},{"value":"2017","qualifier":"dcterms:created"}]""")
+  "DatasetMetadata.dates" should "accept a date without a scheme" in {
+    val s: JsonInput =
+      """{"dates": [
+        |   { "value": "2018", "qualifier": "dcterms:created" },
+        |]}""".stripMargin
+    DatasetMetadata(s) shouldBe a[Success[_]]
   }
 
   "DatasetMetadata.relations" should "accept complete relations" in {
@@ -212,20 +211,6 @@ class DatasetMetadataSpec extends TestSupportFixture {
 
   it should "accept an organisation as author" in {
     DatasetMetadata("""{ "contributors": [ { "organization": "University of Zurich" } ] }""") shouldBe a[Success[_]]
-  }
-
-  "DatasetMetadata.dates" should "reject dcterms:dateSubmitted" in {
-    """{"dates": [{ "qualifier": "dcterms:dateSubmitted", "value": "2018-12", "scheme": "dcterms:W3CDTF" }]}"""
-      .causesInvalidDocumentException("""requirement failed: No dcterms:dateSubmitted allowed; got [{"scheme":"dcterms:W3CDTF","value":"2018-12","qualifier":"dcterms:dateSubmitted"}]""")
-  }
-
-  it should "reject multiple dcterms:available" in {
-    """{"dates": [
-      |  { "qualifier": "dcterms:available", "value": "2018", "scheme": "dcterms:W3CDTF" },
-      |  { "qualifier": "dcterms:available", "value": "2018-12", "scheme": "dcterms:W3CDTF" },
-      |  { "qualifier": "dcterms:created", "value": "2018-12", "scheme": "dcterms:W3CDTF" },
-      |]}""".stripMargin
-      .causesInvalidDocumentException("""requirement failed: At most one allowed; got [{"scheme":"dcterms:W3CDTF","value":"2018","qualifier":"dcterms:available"},{"scheme":"dcterms:W3CDTF","value":"2018-12","qualifier":"dcterms:available"}]""")
   }
 
   "DatasetMetadata.audience" should "reject an audience without a scheme" in {

--- a/src/test/scala/nl.knaw.dans.easy.deposit/docs/MinimalDatasetMetadata.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/docs/MinimalDatasetMetadata.scala
@@ -44,8 +44,8 @@ class MinimalDatasetMetadata(
                               relations: Option[Seq[RelationType]] = None,
                               languagesOfFiles: Option[Seq[PossiblySchemedKeyValue]] = None,
                               dates: Option[Seq[Date]] = Some(Seq(
-                                Date(scheme = Some(W3CDTF.toString), value = "2018", DateQualifier.created),
-                                Date(scheme = Some(W3CDTF.toString), value = "2018", DateQualifier.available)
+                                Date(scheme = Some(W3CDTF.toString), value = Some("2018"), DateQualifier.created),
+                                Date(scheme = Some(W3CDTF.toString), value = Some("2018"), DateQualifier.available)
                               )),
                               sources: Option[Seq[String]] = None,
                               instructionsForReuse: Option[Seq[String]] = None,

--- a/src/test/scala/nl.knaw.dans.easy.deposit/docs/MinimalDatasetMetadata.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/docs/MinimalDatasetMetadata.scala
@@ -44,8 +44,8 @@ class MinimalDatasetMetadata(
                               relations: Option[Seq[RelationType]] = None,
                               languagesOfFiles: Option[Seq[PossiblySchemedKeyValue]] = None,
                               dates: Option[Seq[Date]] = Some(Seq(
-                                Date(scheme = Some(W3CDTF.toString), value = Some("2018"), DateQualifier.created),
-                                Date(scheme = Some(W3CDTF.toString), value = Some("2018"), DateQualifier.available)
+                                Date(scheme = Some(W3CDTF.toString), value = Some("2018"), Some(DateQualifier.created)),
+                                Date(scheme = Some(W3CDTF.toString), value = Some("2018"), Some(DateQualifier.available))
                               )),
                               sources: Option[Seq[String]] = None,
                               instructionsForReuse: Option[Seq[String]] = None,

--- a/src/test/scala/nl.knaw.dans.easy.deposit/servlets/ValidationSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/servlets/ValidationSpec.scala
@@ -248,13 +248,27 @@ class ValidationSpec extends DepositServletFixture {
     DDM(parseIntoValidForSubmit(
       """{
         |  "dates": [
-        |    { "scheme": "dcterms:W3CDTF", "qualifier": "dcterms:available" },
+        |    { "scheme": "dcterms:W3CDTF", "value": "    ", "qualifier": "dcterms:available" },
         |    { "scheme": "dcterms:W3CDTF", "value": "2018-05-31", "qualifier": "dcterms:created" },
         |  ],
         |}""".stripMargin)
     ) should matchPattern {
       case Failure(InvalidDocumentException("DatasetMetadata", cause: SAXParseException))
-        if cause.getMessage.contains("""'' is not a valid value of union type '#AnonType_W3CDTF'""") =>
+        if cause.getMessage.contains("""' ' is not a valid value of union type '#AnonType_W3CDTF'""") =>
+    }
+  }
+
+  it should "fail with a date without a qualifier" in {
+    DDM(parseIntoValidForSubmit(
+      """{"dates": [
+        |  { "scheme": "dcterms:W3CDTF", "value": "2018-05-31", "qualifier": "dcterms:available" },
+        |  { "scheme": "dcterms:W3CDTF", "value": "2018-05-31", "qualifier": "dcterms:created" },
+        |  { "scheme": "dcterms:W3CDTF", "value": "2018-05-31" },
+        |]}""".stripMargin
+    )) should matchPattern {
+      case Failure(InvalidDocumentException("DatasetMetadata", cause: IllegalArgumentException))
+        if cause.getMessage.contains("""got [None] to adjust the <label> of <label """) &&
+          cause.getMessage.endsWith(""">2018-05-31</label>""") =>
     }
   }
 
@@ -293,7 +307,8 @@ class ValidationSpec extends DepositServletFixture {
   }
 
   it should "fail with an invalid enum value" in {
-    // assuming this behaviour for all fields with one of JsonUtil.enumerations
+    // assuming this behaviour for all fields with one of JsonUtil.enumerations in an Option
+    // While DateQualifier was not within an option the complete list of dates was reported as not recognized
     DatasetMetadata(
       """{"dates": [
         |  { "scheme": "dcterms:W3CDTF", "value": "2018-05-31", "qualifier": "dcterms:submitted" },
@@ -301,10 +316,7 @@ class ValidationSpec extends DepositServletFixture {
         |]}""".stripMargin
     ) should matchPattern {
       case Failure(InvalidDocumentException("DatasetMetadata", cause: IllegalArgumentException))
-        if cause.getMessage.startsWith("""don't recognize {"dates":[""") &&
-          cause.getMessage.contains("created") &&
-          cause.getMessage.contains("submitted") =>
-      // too bad JsonUtil.rejectNotExpectedContent doesn't specify which date is not recognized
+        if cause.getMessage == """don't recognize {"dates":{"qualifier":"dcterms:submitted"}}""" =>
     }
   }
 

--- a/src/test/scala/nl.knaw.dans.easy.deposit/servlets/ValidationSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/servlets/ValidationSpec.scala
@@ -63,9 +63,8 @@ class ValidationSpec extends DepositServletFixture {
   // Parsing json is part of PUT(metadata), creating a DDM object is part of PUT(submitted).
 
   it should "fail for an author with just a last name" in {
-    DDM(mandatoryOnSubmit.copy(
-      creators = parse("""{ "creators": [ { "surname": "Einstein", "initials": "  " }]}""").creators
-    )) should matchPattern {
+    DDM(parse("""{ "creators": [ { "surname": "Einstein", "initials": "  " }]}""")
+    ) should matchPattern {
       case Failure(InvalidDocumentException("DatasetMetadata", cause: SAXParseException))
         if cause.getMessage.contains("'dcx-dai:author' is not complete")
           && cause.getLineNumber == 8 =>
@@ -74,54 +73,49 @@ class ValidationSpec extends DepositServletFixture {
   }
 
   it should "fail for an author with just initials" in {
-    DDM(mandatoryOnSubmit.copy(
-      creators = parse("""{ "creators": [ { "surname": "  ", "initials": "A" }]}""").creators
-    )) should matchPattern {
+    DDM(parse("""{ "creators": [ { "surname": "  ", "initials": "A" }]}""")
+    ) should matchPattern {
       case Failure(InvalidDocumentException("DatasetMetadata", cause: SAXParseException))
         if cause.getMessage.contains("'dcx-dai:creatorDetails' is not complete") =>
     }
   }
 
   it should "fail without creators" in {
-    DDM(mandatoryOnSubmit.copy(
-      creators = parse("""{ "creators": []}""").creators
-    )) should matchPattern {
+    DDM(parse("""{ "creators": []}""")
+    ) should matchPattern {
       case Failure(InvalidDocumentException("DatasetMetadata", cause: SAXParseException))
         if cause.getMessage.contains("Invalid content was found starting with element 'ddm:created'") =>
     }
   }
 
   it should "fail for an ID without schema" in pendingUntilFixed {
-    DDM(mandatoryOnSubmit.copy(
-      creators = parse(
+    DDM(parse(
         """{ "creators": [ {
           |  "initials": "A",
           |  "surname": "Einstein",
           |  "ids": [{ "scheme": "id-type:ORCID" }]
-          |}]}""".stripMargin).creators
-    )) should matchPattern {
+          |}]}""")
+    ) should matchPattern {
       case Failure(InvalidDocumentException("DatasetMetadata", cause: SAXParseException))
         if cause.getMessage.contains(" is not complete") =>
     }
   }
 
   it should "fail for an ID without a value" in pendingUntilFixed {
-    DDM(mandatoryOnSubmit.copy(
-      creators = parse(
+    DDM(parse(
         """{ "creators": [ {
           |  "initials": "A",
           |  "surname": "Einstein",
           |  "ids": [{ "value": "0000-0002-9079-593X" }]
-          |}]}""".stripMargin).creators
-    )) should matchPattern {
+          |}]}""")
+    ) should matchPattern {
       case Failure(InvalidDocumentException("DatasetMetadata", cause: SAXParseException))
         if cause.getMessage.contains(" is not complete") =>
     }
   }
 
   it should "fail for a role without a key" in pendingUntilFixed {
-    DDM(mandatoryOnSubmit.copy(
-      creators = parse(
+    DDM(parse(
         """{ "creators": [
           |  { "role": {
           |      "scheme": "datacite:contributorType",
@@ -129,16 +123,15 @@ class ValidationSpec extends DepositServletFixture {
           |    },
           |    "organization": "KNAW"
           |  }
-          |]}""".stripMargin).creators
-    )) should matchPattern {
+          |]}""")
+    ) should matchPattern {
       case Failure(InvalidDocumentException("DatasetMetadata", cause: SAXParseException))
         if cause.getMessage.contains(" is not complete") =>
     }
   }
 
   it should "fail for a role without a value" in pendingUntilFixed {
-    DDM(mandatoryOnSubmit.copy(
-      creators = parse(
+    DDM(parse(
         """{ "creators": [
           |  { "role": {
           |      "scheme": "datacite:contributorType",
@@ -146,16 +139,15 @@ class ValidationSpec extends DepositServletFixture {
           |    },
           |    "organization": "KNAW"
           |  }
-          |]}""".stripMargin).creators
-    )) should matchPattern {
+          |]}""")
+    ) should matchPattern {
       case Failure(InvalidDocumentException("DatasetMetadata", cause: SAXParseException))
         if cause.getMessage.contains(" is not complete") =>
     }
   }
 
   it should "fail for a role without a scheme " in pendingUntilFixed {
-    DDM(mandatoryOnSubmit.copy(
-      creators = parse(
+    DDM(parse(
         """{ "creators": [
           |  { "role": {
           |      "key": "RightsHolder",
@@ -163,16 +155,15 @@ class ValidationSpec extends DepositServletFixture {
           |    },
           |    "organization": "KNAW"
           |  }
-          |]}""".stripMargin).creators
-    )) should matchPattern {
+          |]}""")
+    ) should matchPattern {
       case Failure(InvalidDocumentException("DatasetMetadata", cause: SAXParseException))
         if cause.getMessage.contains("'dcx-dai:creatorDetails' is not complete") =>
     }
   }
 
   it should "fail for a rightsHolding creator with neither surname nor organisation" in {
-    DDM(mandatoryOnSubmit.copy(
-      creators = parse(
+    DDM(parse(
         """{ "creators": [
           |  { "role": {
           |      "scheme": "datacite:contributorType",
@@ -180,8 +171,8 @@ class ValidationSpec extends DepositServletFixture {
           |      "value": "Rights Holder"
           |    }
           |  }
-          |]}""".stripMargin).creators
-    )) should matchPattern {
+          |]}""")
+    ) should matchPattern {
       case Failure(InvalidDocumentException("DatasetMetadata", cause: SAXParseException))
         if cause.getMessage.contains("'dcx-dai:creatorDetails' is not complete") =>
     }
@@ -189,8 +180,7 @@ class ValidationSpec extends DepositServletFixture {
 
 
   it should "fail for a rightsHolding contributor with neither surname nor organisation" in {
-    DDM(mandatoryOnSubmit.copy(
-      contributors = parse(
+    DDM(parse(
         """{ "contributors": [
           |  { "role": {
           |      "scheme": "datacite:contributorType",
@@ -198,24 +188,23 @@ class ValidationSpec extends DepositServletFixture {
           |      "value": "Rights Holder"
           |    }
           |  }
-          |]}""".stripMargin).contributors
-    )) should matchPattern {
+          |]}""")
+    ) should matchPattern {
       case Failure(InvalidDocumentException("DatasetMetadata", cause: SAXParseException))
         if cause.getMessage.contains("'dcx-dai:contributorDetails' is not complete") =>
     }
   }
 
   it should "fail for organisations with insertions and/or titles" in {
-    DDM(mandatoryOnSubmit.copy(
-      creators = parse(
+    DDM(parse(
         """{ "creators": [
           |  { "titles": "Baron", "insertions": "van", "organization": "Nyenrode" },
           |  { "organization": "Harvard", "insertions": "  ", "surname": "  " }
           |  { "titles": "Sir", "organization": "Oxbridge" }
           |  { "titles": "Mr" }
           |  { "insertions": "von", "organization": "ETH Zurich" },
-          |]}""".stripMargin).creators
-    )) should matchPattern {
+          |]}""")
+    ) should matchPattern {
       case Failure(InvalidDocumentException("DatasetMetadata", cause: IllegalArgumentException))
         if cause.getMessage == """An author without surname should have neither titles nor insertions, got: {"titles":"Baron","insertions":"van","organization":"Nyenrode"}, {"titles":"Sir","organization":"Oxbridge"}, {"titles":"Mr"}, {"insertions":"von","organization":"ETH Zurich"}""" =>
     }
@@ -228,13 +217,41 @@ class ValidationSpec extends DepositServletFixture {
 
   /**
    * @param input json object with metadata fragment under test
-   * @return To be injected into a valid-for-submission instance
-   * @throws TestFailedException when the test data can't be deserialized
+   * @return public option fields of parsed input injected into a valid-for-submission instance
+   * @throws TestFailedException when the input can't be parsed
    *                             and thus would be rejected by PUT(metadata).
    */
   private def parse(input: String): DatasetMetadata = {
-    DatasetMetadata(input)
+    val parsed = DatasetMetadata(input.stripMargin)
       .getOrRecover(e => fail(s"loading test data failed: ${ e.getMessage }; $input", e))
+
+    mandatoryOnSubmit.copy(
+      // (alternative)identifiers and types(DCMI) are private and thus not injectable
+      // but other fields have the same types to test validation
+      languageOfDescription = parsed.languageOfDescription orElse mandatoryOnSubmit.languageOfDescription,
+      titles = parsed.titles orElse mandatoryOnSubmit.titles,
+      alternativeTitles = parsed.alternativeTitles orElse mandatoryOnSubmit.alternativeTitles,
+      descriptions = parsed.descriptions orElse mandatoryOnSubmit.descriptions,
+      creators = parsed.creators orElse mandatoryOnSubmit.creators,
+      contributors = parsed.contributors orElse mandatoryOnSubmit.contributors,
+      audiences = parsed.audiences orElse mandatoryOnSubmit.audiences,
+      subjects = parsed.subjects orElse mandatoryOnSubmit.subjects,
+      relations = parsed.relations orElse mandatoryOnSubmit.relations,
+      languagesOfFiles = parsed.languagesOfFiles orElse mandatoryOnSubmit.languagesOfFiles,
+      // TODO dates are private and thus not injectable for testing
+      sources = parsed.sources orElse mandatoryOnSubmit.sources,
+      instructionsForReuse = parsed.instructionsForReuse orElse mandatoryOnSubmit.instructionsForReuse,
+      publishers = parsed.publishers orElse mandatoryOnSubmit.publishers,
+      accessRights = parsed.accessRights orElse mandatoryOnSubmit.accessRights,
+      license = parsed.license orElse mandatoryOnSubmit.license,
+      formats = parsed.formats orElse mandatoryOnSubmit.formats,
+      temporalCoverages = parsed.temporalCoverages orElse mandatoryOnSubmit.temporalCoverages,
+      spatialPoints = parsed.spatialPoints orElse mandatoryOnSubmit.spatialPoints,
+      spatialBoxes = parsed.spatialBoxes orElse mandatoryOnSubmit.spatialBoxes,
+      spatialCoverages = parsed.spatialCoverages orElse mandatoryOnSubmit.spatialCoverages,
+      messageForDataManager = parsed.messageForDataManager orElse mandatoryOnSubmit.messageForDataManager,
+      // privacySensitiveDataPresent and acceptDepositAgreement are not options and thus not injected
+    )
   }
 
   /** Tests inject parsed input into this object to check and document error reporting. */

--- a/src/test/scala/nl.knaw.dans.easy.deposit/servlets/ValidationSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/servlets/ValidationSpec.scala
@@ -267,7 +267,8 @@ class ValidationSpec extends DepositServletFixture {
         |]}""".stripMargin
     )) should matchPattern {
       case Failure(InvalidDocumentException("DatasetMetadata", cause: IllegalArgumentException))
-        if cause.getMessage.contains("""got [None] to adjust the <label> of <label """) &&
+        // TODO this means a missing qualifier!
+        if cause.getMessage.contains("""got [] to adjust the <label> of <label """) &&
           cause.getMessage.endsWith(""">2018-05-31</label>""") =>
     }
   }

--- a/src/test/scala/nl.knaw.dans.easy.deposit/servlets/ValidationSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/servlets/ValidationSpec.scala
@@ -131,6 +131,24 @@ class ValidationSpec extends DepositServletFixture {
     }
   }
 
+  it should "fail for a role with an invalid key" in {
+    // TODO what about invalid schema's?
+    DDM(parseIntoValidForSubmit(
+      """{ "creators": [
+        |  { "role": {
+        |      "scheme": "datacite:contributorType",
+        |      "key": "rabarbera"
+        |      "value": "Rights Holder"
+        |    },
+        |    "organization": "KNAW"
+        |  }
+        |]}""")
+    ) should matchPattern {
+      case Failure(InvalidDocumentException("DatasetMetadata", cause: SAXParseException))
+        if cause.getMessage.contains("Value 'rabarbera' is not facet-valid with respect to enumeration") =>
+    }
+  }
+
   it should "fail for a role without a value" in pendingUntilFixed {
     DDM(parseIntoValidForSubmit(
       """{ "creators": [

--- a/src/test/scala/nl.knaw.dans.easy.deposit/servlets/ValidationSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/servlets/ValidationSpec.scala
@@ -337,49 +337,47 @@ class ValidationSpec extends DepositServletFixture {
   /**
    * @param input json object with metadata fragment under test
    * @return option fields of parsed input injected into a valid-for-submission instance.
-   *         Either the provided private option fields are injected or
-   *         the provided public option fields are injected.
    * @throws TestFailedException when the input can't be parsed at all
    *                             and thus would be rejected by PUT(metadata).
    */
   private def parseIntoValidForSubmit(input: String): DatasetMetadata = {
+    val allParsedValues = DatasetMetadata(input.stripMargin)
+      .getOrRecover(e => fail(s"loading test data failed: ${ e.getMessage }; $input", e))
     new JsonUtil.RichJsonInput(input)
-      .deserialize[PrivateDatasetMetadataValues].map { parsed =>
-      mandatoryOnSubmit.copy(
-        identifiers = parsed.identifiers,
-        alternativeIdentifiers = parsed.alternativeIdentifiers,
-        dates = parsed.dates,
-        typesDcmi = parsed.typesDcmi,
-        types = parsed.types,
-      )
-    }.getOrElse {
-      val parsed = DatasetMetadata(input.stripMargin)
-        .getOrRecover(e => fail(s"loading test data failed: ${ e.getMessage }; $input", e))
-      mandatoryOnSubmit.copy(
-        languageOfDescription = parsed.languageOfDescription orElse mandatoryOnSubmit.languageOfDescription,
-        titles = parsed.titles orElse mandatoryOnSubmit.titles,
-        alternativeTitles = parsed.alternativeTitles orElse mandatoryOnSubmit.alternativeTitles,
-        descriptions = parsed.descriptions orElse mandatoryOnSubmit.descriptions,
-        creators = parsed.creators orElse mandatoryOnSubmit.creators,
-        contributors = parsed.contributors orElse mandatoryOnSubmit.contributors,
-        audiences = parsed.audiences orElse mandatoryOnSubmit.audiences,
-        subjects = parsed.subjects orElse mandatoryOnSubmit.subjects,
-        relations = parsed.relations orElse mandatoryOnSubmit.relations,
-        languagesOfFiles = parsed.languagesOfFiles orElse mandatoryOnSubmit.languagesOfFiles,
-        sources = parsed.sources orElse mandatoryOnSubmit.sources,
-        instructionsForReuse = parsed.instructionsForReuse orElse mandatoryOnSubmit.instructionsForReuse,
-        publishers = parsed.publishers orElse mandatoryOnSubmit.publishers,
-        accessRights = parsed.accessRights orElse mandatoryOnSubmit.accessRights,
-        license = parsed.license orElse mandatoryOnSubmit.license,
-        formats = parsed.formats orElse mandatoryOnSubmit.formats,
-        temporalCoverages = parsed.temporalCoverages orElse mandatoryOnSubmit.temporalCoverages,
-        spatialPoints = parsed.spatialPoints orElse mandatoryOnSubmit.spatialPoints,
-        spatialBoxes = parsed.spatialBoxes orElse mandatoryOnSubmit.spatialBoxes,
-        spatialCoverages = parsed.spatialCoverages orElse mandatoryOnSubmit.spatialCoverages,
-        messageForDataManager = parsed.messageForDataManager orElse mandatoryOnSubmit.messageForDataManager,
+      .deserialize[PrivateDatasetMetadataValues]
+      .map { privateValues =>
+        mandatoryOnSubmit.copy(
+          identifiers = privateValues.identifiers,
+          alternativeIdentifiers = privateValues.alternativeIdentifiers,
+          dates = privateValues.dates,
+          typesDcmi = privateValues.typesDcmi,
+          types = privateValues.types,
+        )
+      }.getOrElse(mandatoryOnSubmit)
+      .copy(
+        languageOfDescription = allParsedValues.languageOfDescription orElse mandatoryOnSubmit.languageOfDescription,
+        titles = allParsedValues.titles orElse mandatoryOnSubmit.titles,
+        alternativeTitles = allParsedValues.alternativeTitles orElse mandatoryOnSubmit.alternativeTitles,
+        descriptions = allParsedValues.descriptions orElse mandatoryOnSubmit.descriptions,
+        creators = allParsedValues.creators orElse mandatoryOnSubmit.creators,
+        contributors = allParsedValues.contributors orElse mandatoryOnSubmit.contributors,
+        audiences = allParsedValues.audiences orElse mandatoryOnSubmit.audiences,
+        subjects = allParsedValues.subjects orElse mandatoryOnSubmit.subjects,
+        relations = allParsedValues.relations orElse mandatoryOnSubmit.relations,
+        languagesOfFiles = allParsedValues.languagesOfFiles orElse mandatoryOnSubmit.languagesOfFiles,
+        sources = allParsedValues.sources orElse mandatoryOnSubmit.sources,
+        instructionsForReuse = allParsedValues.instructionsForReuse orElse mandatoryOnSubmit.instructionsForReuse,
+        publishers = allParsedValues.publishers orElse mandatoryOnSubmit.publishers,
+        accessRights = allParsedValues.accessRights orElse mandatoryOnSubmit.accessRights,
+        license = allParsedValues.license orElse mandatoryOnSubmit.license,
+        formats = allParsedValues.formats orElse mandatoryOnSubmit.formats,
+        temporalCoverages = allParsedValues.temporalCoverages orElse mandatoryOnSubmit.temporalCoverages,
+        spatialPoints = allParsedValues.spatialPoints orElse mandatoryOnSubmit.spatialPoints,
+        spatialBoxes = allParsedValues.spatialBoxes orElse mandatoryOnSubmit.spatialBoxes,
+        spatialCoverages = allParsedValues.spatialCoverages orElse mandatoryOnSubmit.spatialCoverages,
+        messageForDataManager = allParsedValues.messageForDataManager orElse mandatoryOnSubmit.messageForDataManager,
         // privacySensitiveDataPresent and acceptDepositAgreement are not options and thus not injected
       )
-    }
   }
 
   case class PrivateDatasetMetadataValues(identifiers: Option[Seq[SchemedValue]] = None,


### PR DESCRIPTION
Fixes EASY-1747 postpone validation to submit (authors only)

#### When applied it will
* no longer cause validation errors on dates when saving metadata
* friendly error messages are kept out of scope, see [EASY-1905](https://drivenbydata.atlassian.net/browse/EASY-1905) therefore submission relies on schema validation for now unless something would not be covered.
* [x] fix parseIntoValidForSubmit

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### Related pull requests on github
repo                       | PR                | note
-------------------------- | ----------------- | ----
easy-                      | [PR#](PRlink)     | ..
