### PR TITLE
EASY-1747 postpone validation to submit (spatial points/boxes)

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.deposit/docs/DatasetMetadata.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/docs/DatasetMetadata.scala
@@ -96,7 +96,7 @@ case class DatasetMetadata(private val identifiers: Option[Seq[SchemedValue]] = 
 
     for { // TODO collect errors
       _ <- Author.validate(authors)
-      _ <- Spatial.validate((spatialPoints ++ spatialBoxes).toSeq.flatten)
+      _ <- Spatial.hasMandatory((spatialPoints++ spatialBoxes).toSeq.flatten)
     } yield ()
   }
 }

--- a/src/main/scala/nl.knaw.dans.easy.deposit/docs/DatasetMetadata.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/docs/DatasetMetadata.scala
@@ -93,7 +93,11 @@ case class DatasetMetadata(private val identifiers: Option[Seq[SchemedValue]] = 
 
   /** Validations as far as not covered by DDM schema validation. */
   private[docs] def validate(): Try[Unit] = {
-    Author.validate(authors)
+
+    for { // TODO collect errors
+      _ <- Author.validate(authors)
+      _ <- Spatial.validate((spatialPoints ++ spatialBoxes).toSeq.flatten)
+    } yield ()
   }
 }
 

--- a/src/main/scala/nl.knaw.dans.easy.deposit/docs/DatasetMetadata.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/docs/DatasetMetadata.scala
@@ -106,11 +106,7 @@ case class DatasetMetadata(private val identifiers: Option[Seq[SchemedValue]] = 
 
     for { // TODO collect errors over multiple types of validation errors
       _ <- Author.validate(authors)
-      _ <- missingMandatory(
-        // filterNot: stick to schema validation for now, error message of missingMandatory not clear
-        authors.filterNot(_ == Author()) ++
-          (dates ++ spatialPoints ++ spatialBoxes).toSeq.flatten
-      )
+      _ <- missingMandatory(authors ++ (dates ++ spatialPoints ++ spatialBoxes).toSeq.flatten)
     } yield ()
   }
 }

--- a/src/main/scala/nl.knaw.dans.easy.deposit/docs/DatasetMetadata.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/docs/DatasetMetadata.scala
@@ -17,7 +17,7 @@ package nl.knaw.dans.easy.deposit.docs
 
 import nl.knaw.dans.easy.deposit.docs.DatasetMetadata._
 import nl.knaw.dans.easy.deposit.docs.JsonUtil.{ InvalidDocumentException, RichJsonInput }
-import nl.knaw.dans.easy.deposit.docs.dm.Date.{ dateSubmitted, _ }
+import nl.knaw.dans.easy.deposit.docs.dm.Date._
 import nl.knaw.dans.easy.deposit.docs.dm.PrivacySensitiveDataPresent.PrivacySensitiveDataPresent
 import nl.knaw.dans.easy.deposit.docs.dm._
 import org.json4s.JsonInput
@@ -96,7 +96,7 @@ case class DatasetMetadata(private val identifiers: Option[Seq[SchemedValue]] = 
 
     for { // TODO collect errors
       _ <- Author.validate(authors)
-      _ <- Spatial.hasMandatory((spatialPoints++ spatialBoxes).toSeq.flatten)
+      _ <- Spatial.hasMandatory((spatialPoints ++ spatialBoxes).toSeq.flatten)
     } yield ()
   }
 }

--- a/src/main/scala/nl.knaw.dans.easy.deposit/docs/DatasetMetadata.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/docs/DatasetMetadata.scala
@@ -93,23 +93,24 @@ case class DatasetMetadata(private val identifiers: Option[Seq[SchemedValue]] = 
 
   /** Validations as far as not covered by DDM schema validation. */
   private[docs] def validate(): Try[Unit] = {
-    def missingMandatory[T <: Mandatory](msg: String, values: Seq[T]): Try[Unit] = {
+    def missingMandatory[T <: Mandatory](values: Seq[T]): Try[Unit] = {
       val invalid = values
         .withFilter(!_.hasMandatory)
-        .map(JsonUtil.toJson)
+        .map(x => x.getClass.getSimpleName + JsonUtil.toJson(x))
         .mkString(", ")
       if (invalid.isEmpty) Success(())
       else {
-        Failure(new IllegalArgumentException(s"Missing values for $msg: $invalid"))
+        Failure(new IllegalArgumentException(s"Missing mandatory values in: $invalid"))
       }
     }
 
-    for { // TODO collect errors over multiple fields, not just within the list of a field
+    for { // TODO collect errors over multiple types of validation errors
       _ <- Author.validate(authors)
-      // filterNot: stick to schema validation for now, error message of missingMandatory not clear
-      _ <- missingMandatory("authors", authors.filterNot(_ == Author()))
-      _ <- missingMandatory("dates", dates.toSeq.flatten)
-      _ <- missingMandatory("spatial points and/or boxes", (spatialPoints ++ spatialBoxes).toSeq.flatten)
+      _ <- missingMandatory(
+        // filterNot: stick to schema validation for now, error message of missingMandatory not clear
+        authors.filterNot(_ == Author()) ++
+          (dates ++ spatialPoints ++ spatialBoxes).toSeq.flatten
+      )
     } yield ()
   }
 }

--- a/src/main/scala/nl.knaw.dans.easy.deposit/docs/DatasetMetadata.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/docs/DatasetMetadata.scala
@@ -100,9 +100,7 @@ case class DatasetMetadata(private val identifiers: Option[Seq[SchemedValue]] = 
         .mkString(", ")
       if (invalid.isEmpty) Success(())
       else {
-        Failure(new IllegalArgumentException(
-          s"Missing values for $msg: $invalid"
-        ))
+        Failure(new IllegalArgumentException(s"Missing values for $msg: $invalid"))
       }
     }
 

--- a/src/main/scala/nl.knaw.dans.easy.deposit/docs/dm/Author.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/docs/dm/Author.scala
@@ -47,8 +47,8 @@ case class Author(titles: Option[String] = None,
     }
   }
 
-  private[docs] override def hasMandatory: Boolean = organization.isDefined ||
-    (surname.isDefined && initials.isDefined)
+  private[docs] override def hasMandatory: Boolean = organization.isProvided ||
+    (surname.isProvided && initials.isProvided)
 }
 object Author {
   private[docs] def validate(authors: Seq[Author]): Try[Unit] = {

--- a/src/main/scala/nl.knaw.dans.easy.deposit/docs/dm/Author.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/docs/dm/Author.scala
@@ -29,7 +29,7 @@ case class Author(titles: Option[String] = None,
                   role: Option[SchemedKeyValue] = None,
                   ids: Option[Seq[SchemedValue]] = None,
                   organization: Option[String] = None,
-                 ) extends Requirements {
+                 ) extends Mandatory {
   private val hasRedundant: Boolean = !surname.isProvided && (titles.isProvided || insertions.isProvided)
 
   def isRightsHolder: Boolean = role.exists(_.key == "RightsHolder")
@@ -46,6 +46,9 @@ case class Author(titles: Option[String] = None,
       case (None, None) => "" // schema validation will fail for creator respectively contributor
     }
   }
+
+  private[docs] override def hasMandatory: Boolean = organization.isDefined ||
+    (surname.isDefined && initials.isDefined)
 }
 object Author {
   private[docs] def validate(authors: Seq[Author]): Try[Unit] = {

--- a/src/main/scala/nl.knaw.dans.easy.deposit/docs/dm/Date.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/docs/dm/Date.scala
@@ -17,6 +17,7 @@ package nl.knaw.dans.easy.deposit.docs.dm
 
 import nl.knaw.dans.easy.deposit.docs.DatasetMetadata.PossiblySchemed
 import nl.knaw.dans.easy.deposit.docs.JsonUtil.toJson
+import nl.knaw.dans.easy.deposit.docs.StringUtils._
 import nl.knaw.dans.easy.deposit.docs.dm.DateQualifier.DateQualifier
 import org.joda.time.DateTime
 import org.joda.time.format.ISODateTimeFormat
@@ -44,7 +45,7 @@ case class Date(
                  value: Option[String],
                  qualifier: Option[DateQualifier],
                ) extends PossiblySchemed with Mandatory {
-  private[docs] override def hasMandatory: Boolean = qualifier.isDefined && value.isDefined
+  private[docs] override def hasMandatory: Boolean = qualifier.isDefined && value.isProvided
 }
 
 object Date {

--- a/src/main/scala/nl.knaw.dans.easy.deposit/docs/dm/Date.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/docs/dm/Date.scala
@@ -15,14 +15,11 @@
  */
 package nl.knaw.dans.easy.deposit.docs.dm
 
-import javax.xml.validation.Schema
 import nl.knaw.dans.easy.deposit.docs.DatasetMetadata.PossiblySchemed
 import nl.knaw.dans.easy.deposit.docs.JsonUtil.toJson
 import nl.knaw.dans.easy.deposit.docs.dm.DateQualifier.DateQualifier
 import org.joda.time.DateTime
 import org.joda.time.format.ISODateTimeFormat
-
-import scala.util.Try
 
 object DateQualifier extends Enumeration {
   type DateQualifier = Value
@@ -46,7 +43,8 @@ case class Date(
                  override val scheme: Option[String],
                  value: Option[String],
                  qualifier: Option[DateQualifier],
-               ) extends PossiblySchemed with Requirements {
+               ) extends PossiblySchemed with Mandatory {
+  private[docs] override def hasMandatory: Boolean = qualifier.isDefined && value.isDefined
 }
 
 object Date {

--- a/src/main/scala/nl.knaw.dans.easy.deposit/docs/dm/Mandatory.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/docs/dm/Mandatory.scala
@@ -1,0 +1,5 @@
+package nl.knaw.dans.easy.deposit.docs.dm
+
+trait Mandatory {
+  private[docs] def hasMandatory: Boolean
+}

--- a/src/main/scala/nl.knaw.dans.easy.deposit/docs/dm/Mandatory.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/docs/dm/Mandatory.scala
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2018 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package nl.knaw.dans.easy.deposit.docs.dm
 
 trait Mandatory {

--- a/src/main/scala/nl.knaw.dans.easy.deposit/docs/dm/Spatial.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/docs/dm/Spatial.scala
@@ -15,32 +15,15 @@
  */
 package nl.knaw.dans.easy.deposit.docs.dm
 
-import nl.knaw.dans.easy.deposit.docs.JsonUtil
-
-import scala.util.{ Failure, Success, Try }
-
 object Spatial {
   /** coordinate order y, x = latitude (DCX_SPATIAL_Y), longitude (DCX_SPATIAL_X) */
   val DEGREES_SRS_NAME = "http://www.opengis.net/def/crs/EPSG/0/4326"
 
   /** coordinate order x, y = longitude (DCX_SPATIAL_X), latitude (DCX_SPATIAL_Y) */
   val RD_SRS_NAME = "http://www.opengis.net/def/crs/EPSG/0/28992"
-
-  private[docs] def hasMandatory[T <: SchemedSpatial](spatials: Seq[T]): Try[Unit] = {
-    val invalid = spatials
-      .withFilter(!_.hasMandatory)
-      .map(JsonUtil.toJson)
-      .mkString(", ")
-    if (invalid.isEmpty) Success(())
-    else {
-      Failure(new IllegalArgumentException(
-        s"Missing values for spatial points and/or boxes: $invalid"
-      ))
-    }
-  }
 }
 
-trait SchemedSpatial {
+trait SchemedSpatial extends Mandatory {
   val scheme: Option[String]
 
   lazy val srsName: String = {
@@ -52,7 +35,7 @@ trait SchemedSpatial {
     }
   }
 
-  private[docs] def hasMandatory: Boolean = scheme.isDefined
+  private[docs] override def hasMandatory: Boolean = scheme.isDefined
 }
 
 case class SpatialPoint(override val scheme: Option[String],

--- a/src/main/scala/nl.knaw.dans.easy.deposit/docs/dm/Spatial.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/docs/dm/Spatial.scala
@@ -83,24 +83,24 @@ case class SpatialBox(override val scheme: Option[String],
   private lazy val xy = (s"$sWest $sSouth", s"$sEast $sNorth")
   private lazy val yx = (s"$sSouth $sWest", s"$sNorth $sEast")
   /*
-           * Note that Y is along North - South and X is along East - West
-           * The lower corner is with the minimal coordinate values and upper corner with the maximal coordinate values
-           * If x was increasing from West to East and y was increasing from South to North we would have
-           * lower corner (x,y) = (West,South) and upper corner (x,y) = (East,North)
-           * as shown in the schematic drawing of the box below.
-           * This is the case for the WGS84 and RD coordinate systems, but not per se for any other system!
-           *
-           *                upper(x,y)=(E,N)
-           *       *---N---u
-           *       |       |
-           *       W       E
-           *  ^    |       |
-           *  |    l---S---*
-           *  |  lower(x,y)=(W,S)
-           *  y
-           *   x -->
-           *
-           */
+   * Note that Y is along North - South and X is along East - West
+   * The lower corner is with the minimal coordinate values and upper corner with the maximal coordinate values
+   * If x was increasing from West to East and y was increasing from South to North we would have
+   * lower corner (x,y) = (West,South) and upper corner (x,y) = (East,North)
+   * as shown in the schematic drawing of the box below.
+   * This is the case for the WGS84 and RD coordinate systems, but not per se for any other system!
+   *
+   *                upper(x,y)=(E,N)
+   *       *---N---u
+   *       |       |
+   *       W       E
+   *  ^    |       |
+   *  |    l---S---*
+   *  |  lower(x,y)=(W,S)
+   *  y
+   *   x -->
+   *
+   */
   lazy val (lower: String, upper: String) = srsName match {
     case Spatial.RD_SRS_NAME => xy
     case Spatial.DEGREES_SRS_NAME => yx

--- a/src/main/scala/nl.knaw.dans.easy.deposit/docs/dm/Spatial.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/docs/dm/Spatial.scala
@@ -15,12 +15,30 @@
  */
 package nl.knaw.dans.easy.deposit.docs.dm
 
+import nl.knaw.dans.easy.deposit.docs.JsonUtil
+
+import scala.util.{ Failure, Success, Try }
+
 object Spatial {
   /** coordinate order y, x = latitude (DCX_SPATIAL_Y), longitude (DCX_SPATIAL_X) */
   val DEGREES_SRS_NAME = "http://www.opengis.net/def/crs/EPSG/0/4326"
 
   /** coordinate order x, y = longitude (DCX_SPATIAL_X), latitude (DCX_SPATIAL_Y) */
   val RD_SRS_NAME = "http://www.opengis.net/def/crs/EPSG/0/28992"
+
+  private[docs] def validate[T <: SchemedSpatial](spatials: Seq[T]): Try[Unit] = {
+    val invalid = spatials
+      .withFilter(_.scheme.isEmpty)
+      .map(JsonUtil.toJson)
+      .mkString(", ")
+    if (invalid.isEmpty) Success(())
+    else {
+      Failure(new IllegalArgumentException(
+        // TODO use type name when we can  exclude SchemedSpatial itself at compile time
+        s"Spatial points and boxes should have schemes, got: $invalid"
+      ))
+    }
+  }
 }
 
 trait SchemedSpatial extends Requirements {

--- a/src/main/scala/nl.knaw.dans.easy.deposit/docs/dm/Spatial.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/docs/dm/Spatial.scala
@@ -15,6 +15,8 @@
  */
 package nl.knaw.dans.easy.deposit.docs.dm
 
+import nl.knaw.dans.easy.deposit.docs.StringUtils._
+
 object Spatial {
   /** coordinate order y, x = latitude (DCX_SPATIAL_Y), longitude (DCX_SPATIAL_X) */
   val DEGREES_SRS_NAME = "http://www.opengis.net/def/crs/EPSG/0/4326"
@@ -35,7 +37,7 @@ trait SchemedSpatial extends Mandatory {
     }
   }
 
-  private[docs] override def hasMandatory: Boolean = scheme.isDefined
+  private[docs] override def hasMandatory: Boolean = scheme.isProvided
 }
 
 case class SpatialPoint(override val scheme: Option[String],
@@ -50,7 +52,7 @@ case class SpatialPoint(override val scheme: Option[String],
     case _ => s"$sy $sx"
   }
 
-  private[docs] override def hasMandatory: Boolean = super.hasMandatory && x.isDefined && y.isDefined
+  private[docs] override def hasMandatory: Boolean = super.hasMandatory && x.isProvided && y.isProvided
 }
 
 case class SpatialBox(override val scheme: Option[String],
@@ -90,5 +92,5 @@ case class SpatialBox(override val scheme: Option[String],
     case _ => yx
   }
 
-  private[docs] override def hasMandatory: Boolean = super.hasMandatory && north.isDefined && east.isDefined && south.isDefined && west.isDefined
+  private[docs] override def hasMandatory: Boolean = super.hasMandatory && north.isProvided && east.isProvided && south.isProvided && west.isProvided
 }

--- a/src/main/scala/nl.knaw.dans.easy.deposit/docs/dm/Spatial.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/docs/dm/Spatial.scala
@@ -41,27 +41,23 @@ object Spatial {
   }
 }
 
-trait SchemedSpatial extends Requirements {
-  val scheme: String
-  requireNonEmptyString(scheme)
+trait SchemedSpatial {
+  val scheme: Option[String]
 
   lazy val srsName: String = {
     scheme match {
-      case "degrees" => Spatial.DEGREES_SRS_NAME
-      case "RD" => Spatial.RD_SRS_NAME
-      case s if s.trim.isEmpty => null // will suppress the XML attribute
-      case _ => scheme
+      case Some("degrees") => Spatial.DEGREES_SRS_NAME
+      case Some("RD") => Spatial.RD_SRS_NAME
+      case Some(s) if s.trim.nonEmpty => s
+      case _ => null // will suppress the XML attribute
     }
   }
 }
 
-case class SpatialPoint(override val scheme: String,
+case class SpatialPoint(override val scheme: Option[String],
                         x: String,
                         y: String,
-                       ) extends Requirements with SchemedSpatial {
-  requireDouble(x)
-  requireDouble(y)
-
+                       ) extends SchemedSpatial {
   lazy val pos: String = srsName match {
     case Spatial.RD_SRS_NAME => s"$x $y"
     case Spatial.DEGREES_SRS_NAME => s"$y $x"
@@ -69,17 +65,12 @@ case class SpatialPoint(override val scheme: String,
   }
 }
 
-case class SpatialBox(override val scheme: String,
+case class SpatialBox(override val scheme: Option[String],
                       north: String,
                       east: String,
                       south: String,
                       west: String,
-                     ) extends Requirements with SchemedSpatial {
-  requireDouble(north)
-  requireDouble(east)
-  requireDouble(south)
-  requireDouble(west)
-
+                     ) extends SchemedSpatial {
   /*
    * Note that Y is along North - South and X is along East - West
    * The lower corner is with the minimal coordinate values and upper corner with the maximal coordinate values

--- a/src/test/scala/nl.knaw.dans.easy.deposit/docs/DatasetMetadataSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/docs/DatasetMetadataSpec.scala
@@ -233,11 +233,6 @@ class DatasetMetadataSpec extends TestSupportFixture {
       .causesInvalidDocumentException("""requirement failed: Empty string for a mandatory field; got {"scheme":"xxx","key":"yyy","value":""} SchemedKeyValue""")
   }
 
-  "DatasetMetadata.spatialBoxes" should "reject a non-numeric value" in {
-    """{"spatialBoxes": [ { "scheme": "RD", "north": "486890,5", "east": 121811.88, "south": 436172.5,  "west": 91232.016 }]}""".stripMargin
-      .causesInvalidDocumentException("""requirement failed: Invalid number [486890,5]; got {"scheme":"RD","north":"486890,5","east":"121811.88","south":"436172.5","west":"91232.016"} SpatialBox""")
-  }
-
   it should "accept both quoted and non quoted numbers" in {
     // the server will return all numbers quoted
     val s =

--- a/src/test/scala/nl.knaw.dans.easy.deposit/servlets/IntegrationSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/servlets/IntegrationSpec.scala
@@ -44,7 +44,7 @@ class IntegrationSpec extends TestSupportFixture with ServletFixture with Scalat
   }
   mountServlets(app, authMocker.mockedAuthenticationProvider)
 
-  s"scenario: /deposit/:uuid/metadata life cycle" should "return default dataset metadata" in {
+  "scenario: /deposit/:uuid/metadata life cycle" should "return default dataset metadata" in {
 
     // create dataset
     authMocker.expectsUserFooBar
@@ -78,28 +78,7 @@ class IntegrationSpec extends TestSupportFixture with ServletFixture with Scalat
     }
   }
 
-  s"POST /deposit/:uuid/metadata" should "return a user friendly message" in {
-    // more variants in DDMSpec and DatasetMetadataSpec, here we test the full chain of error handling
-
-    // create dataset
-    authMocker.expectsUserFooBar
-    val responseBody = post(uri = s"/deposit", headers = Seq(fooBarBasicAuthHeader)) { body }
-    val uuid = DepositInfo(responseBody).map(_.id.toString).getOrRecover(e => fail(e.toString, e))
-    val metadataURI = s"/deposit/$uuid/metadata"
-
-    // create dataset metadata
-    assume(DDM.triedSchema.isAvailable)
-    authMocker.expectsUserFooBar
-    put(
-      metadataURI, headers = Seq(fooBarBasicAuthHeader),
-      body = """{"spatialPoints": [{ "scheme": "RD", "x": "795,00", "y": "446750Z" }]}"""
-    ) {
-      body shouldBe """Bad Request. invalid DatasetMetadata: requirement failed: Invalid number [795,00]; got {"scheme":"RD","x":"795,00","y":"446750Z"} SpatialPoint"""
-      status shouldBe BAD_REQUEST_400
-    }
-  }
-
-  s"scenario: POST /deposit twice; GET /deposit" should "return a list of datasets" in {
+  "scenario: POST /deposit twice; GET /deposit" should "return a list of datasets" in {
 
     // create two deposits
     val responseBodies: Seq[String] = (0 until 2).map { _ =>
@@ -167,7 +146,7 @@ class IntegrationSpec extends TestSupportFixture with ServletFixture with Scalat
     }
   }
 
-  s"scenario: POST /deposit; twice GET /deposit/:uuid/doi" should "return 200" in {
+  "scenario: POST /deposit; twice GET /deposit/:uuid/doi" should "return 200" in {
 
     // create dataset
     authMocker.expectsUserFooBar
@@ -195,7 +174,7 @@ class IntegrationSpec extends TestSupportFixture with ServletFixture with Scalat
     }
   }
 
-  s"scenario: create - ... - sumbit" should "create submitted dataset copied from a draft" in {
+  "scenario: create - ... - sumbit" should "create submitted dataset copied from a draft" in {
 
     val datasetMetadata = getManualTestResource("datasetmetadata-from-ui-all.json")
     val doi = DatasetMetadata(datasetMetadata)
@@ -241,7 +220,7 @@ class IntegrationSpec extends TestSupportFixture with ServletFixture with Scalat
     }
   }
 
-  s"scenario: create - sumbit" should "refuse a submit without DOI" in {
+  "scenario: create - sumbit" should "refuse a submit without DOI" in {
     (testDir / "stage").createDirectories()
     (testDir / "easy-ingest-flow-inbox").createDirectories()
     val metadataWithoutDOI = JsonUtil.toJson(
@@ -279,7 +258,7 @@ class IntegrationSpec extends TestSupportFixture with ServletFixture with Scalat
     }
   }
 
-  s"scenario: POST /deposit; hack state to ARCHIVED; SUBMIT" should "reject state transition" in {
+  "scenario: POST /deposit; hack state to ARCHIVED; SUBMIT" should "reject state transition" in {
 
     // create dataset
     authMocker.expectsUserFooBar

--- a/src/test/scala/nl.knaw.dans.easy.deposit/servlets/ValidationSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/servlets/ValidationSpec.scala
@@ -44,9 +44,8 @@ class ValidationSpec extends DepositServletFixture {
 
   "PUT(metadata) should succeed with incomplete authors, PUT(submitted)" should "fail for an empty creator" in {
     def checkSubmitResponse = {
-      body should include("'dcx-dai:creatorDetails' is not complete")
-      body shouldNot include("'dcx-dai:contributorDetails' is not complete")
-      // a client has no clue there is a second violation on contributorDetails
+      body shouldBe """Bad Request. invalid DatasetMetadata: Missing mandatory values in: Author{}, Author{}"""
+      // a client has no clue whether it are creators or contributors
       status shouldBe BAD_REQUEST_400
     }
 
@@ -58,7 +57,7 @@ class ValidationSpec extends DepositServletFixture {
 
   it should "fail for an empty contributor" in {
     def checkSubmitResponse = {
-      body should include("'dcx-dai:contributorDetails' is not complete")
+      body should include("Missing mandatory values in: Author{}")
       // a client has no clue which one in the list is violating the requirements
       status shouldBe BAD_REQUEST_400
     }

--- a/src/test/scala/nl.knaw.dans.easy.deposit/servlets/ValidationSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/servlets/ValidationSpec.scala
@@ -205,8 +205,8 @@ class ValidationSpec extends DepositServletFixture {
         |  }
         |]}""")
     ) should matchPattern {
-      case Failure(InvalidDocumentException("DatasetMetadata", cause: SAXParseException))
-        if cause.getMessage.contains("'dcx-dai:creatorDetails' is not complete") =>
+      case Failure(InvalidDocumentException("DatasetMetadata", cause: IllegalArgumentException))
+        if cause.getMessage == """Missing values for authors: {"role":{"scheme":"datacite:contributorType","key":"RightsHolder","value":"Rights Holder"}}""" =>
     }
   }
 
@@ -222,8 +222,8 @@ class ValidationSpec extends DepositServletFixture {
         |  }
         |]}""")
     ) should matchPattern {
-      case Failure(InvalidDocumentException("DatasetMetadata", cause: SAXParseException))
-        if cause.getMessage.contains("'dcx-dai:contributorDetails' is not complete") =>
+      case Failure(InvalidDocumentException("DatasetMetadata", cause: IllegalArgumentException))
+        if cause.getMessage == """Missing values for authors: {"role":{"scheme":"datacite:contributorType","key":"RightsHolder","value":"Rights Holder"}}""" =>
     }
   }
 
@@ -280,9 +280,7 @@ class ValidationSpec extends DepositServletFixture {
         |]}""".stripMargin
     )) should matchPattern {
       case Failure(InvalidDocumentException("DatasetMetadata", cause: IllegalArgumentException))
-        // TODO this means a missing qualifier!
-        if cause.getMessage.contains("""got [] to adjust the <label> of <label """) &&
-          cause.getMessage.endsWith(""">2018-05-31</label>""") =>
+        if cause.getMessage == """Missing values for dates: {"scheme":"dcterms:W3CDTF","value":"2018-05-31"}""" =>
     }
   }
 

--- a/src/test/scala/nl.knaw.dans.easy.deposit/servlets/ValidationSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/servlets/ValidationSpec.scala
@@ -371,11 +371,11 @@ class ValidationSpec extends DepositServletFixture {
     DDM(parseIntoValidForSubmit(
       """{
         |  "spatialBoxes": [{ "north": 1, "east": 2, "south": "3", "west": "4" }]
-        |  "spatialPoints": [{ "x": "5", "y": 6 }, { "scheme": "RD", "x": "7", "y": 8 }]
+        |  "spatialPoints": [{ "x": "5", "y": 6 }, { "scheme": "RD", "x": "7", "y": 8 }, { "scheme": "RD", "x": "9"}]
         |}""".stripMargin)
     ) should matchPattern {
       case Failure(InvalidDocumentException(_, cause: Throwable))
-        if cause.getMessage == """Spatial points and boxes should have schemes, got: {"x":"5","y":"6"}, {"north":"1","east":"2","south":"3","west":"4"}""" =>
+        if cause.getMessage == """Missing values for spatial points and/or boxes: {"x":"5","y":"6"}, {"scheme":"RD","x":"9"}, {"north":"1","east":"2","south":"3","west":"4"}""" =>
     }
   }
 

--- a/src/test/scala/nl.knaw.dans.easy.deposit/servlets/ValidationSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/servlets/ValidationSpec.scala
@@ -206,7 +206,7 @@ class ValidationSpec extends DepositServletFixture {
         |]}""")
     ) should matchPattern {
       case Failure(InvalidDocumentException("DatasetMetadata", cause: IllegalArgumentException))
-        if cause.getMessage == """Missing values for authors: {"role":{"scheme":"datacite:contributorType","key":"RightsHolder","value":"Rights Holder"}}""" =>
+        if cause.getMessage == """Missing mandatory values in: Author{"role":{"scheme":"datacite:contributorType","key":"RightsHolder","value":"Rights Holder"}}""" =>
     }
   }
 
@@ -223,7 +223,7 @@ class ValidationSpec extends DepositServletFixture {
         |]}""")
     ) should matchPattern {
       case Failure(InvalidDocumentException("DatasetMetadata", cause: IllegalArgumentException))
-        if cause.getMessage == """Missing values for authors: {"role":{"scheme":"datacite:contributorType","key":"RightsHolder","value":"Rights Holder"}}""" =>
+        if cause.getMessage == """Missing mandatory values in: Author{"role":{"scheme":"datacite:contributorType","key":"RightsHolder","value":"Rights Holder"}}""" =>
     }
   }
 
@@ -280,7 +280,7 @@ class ValidationSpec extends DepositServletFixture {
         |]}""".stripMargin
     )) should matchPattern {
       case Failure(InvalidDocumentException("DatasetMetadata", cause: IllegalArgumentException))
-        if cause.getMessage == """Missing values for dates: {"scheme":"dcterms:W3CDTF","value":"2018-05-31"}""" =>
+        if cause.getMessage == """Missing mandatory values in: Date{"scheme":"dcterms:W3CDTF","value":"2018-05-31"}""" =>
     }
   }
 
@@ -373,7 +373,7 @@ class ValidationSpec extends DepositServletFixture {
         |}""".stripMargin)
     ) should matchPattern {
       case Failure(InvalidDocumentException(_, cause: Throwable))
-        if cause.getMessage == """Missing values for spatial points and/or boxes: {"x":"5","y":"6"}, {"scheme":"RD","x":"9"}, {"north":"1","east":"2","south":"3","west":"4"}""" =>
+        if cause.getMessage == """Missing mandatory values in: SpatialPoint{"x":"5","y":"6"}, SpatialPoint{"scheme":"RD","x":"9"}, SpatialBox{"north":"1","east":"2","south":"3","west":"4"}""" =>
     }
   }
 

--- a/src/test/scala/nl.knaw.dans.easy.deposit/servlets/ValidationSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/servlets/ValidationSpec.scala
@@ -78,9 +78,8 @@ class ValidationSpec extends DepositServletFixture {
   it should "fail for an author with just a last name" in {
     DDM(parseIntoValidForSubmit("""{ "creators": [ { "surname": "Einstein", "initials": "  " }]}""")
     ) should matchPattern {
-      case Failure(InvalidDocumentException("DatasetMetadata", cause: SAXParseException))
-        if cause.getMessage.contains("'dcx-dai:author' is not complete")
-          && cause.getLineNumber == 8 =>
+      case Failure(InvalidDocumentException("DatasetMetadata", cause: IllegalArgumentException))
+        if cause.getMessage == """Missing mandatory values in: Author{"initials":"  ","surname":"Einstein"}""" =>
       // TODO error handling should produce the XML line(s) to give the client a clue about the violating instance
     }
   }
@@ -88,8 +87,8 @@ class ValidationSpec extends DepositServletFixture {
   it should "fail for an author with just initials" in {
     DDM(parseIntoValidForSubmit("""{ "creators": [ { "surname": "  ", "initials": "A" }]}""")
     ) should matchPattern {
-      case Failure(InvalidDocumentException("DatasetMetadata", cause: SAXParseException))
-        if cause.getMessage.contains("'dcx-dai:creatorDetails' is not complete") =>
+      case Failure(InvalidDocumentException("DatasetMetadata", cause: IllegalArgumentException))
+        if cause.getMessage == """Missing mandatory values in: Author{"initials":"A","surname":"  "}""" =>
     }
   }
 
@@ -265,8 +264,8 @@ class ValidationSpec extends DepositServletFixture {
         |  ],
         |}""".stripMargin)
     ) should matchPattern {
-      case Failure(InvalidDocumentException("DatasetMetadata", cause: SAXParseException))
-        if cause.getMessage.contains("""' ' is not a valid value of union type '#AnonType_W3CDTF'""") =>
+      case Failure(InvalidDocumentException("DatasetMetadata", cause: IllegalArgumentException))
+        if cause.getMessage == """Missing mandatory values in: Date{"scheme":"dcterms:W3CDTF","value":"    ","qualifier":"dcterms:available"}""" =>
     }
   }
 
@@ -356,11 +355,11 @@ class ValidationSpec extends DepositServletFixture {
     }
   }
 
-  it should "fail for an empty x" in pendingUntilFixed {
-    DDM(parseIntoValidForSubmit("""{"spatialPoints": [{ "scheme": "RD", "x": "", "y": "446750" }]}""")
+  it should "fail for an empty x" in {
+    DDM(parseIntoValidForSubmit("""{"spatialPoints": [{ "scheme": "RD", "x": " ", "y": "446750" }]}""")
     ) should matchPattern {
-      case Failure(InvalidDocumentException(_, cause: Throwable))
-        if cause.getMessage.contains("xxx") =>
+      case Failure(InvalidDocumentException(_, cause: IllegalArgumentException))
+        if cause.getMessage == """Missing mandatory values in: SpatialPoint{"scheme":"RD","x":" ","y":"446750"}""" =>
     }
   }
 


### PR DESCRIPTION
Fixes EASY-1747 postpone validation to submit (spatial points/boxes)

#### When applied it will
* no longer cause validation errors on spatial points/boxes when saving metadata
* [x] treat fields with just white space as None
* [x] ~~wait for the discussion on deposit-ui~~
  * conversion is beyond the scope of this issue, which is:
     _accept partial data on save, but not on submit_
  * api should apply same conversion of x/y to lat/long as bulk import, the source of this code

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### Related pull requests on github
repo                       | PR                | note
-------------------------- | ----------------- | ----
easy-                      | [PR#](PRlink)     | ..
