### PR TITLE
EASY-1962 fix bag-info.txt

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.deposit/DepositDir.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/DepositDir.scala
@@ -257,7 +257,6 @@ object DepositDir {
     for {
       _ <- Try { depositDir.createDirectories }
       bag <- DansV0Bag.empty(depositDir / "bag")
-      _ = bag.withEasyUserAccount(deposit.user)
       _ <- bag.addTagFile("{}".inputStream, Paths.get("metadata/dataset.json"))
       _ <- bag.save()
       _ <- createDepositProperties(user, depositInfo, deposit)

--- a/src/main/scala/nl.knaw.dans.easy.deposit/DepositDir.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/DepositDir.scala
@@ -257,6 +257,7 @@ object DepositDir {
     for {
       _ <- Try { depositDir.createDirectories }
       bag <- DansV0Bag.empty(depositDir / "bag")
+      _ = bag.withCreated()
       _ <- bag.addTagFile("{}".inputStream, Paths.get("metadata/dataset.json"))
       _ <- bag.save()
       _ <- createDepositProperties(user, depositInfo, deposit)


### PR DESCRIPTION
Fixes EASY-1962 fix bag-info.txt

#### When applied it will
* dropped user-account
* added created
* 

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

* build and deploy on deasy
* Submit a deposit with the ui
* Work around https://drivenbydata.atlassian.net/browse/EASY-1932
 `sudo chgrp -R deposits /var/opt/dans.knaw.nl/tmp/easy-ingest-flow-inbox/` 
 `sudo chmod -R 755 /var/opt/dans.knaw.nl/tmp/easy-ingest-flow-inbox/` 
 `sudo service easy-ingest-flow restart`

ingest-flow now only complains about `metadata/message-from-depositor.txt` but that is to be fixed with https://drivenbydata.atlassian.net/browse/EASY-1961

#### Related pull requests on github
repo                       | PR                | note
-------------------------- | ----------------- | ----
easy-                      | [PR#](PRlink)     | ..
