### PR TITLE
EASY-1932 file rights before moving to ingest inbox

### DIFF
--- a/src/main/assembly/dist/cfg/application.properties
+++ b/src/main/assembly/dist/cfg/application.properties
@@ -21,6 +21,7 @@ deposits.drafts=/var/opt/dans.knaw.nl/tmp/easy-deposit/drafts
 deposits.stage=/var/opt/dans.knaw.nl/tmp/easy-deposit/stage
 deposits.submit-to=/var/opt/dans.knaw.nl/tmp/easy-ingest-flow-inbox
 
+# file rights that allow easy-ingest-flow to process deposits from its inbox
 deposit.permissions.access=rwxrwx---
 deposit.permissions.group=deposits
 

--- a/src/main/assembly/dist/cfg/application.properties
+++ b/src/main/assembly/dist/cfg/application.properties
@@ -22,7 +22,6 @@ deposits.stage=/var/opt/dans.knaw.nl/tmp/easy-deposit/stage
 deposits.submit-to=/var/opt/dans.knaw.nl/tmp/easy-ingest-flow-inbox
 
 # file rights that allow easy-ingest-flow to process deposits from its inbox
-deposit.permissions.access=rwxrwx---
 deposit.permissions.group=deposits
 
 #

--- a/src/main/assembly/dist/cfg/application.properties
+++ b/src/main/assembly/dist/cfg/application.properties
@@ -21,7 +21,7 @@ deposits.drafts=/var/opt/dans.knaw.nl/tmp/easy-deposit-api/drafts
 deposits.stage=/var/opt/dans.knaw.nl/tmp/easy-deposit-api/stage
 deposits.submit-to=/var/opt/dans.knaw.nl/tmp/easy-ingest-flow-inbox
 
-# file rights that allow easy-ingest-flow to process deposits from its inbox
+# The group to assign to the files and directories making up the deposit, before moving it to submit-to.
 deposit.permissions.group=deposits
 
 #

--- a/src/main/assembly/dist/cfg/application.properties
+++ b/src/main/assembly/dist/cfg/application.properties
@@ -6,19 +6,22 @@
 daemon.http.port=20190
 
 #
-# Directories for managing the deposits. The lifecycle of a deposit is:
+# Directories for managing the deposits.
 #
-# 1.   Created in the drafts directory.
-# 2.   On submit: copied to stage and then that copy is moved to the submit-to directory.
-# 3a)  If archived successfully the bag in the stage is moved to submit-to
-# 3b)  If the deposit is rejected, the depositor can reopen the draft, modify it and resubmit it.
+# - stage-zips:       is used for uploads of zipped directories or complete deposits.
+# - drafts:           contains the draft deposits; single files are uploaded here directly,
+#                     unzipped directories and deposits are moved here from stage-zips.
+# - stage-for-submit: the completed draft is copied here when the user submits it.
+# - submit-to:        the target directory to which the copy in stage-for-submit is moved for further processing.
 #
-# stage and submit-to must be on a single mount to allow moving from the first to the latter
-# stage.upload and draft must be on a single mount to allow moving zip-content into the draft bag
+# N.B. stage-zips and drafts must be located on the same partition in order to support atomic moving.
+# The same holds for stage-for-submit and submit-to.
 #
-deposits.stage.upload=/var/opt/dans.knaw.nl/tmp/easy-deposit-api/stage-upload
+# Note that the stage-* directories only have temporary content, so the service should clear them automatically.
+#
+deposits.stage-zips=/var/opt/dans.knaw.nl/tmp/easy-deposit-api/stage-upload
 deposits.drafts=/var/opt/dans.knaw.nl/tmp/easy-deposit-api/drafts
-deposits.stage=/var/opt/dans.knaw.nl/tmp/easy-deposit-api/stage
+deposits.stage-for-submit=/var/opt/dans.knaw.nl/tmp/easy-deposit-api/stage
 deposits.submit-to=/var/opt/dans.knaw.nl/tmp/easy-ingest-flow-inbox
 
 # The group to assign to the files and directories making up the deposit, before moving it to submit-to.

--- a/src/main/assembly/dist/cfg/application.properties
+++ b/src/main/assembly/dist/cfg/application.properties
@@ -12,12 +12,15 @@ daemon.http.port=20190
 # - drafts:           contains the draft deposits; single files are uploaded here directly,
 #                     unzipped directories and deposits are moved here from stage-zips.
 # - stage-for-submit: the completed draft is copied here when the user submits it.
-# - submit-to:        the target directory to which the copy in stage-for-submit is moved for further processing.
+# - submit-to:        the deposit copy in stage-for-submit is moved here on successful completion
+#                     of a submit request.  As moving is an atomic action this prevents further
+#                     processing of incomplete deposits.
 #
 # N.B. stage-zips and drafts must be located on the same partition in order to support atomic moving.
 # The same holds for stage-for-submit and submit-to.
 #
-# Note that the stage-* directories only have temporary content, so the service should clear them automatically.
+# Note that the stage-* directories only have temporary content, so the service should clear them
+# automatically on completion of a request.
 #
 deposits.stage-zips=/var/opt/dans.knaw.nl/tmp/easy-deposit-api/stage-zips
 deposits.drafts=/var/opt/dans.knaw.nl/tmp/easy-deposit-api/drafts

--- a/src/main/assembly/dist/cfg/application.properties
+++ b/src/main/assembly/dist/cfg/application.properties
@@ -19,9 +19,9 @@ daemon.http.port=20190
 #
 # Note that the stage-* directories only have temporary content, so the service should clear them automatically.
 #
-deposits.stage-zips=/var/opt/dans.knaw.nl/tmp/easy-deposit-api/stage-upload
+deposits.stage-zips=/var/opt/dans.knaw.nl/tmp/easy-deposit-api/stage-zips
 deposits.drafts=/var/opt/dans.knaw.nl/tmp/easy-deposit-api/drafts
-deposits.stage-for-submit=/var/opt/dans.knaw.nl/tmp/easy-deposit-api/stage
+deposits.stage-for-submit=/var/opt/dans.knaw.nl/tmp/easy-deposit-api/stage-for-submit
 deposits.submit-to=/var/opt/dans.knaw.nl/tmp/easy-ingest-flow-inbox
 
 # The group to assign to the files and directories making up the deposit, before moving it to submit-to.

--- a/src/main/assembly/dist/cfg/application.properties
+++ b/src/main/assembly/dist/cfg/application.properties
@@ -10,11 +10,11 @@ daemon.http.port=20190
 #
 # 1.   Created in the drafts directory.
 # 2.   On submit: copied to stage and then that copy is moved to the submit-to directory.
-# 3a)  If archived successfully the bag in the draft-copy is deleted
+# 3a)  If archived successfully the bag in the stage is moved to submit-to
 # 3b)  If the deposit is rejected, the depositor can reopen the draft, modify it and resubmit it.
 #
-# stage and submit-to must be on a single mount to allow moving
-# stage.upload and draft must be on a single mount to allow moving
+# stage and submit-to must be on a single mount to allow moving from the first to the latter
+# stage.upload and draft must be on a single mount to allow moving zip-content into the draft bag
 #
 deposits.stage.upload=/var/opt/dans.knaw.nl/tmp/easy-deposit/stage-upload
 deposits.drafts=/var/opt/dans.knaw.nl/tmp/easy-deposit/drafts

--- a/src/main/assembly/dist/cfg/application.properties
+++ b/src/main/assembly/dist/cfg/application.properties
@@ -21,6 +21,9 @@ deposits.drafts=/var/opt/dans.knaw.nl/tmp/easy-deposit/drafts
 deposits.stage=/var/opt/dans.knaw.nl/tmp/easy-deposit/stage
 deposits.submit-to=/var/opt/dans.knaw.nl/tmp/easy-ingest-flow-inbox
 
+deposit.permissions.access=rwxrwx---
+deposit.permissions.group=deposits
+
 #
 # Settings for user authentication. The LDAP directory at ldap-url is used to check the credentials
 # of the user by trying to access the entry:

--- a/src/main/assembly/dist/cfg/application.properties
+++ b/src/main/assembly/dist/cfg/application.properties
@@ -1,4 +1,8 @@
-### General settings ###
+#
+# EASY deposit-api configuration file
+#
+# Please, modify the configuration below to match your environment. Also, delete and/or modify
+# this description.
 
 #
 # Port that the HTTP-service listens on.

--- a/src/main/rpm/2-post-install.sh
+++ b/src/main/rpm/2-post-install.sh
@@ -20,9 +20,9 @@
 NUMBER_OF_INSTALLATIONS=$1
 MODULE_NAME=easy-deposit-api
 INSTALL_DIR=/opt/dans.knaw.nl/$MODULE_NAME
-DEPOSITS_STAGE_UPLOAD=/var/opt/dans.knaw.nl/tmp/easy-deposit-api/stage-upload
+DEPOSITS_STAGE_ZIPS=/var/opt/dans.knaw.nl/tmp/easy-deposit-api/stage-zips
 DEPOSITS_DRAFTS=/var/opt/dans.knaw.nl/tmp/easy-deposit-api/drafts
-DEPOSITS_STAGE=/var/opt/dans.knaw.nl/tmp/easy-deposit-api/stage
+DEPOSITS_STAGE_FOR_SUBMIT=/var/opt/dans.knaw.nl/tmp/easy-deposit-api/stage-for-submit
 DEPOSITS_SUBMIT_TO=/var/opt/dans.knaw.nl/tmp/easy-ingest-flow-inbox
 PHASE="POST-INSTALL"
 
@@ -32,24 +32,24 @@ service_install_systemd_unit "$INSTALL_DIR/install/$MODULE_NAME.service" $MODULE
 service_create_log_directory $MODULE_NAME
 echo "$PHASE: DONE"
 
-if [[ ! -d ${DEPOSITS_STAGE_UPLOAD} ]]; then
-  echo -n "Creating deposits stage/upload directory at ${DEPOSITS_STAGE_UPLOAD}..."
-  mkdir -p ${DEPOSITS_STAGE_UPLOAD}
-  chmod 755 ${DEPOSITS_STAGE_UPLOAD}
+if [[ ! -d ${DEPOSITS_STAGE_ZIPS} ]]; then
+  echo -n "Creating deposits stage/upload directory at ${DEPOSITS_STAGE_ZIPS}..."
+  mkdir -p ${DEPOSITS_STAGE_ZIPS}
+  chmod 755 ${DEPOSITS_STAGE_ZIPS}
   echo "OK"
 fi
 
 if [[ ! -d ${DEPOSITS_DRAFTS} ]]; then
-  echo -n "Creating deposits draft directory at ${DEPOSITS_STAGE}..."
+  echo -n "Creating deposits draft directory at ${DEPOSITS_STAGE_FOR_SUBMIT}..."
   mkdir -p ${DEPOSITS_DRAFTS}
   chmod 755 ${DEPOSITS_DRAFTS}
   echo "OK"
 fi
 
-if [[ ! -d ${DEPOSITS_STAGE} ]]; then
-  echo -n "Creating deposits stage directory at ${DEPOSITS_STAGE}..."
-  mkdir -p ${DEPOSITS_STAGE}
-  chmod 755 ${DEPOSITS_STAGE}
+if [[ ! -d ${DEPOSITS_STAGE_FOR_SUBMIT} ]]; then
+  echo -n "Creating deposits stage directory at ${DEPOSITS_STAGE_FOR_SUBMIT}..."
+  mkdir -p ${DEPOSITS_STAGE_FOR_SUBMIT}
+  chmod 755 ${DEPOSITS_STAGE_FOR_SUBMIT}
   echo "OK"
 fi
 

--- a/src/main/scala/nl.knaw.dans.easy.deposit/EasyDepositApiApp.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/EasyDepositApiApp.scala
@@ -15,9 +15,8 @@
  */
 package nl.knaw.dans.easy.deposit
 
-import java.io.{ IOException, InputStream }
+import java.io.InputStream
 import java.net.URI
-import java.nio.file.attribute.{ GroupPrincipal, UserPrincipalNotFoundException }
 import java.nio.file.{ FileAlreadyExistsException, Path }
 import java.util.UUID
 
@@ -31,7 +30,6 @@ import nl.knaw.dans.lib.error._
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
 import org.apache.commons.configuration.PropertiesConfiguration
 
-import scala.util.control.NonFatal
 import scala.util.{ Failure, Success, Try }
 
 class EasyDepositApiApp(configuration: Configuration) extends DebugEnhancedLogging

--- a/src/main/scala/nl.knaw.dans.easy.deposit/EasyDepositApiApp.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/EasyDepositApiApp.scala
@@ -60,7 +60,7 @@ class EasyDepositApiApp(configuration: Configuration) extends DebugEnhancedLoggi
   }
 
   private val uploadStagingDir = {
-    val dir = getConfiguredDirectory("deposits.stage.upload")
+    val dir = getConfiguredDirectory("deposits.stage-zips")
     logger.info(s"Uploads are staged in $dir")
     if (dir.nonEmpty) {
       val msg = s"Pending uploads were probably interrupted. See logs lines with 'POST /deposit/{id}/file/{dir_path}'. Please remove their directories from the staging area: $dir"
@@ -72,7 +72,7 @@ class EasyDepositApiApp(configuration: Configuration) extends DebugEnhancedLoggi
   private val draftsDir = getConfiguredDirectory("deposits.drafts")
 
   private val submitter = new Submitter(
-    getConfiguredDirectory("deposits.stage"),
+    getConfiguredDirectory("deposits.stage-for-submit"),
     getConfiguredDirectory("deposits.submit-to"),
     configuration.properties.getString("deposit.permissions.group"),
   )

--- a/src/main/scala/nl.knaw.dans.easy.deposit/EasyDepositApiApp.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/EasyDepositApiApp.scala
@@ -17,7 +17,7 @@ package nl.knaw.dans.easy.deposit
 
 import java.io.{ IOException, InputStream }
 import java.net.URI
-import java.nio.file.attribute.UserPrincipalNotFoundException
+import java.nio.file.attribute.{ GroupPrincipal, UserPrincipalNotFoundException }
 import java.nio.file.{ FileAlreadyExistsException, Path }
 import java.util.UUID
 
@@ -72,18 +72,23 @@ class EasyDepositApiApp(configuration: Configuration) extends DebugEnhancedLoggi
     dir
   }
   private val draftsDir = getConfiguredDirectory("deposits.drafts")
-  private val stagingDir = getConfiguredDirectory("deposits.stage")
-  private val submitToDir = getConfiguredDirectory("deposits.submit-to")
 
-  private val group = configuration.properties.getString("deposit.permissions.group")
-  private val principal = Try {
-    stagingDir.path.getFileSystem.getUserPrincipalLookupService.lookupPrincipalByGroupName(group)
-  }.getOrRecover {
-    case e: UserPrincipalNotFoundException => throw new IOException(s"Group $group could not be found", e)
-    case e: UnsupportedOperationException => throw new IOException("Not on a POSIX supported file system", e)
-    case NonFatal(e) => throw new IOException(s"unexpected error occured on $stagingDir", e)
+  private val submitter = new Submitter(
+    getConfiguredDirectory("deposits.stage"),
+    getConfiguredDirectory("deposits.submit-to"),
+    getGroupPrincipal(configuration.properties.getString("deposit.permissions.group"))
+  )
+
+  private def getGroupPrincipal(groupName: String): GroupPrincipal = {
+    val dir = getConfiguredDirectory("deposits.stage")
+    Try {
+      dir.path.getFileSystem.getUserPrincipalLookupService.lookupPrincipalByGroupName(groupName)
+    }.getOrRecover {
+      case e: UserPrincipalNotFoundException => throw new IOException(s"Group $groupName could not be found", e)
+      case e: UnsupportedOperationException => throw new IOException("Not on a POSIX supported file system", e)
+      case NonFatal(e) => throw new IOException(s"unexpected error occured on $dir", e)
+    }
   }
-  private lazy val submitter = new Submitter(stagingDir, submitToDir, principal)
 
   private def getConfiguredDirectory(key: String): File = {
     val dir = File(configuration.properties.getString(key))

--- a/src/main/scala/nl.knaw.dans.easy.deposit/EasyDepositApiApp.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/EasyDepositApiApp.scala
@@ -72,7 +72,6 @@ class EasyDepositApiApp(configuration: Configuration) extends DebugEnhancedLoggi
   private lazy val submitter = new Submitter(
     stagingBaseDir = getConfiguredDirectory("deposits.stage"),
     submitToBaseDir = getConfiguredDirectory("deposits.submit-to"),
-    permissions = configuration.properties.getString("deposit.permissions.access"),
     group = configuration.properties.getString("deposit.permissions.group"),
   )
 

--- a/src/main/scala/nl.knaw.dans.easy.deposit/EasyDepositApiApp.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/EasyDepositApiApp.scala
@@ -71,7 +71,9 @@ class EasyDepositApiApp(configuration: Configuration) extends DebugEnhancedLoggi
   private val draftsDir = getConfiguredDirectory("deposits.drafts")
   private lazy val submitter = new Submitter(
     stagingBaseDir = getConfiguredDirectory("deposits.stage"),
-    submitToBaseDir = getConfiguredDirectory("deposits.submit-to")
+    submitToBaseDir = getConfiguredDirectory("deposits.submit-to"),
+    permissions = configuration.properties.getString("deposit.permissions.access"),
+    group = configuration.properties.getString("deposit.permissions.group"),
   )
 
   private def getConfiguredDirectory(key: String): File = {

--- a/src/main/scala/nl.knaw.dans.easy.deposit/EasyDepositApiApp.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/EasyDepositApiApp.scala
@@ -76,19 +76,8 @@ class EasyDepositApiApp(configuration: Configuration) extends DebugEnhancedLoggi
   private val submitter = new Submitter(
     getConfiguredDirectory("deposits.stage"),
     getConfiguredDirectory("deposits.submit-to"),
-    getGroupPrincipal(configuration.properties.getString("deposit.permissions.group"))
+    configuration.properties.getString("deposit.permissions.group"),
   )
-
-  private def getGroupPrincipal(groupName: String): GroupPrincipal = {
-    val dir = getConfiguredDirectory("deposits.stage")
-    Try {
-      dir.path.getFileSystem.getUserPrincipalLookupService.lookupPrincipalByGroupName(groupName)
-    }.getOrRecover {
-      case e: UserPrincipalNotFoundException => throw new IOException(s"Group $groupName could not be found", e)
-      case e: UnsupportedOperationException => throw new IOException("Not on a POSIX supported file system", e)
-      case NonFatal(e) => throw new IOException(s"unexpected error occured on $dir", e)
-    }
-  }
 
   private def getConfiguredDirectory(key: String): File = {
     val dir = File(configuration.properties.getString(key))

--- a/src/main/scala/nl.knaw.dans.easy.deposit/Submitter.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/Submitter.scala
@@ -15,6 +15,7 @@
  */
 package nl.knaw.dans.easy.deposit
 
+import java.nio.file.attribute.PosixFilePermission
 import java.nio.file.{ Path, Paths }
 
 import better.files.File
@@ -85,8 +86,14 @@ class Submitter(stagingBaseDir: File,
     // EASY-1464 3.3.7 checksums
     _ <- samePayloadManifestEntries(stageBag, draftBag)
     // EASY-1464 step 3.3.9 Move copy to submit-to area
+    _ = stageBag.baseDir.parent.list.foreach(setRights(_))
     _ = stageBag.baseDir.parent.moveTo(submitDir)
   } yield ()
+
+  private def setRights(file: File) = {
+    file.addPermission(PosixFilePermission.GROUP_WRITE)
+    file.setGroup("deposits")
+  }
 
   type ManifestItems = Map[File, String]
   type ManifestMap = Map[ChecksumAlgorithm, ManifestItems]

--- a/src/main/scala/nl.knaw.dans.easy.deposit/Submitter.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/Submitter.scala
@@ -20,6 +20,7 @@ import java.nio.file._
 import java.nio.file.attribute.{ PosixFileAttributeView, PosixFilePermissions, UserPrincipalNotFoundException }
 
 import better.files.File
+import better.files.File.VisitOptions
 import nl.knaw.dans.bag.ChecksumAlgorithm.ChecksumAlgorithm
 import nl.knaw.dans.bag.DansBag
 import nl.knaw.dans.bag.v0.DansV0Bag
@@ -99,10 +100,10 @@ class Submitter(stagingBaseDir: File,
   } yield ()
 
   private def setRightsRecursively(file: File): Try[Unit] = {
-    val stream = Files.walk(file.path, Int.MaxValue, better.files.File.VisitOptions.default: _*)
+    val javaStream = Files.walk(file.path, Int.MaxValue, VisitOptions.default: _*)
     // toStream makes sure setRights is no longer called once it fails
-    val result = stream.iterator().asScala.toStream.map(setRights).find(_.isFailure).getOrElse(Success(()))
-    stream.close() // in case the underlying java stream is not fully consumed by the iterator
+    val result = javaStream.iterator().asScala.toStream.map(setRights).find(_.isFailure).getOrElse(Success(()))
+    javaStream.close() // in case the underlying java stream is not fully consumed by the iterator
     result
   }
 

--- a/src/main/scala/nl.knaw.dans.easy.deposit/Submitter.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/Submitter.scala
@@ -18,7 +18,7 @@ package nl.knaw.dans.easy.deposit
 import java.io.IOException
 import java.nio.file._
 import java.nio.file.attribute.PosixFilePermission.GROUP_WRITE
-import java.nio.file.attribute.{ GroupPrincipal, PosixFileAttributeView, UserPrincipalNotFoundException }
+import java.nio.file.attribute.{ PosixFileAttributeView, UserPrincipalNotFoundException }
 
 import better.files.File
 import better.files.File.VisitOptions
@@ -26,13 +26,13 @@ import nl.knaw.dans.bag.ChecksumAlgorithm.ChecksumAlgorithm
 import nl.knaw.dans.bag.DansBag
 import nl.knaw.dans.bag.v0.DansV0Bag
 import nl.knaw.dans.easy.deposit.docs.{ AgreementsXml, DDM, FilesXml, StateInfo }
+import nl.knaw.dans.lib.error._
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
 import org.joda.time.DateTime
 
 import scala.collection.JavaConverters._
 import scala.util.control.NonFatal
 import scala.util.{ Failure, Success, Try }
-import nl.knaw.dans.lib.error._
 
 /**
  * Object that contains the logic for submitting a deposit.
@@ -44,7 +44,7 @@ class Submitter(stagingBaseDir: File,
                 submitToBaseDir: File,
                 groupName: String,
                ) extends DebugEnhancedLogging {
-  private val groupPrincipal =  {
+  private val groupPrincipal = {
     Try {
       stagingBaseDir.path.getFileSystem.getUserPrincipalLookupService.lookupPrincipalByGroupName(groupName)
     }.getOrRecover {

--- a/src/test/resources/debug-config/application.properties
+++ b/src/test/resources/debug-config/application.properties
@@ -21,6 +21,7 @@ deposits.drafts=data/drafts
 deposits.stage=data/stage
 deposits.submit-to=data/easy-ingest-flow-inbox
 
+# file rights that allow easy-ingest-flow to process deposits from its inbox
 deposit.permissions.access=rwxrwx---
 deposit.permissions.group=deposits
 

--- a/src/test/resources/debug-config/application.properties
+++ b/src/test/resources/debug-config/application.properties
@@ -21,6 +21,9 @@ deposits.drafts=data/drafts
 deposits.stage=data/stage
 deposits.submit-to=data/easy-ingest-flow-inbox
 
+deposit.permissions.access=rwxrwx---
+deposit.permissions.group=deposits
+
 #
 # Settings for user authentication. The LDAP directory at ldap-url is used to check the credentials
 # of the user by trying to access the entry:

--- a/src/test/resources/debug-config/application.properties
+++ b/src/test/resources/debug-config/application.properties
@@ -10,11 +10,11 @@ daemon.http.port=20190
 #
 # 1.   Created in the drafts directory.
 # 2.   On submit: copied to stage and then that copy is moved to the submit-to directory.
-# 3a)  If archived successfully the bag in the draft-copy is deleted
+# 3a)  If archived successfully the deposit in stage is moved to submit-to
 # 3b)  If the deposit is rejected, the depositor can reopen the draft, modify it and resubmit it.
 #
-# stage and submit-to must be on a single mount to allow moving
-# stage.upload and draft must be on a single mount to allow moving
+# stage and submit-to must be on a single mount to allow moving from the first to the latter
+# stage.upload and draft must be on a single mount to allow moving zip-content into the draft bag
 #
 deposits.stage.upload=data/stage-upload
 deposits.drafts=data/drafts

--- a/src/test/resources/debug-config/application.properties
+++ b/src/test/resources/debug-config/application.properties
@@ -19,9 +19,9 @@ daemon.http.port=20190
 #
 # Note that the stage-* directories only have temporary content, so the service should clear them automatically.
 #
-deposits.stage-zips=data/stage-upload
+deposits.stage-zips=data/stage-zips
 deposits.drafts=data/drafts
-deposits.stage-for-submit=data/stage
+deposits.stage-for-submit=data/stage-for-submit
 deposits.submit-to=data/easy-ingest-flow-inbox
 
 # file rights that allow easy-ingest-flow to process deposits from its inbox

--- a/src/test/resources/debug-config/application.properties
+++ b/src/test/resources/debug-config/application.properties
@@ -22,7 +22,6 @@ deposits.stage=data/stage
 deposits.submit-to=data/easy-ingest-flow-inbox
 
 # file rights that allow easy-ingest-flow to process deposits from its inbox
-deposit.permissions.access=rwxrwx---
 deposit.permissions.group=deposits
 
 #

--- a/src/test/resources/debug-config/application.properties
+++ b/src/test/resources/debug-config/application.properties
@@ -1,73 +1,20 @@
-### General settings ###
-
-#
-# Port that the HTTP-service listens on.
-#
 daemon.http.port=20190
 
-#
-# Directories for managing the deposits.
-#
-# - stage-zips:       is used for uploads of zipped directories or complete deposits.
-# - drafts:           contains the draft deposits; single files are uploaded here directly,
-#                     unzipped directories and deposits are moved here from stage-zips.
-# - stage-for-submit: the completed draft is copied here when the user submits it.
-# - submit-to:        the deposit copy in stage-for-submit is moved here on successful completion
-#                     of a submit request.  As moving is an atomic action this prevents further
-#                     processing of incomplete deposits.
-#
-# N.B. stage-zips and drafts must be located on the same partition in order to support atomic moving.
-# The same holds for stage-for-submit and submit-to.
-#
-# Note that the stage-* directories only have temporary content, so the service should clear them
-# automatically on completion of a request.
-#
 deposits.stage-zips=data/stage-zips
 deposits.drafts=data/drafts
 deposits.stage-for-submit=data/stage-for-submit
 deposits.submit-to=data/easy-ingest-flow-inbox
 
-# The group to assign to the files and directories making up the deposit, before moving it to submit-to.
 deposit.permissions.group=deposits
 
-#
-# Settings for user authentication. The LDAP directory at ldap-url is used to check the credentials
-# of the user by trying to access the entry:
-#
-# <ldap-user-id-attr-name>=<username>, <ldap-parent-entry>
-#
-# For example user jdoe wants to connect. With the defaults this will result in easy-deposit-api
-# to try and access
-#
-# uid=jdoe,ou=users,ou=easy,dc=dans,dc=knaw,dc=nl
-#
-# LDAP should be set up so as to only allow access to users with the correct password.
-#
 users.ldap-url=ldap://deasy.dans.knaw.nl
 users.ldap-parent-entry=ou=users,ou=easy,dc=dans,dc=knaw,dc=nl
 users.ldap-user-id-attr-name=uid
-
-#
-# Settings required to fetch user data when we no longer have the user's password.
-#
 users.ldap-admin-principal=cn=ldapadmin,dc=dans,dc=knaw,dc=nl
 users.ldap-admin-password=ldapadmin
 
-#
-# Base URL of the easy-pid-generator service to use for minting DOIs.
-#
 pids.generator-service=http://deasy.dans.knaw.nl:20140/
 
-#
-# Lifetime for JSON Web Token cookie (named "scentry.auth.default.user") in seconds.
-# (Example: 3600 ( = 60 * 60 = is one hour ).
-#
 auth.cookie.expiresIn=600
-
-#
-# Symmetric algorithm and secret key to use for JSON Web Token. Algorithm can be any of the values implementing JwtHmacAlgorithm, see fromString in:
-#
-# https://github.com/pauldijou/jwt-scala/blob/master/core/common/src/main/scala/JwtAlgorithm.scala
-#
 auth.jwt.hmac.algorithm=HS256
 auth.jwt.secret.key=changeMe

--- a/src/test/resources/debug-config/application.properties
+++ b/src/test/resources/debug-config/application.properties
@@ -8,23 +8,26 @@ daemon.http.port=20190
 #
 # Directories for managing the deposits.
 #
-# - stage-zips: is used for uploads of zipped directories or complete deposits.
-# - drafts: contains the draft deposits; single files are uploaded here directly, unzipped directories and deposits
-#     are moved here from stage-zips.
+# - stage-zips:       is used for uploads of zipped directories or complete deposits.
+# - drafts:           contains the draft deposits; single files are uploaded here directly,
+#                     unzipped directories and deposits are moved here from stage-zips.
 # - stage-for-submit: the completed draft is copied here when the user submits it.
-# - submit-to: the target directory to which the copy in stage-for-submit is moved for further processing.
+# - submit-to:        the deposit copy in stage-for-submit is moved here on successful completion
+#                     of a submit request.  As moving is an atomic action this prevents further
+#                     processing of incomplete deposits.
 #
-# N.B. stage-zips and drafts must be located on the same partition in order to support atomic moving. The same
-# holds for stage-for-submit and submit-to.
+# N.B. stage-zips and drafts must be located on the same partition in order to support atomic moving.
+# The same holds for stage-for-submit and submit-to.
 #
-# Note that the stage-* directories only have temporary content, so the service should clear them automatically.
+# Note that the stage-* directories only have temporary content, so the service should clear them
+# automatically on completion of a request.
 #
 deposits.stage-zips=data/stage-zips
 deposits.drafts=data/drafts
 deposits.stage-for-submit=data/stage-for-submit
 deposits.submit-to=data/easy-ingest-flow-inbox
 
-# file rights that allow easy-ingest-flow to process deposits from its inbox
+# The group to assign to the files and directories making up the deposit, before moving it to submit-to.
 deposit.permissions.group=deposits
 
 #
@@ -44,16 +47,27 @@ users.ldap-url=ldap://deasy.dans.knaw.nl
 users.ldap-parent-entry=ou=users,ou=easy,dc=dans,dc=knaw,dc=nl
 users.ldap-user-id-attr-name=uid
 
-# Settings required to fetch user data when we no longer have its password.
+#
+# Settings required to fetch user data when we no longer have the user's password.
+#
 users.ldap-admin-principal=cn=ldapadmin,dc=dans,dc=knaw,dc=nl
 users.ldap-admin-password=ldapadmin
 
+#
+# Base URL of the easy-pid-generator service to use for minting DOIs.
+#
 pids.generator-service=http://deasy.dans.knaw.nl:20140/
 
-# Lifetime for cookie with name scentry.auth.default.user that contains the jwt after providing valid credentials.
-# In seconds, 60*10=600 is 10 minutes
+#
+# Lifetime for JSON Web Token cookie (named "scentry.auth.default.user") in seconds.
+# (Example: 3600 ( = 60 * 60 = is one hour ).
+#
 auth.cookie.expiresIn=600
 
-# Pick a value starting with H, see fromString in https://github.com/pauldijou/jwt-scala/blob/master/core/common/src/main/scala/JwtAlgorithm.scala
+#
+# Symmetric algorithm and secret key to use for JSON Web Token. Algorithm can be any of the values implementing JwtHmacAlgorithm, see fromString in:
+#
+# https://github.com/pauldijou/jwt-scala/blob/master/core/common/src/main/scala/JwtAlgorithm.scala
+#
 auth.jwt.hmac.algorithm=HS256
 auth.jwt.secret.key=changeMe

--- a/src/test/resources/debug-config/application.properties
+++ b/src/test/resources/debug-config/application.properties
@@ -6,19 +6,22 @@
 daemon.http.port=20190
 
 #
-# Directories for managing the deposits. The lifecycle of a deposit is:
+# Directories for managing the deposits.
 #
-# 1.   Created in the drafts directory.
-# 2.   On submit: copied to stage and then that copy is moved to the submit-to directory.
-# 3a)  If archived successfully the deposit in stage is moved to submit-to
-# 3b)  If the deposit is rejected, the depositor can reopen the draft, modify it and resubmit it.
+# - stage-zips: is used for uploads of zipped directories or complete deposits.
+# - drafts: contains the draft deposits; single files are uploaded here directly, unzipped directories and deposits
+#     are moved here from stage-zips.
+# - stage-for-submit: the completed draft is copied here when the user submits it.
+# - submit-to: the target directory to which the copy in stage-for-submit is moved for further processing.
 #
-# stage and submit-to must be on a single mount to allow moving from the first to the latter
-# stage.upload and draft must be on a single mount to allow moving zip-content into the draft bag
+# N.B. stage-zips and drafts must be located on the same partition in order to support atomic moving. The same
+# holds for stage-for-submit and submit-to.
 #
-deposits.stage.upload=data/stage-upload
+# Note that the stage-* directories only have temporary content, so the service should clear them automatically.
+#
+deposits.stage-zips=data/stage-upload
 deposits.drafts=data/drafts
-deposits.stage=data/stage
+deposits.stage-for-submit=data/stage
 deposits.submit-to=data/easy-ingest-flow-inbox
 
 # file rights that allow easy-ingest-flow to process deposits from its inbox

--- a/src/test/scala/nl.knaw.dans.easy.deposit/StagedFilesTargetSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/StagedFilesTargetSpec.scala
@@ -28,7 +28,7 @@ import scala.util.{ Failure, Success }
 class StagedFilesTargetSpec extends TestSupportFixture {
 
   private val draftDir = testDir / "draft"
-  private val stagedDir = testDir / "staged"
+  private val stagedDir = testDir / "stage-for-submit"
 
   override def beforeEach(): Unit = {
     super.beforeEach()

--- a/src/test/scala/nl.knaw.dans.easy.deposit/SubmitterSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/SubmitterSpec.scala
@@ -57,7 +57,7 @@ class SubmitterSpec extends TestSupportFixture with MockFactory {
 
     assume(DDM.triedSchema.isAvailable)
     // the test
-    new Submitter(testDir / "staged", testDir / "submitted")
+    new Submitter(testDir / "staged", testDir / "submitted", "rwxrwx---","deposits")
       .submit(depositDir) should matchPattern { case Success(()) => }
 
     // post conditions
@@ -87,7 +87,7 @@ class SubmitterSpec extends TestSupportFixture with MockFactory {
     (testDir / "submitted").createDirectories()
 
     assume(DDM.triedSchema.isAvailable)
-    new Submitter(testDir / "staged", testDir / "submitted")
+    new Submitter(testDir / "staged", testDir / "submitted", "rwxrwx---","deposits")
       .submit(depositDir) should matchPattern { case Success(()) => }
 
     (testDir / "submitted" / depositDir.id.toString / "bag" / "metadata" / "message-from-depositor.txt")
@@ -106,7 +106,7 @@ class SubmitterSpec extends TestSupportFixture with MockFactory {
     (bag.baseDir / "manifest-sha1.txt").append("chk file")
 
     assume(DDM.triedSchema.isAvailable)
-    new Submitter(testDir / "staged", testDir / "submitted").submit(depositDir) should matchPattern {
+    new Submitter(testDir / "staged", testDir / "submitted", "rwxrwx---","deposits").submit(depositDir) should matchPattern {
       case Failure(e) if e.getMessage == s"invalid bag, missing [files, checksums]: [Set($testDir/drafts/user/${ depositDir.id }/bag/file), Set()]" =>
     }
   }
@@ -125,7 +125,7 @@ class SubmitterSpec extends TestSupportFixture with MockFactory {
 
     val checksum = "a57ec0c3239f30b29f1e9270581be50a70c74c04"
     assume(DDM.triedSchema.isAvailable)
-    new Submitter(testDir / "staged", testDir / "submitted").submit(depositDir) should matchPattern {
+    new Submitter(testDir / "staged", testDir / "submitted", "rwxrwx---","deposits").submit(depositDir) should matchPattern {
       case Failure(e)
         if e.getMessage == s"staged and draft bag [${ bag.baseDir.parent }] have different payload manifest elements: (Set((data/file.txt,$checksum)),Set((data/file.txt,${ checksum }xxx)))" =>
     }

--- a/src/test/scala/nl.knaw.dans.easy.deposit/SubmitterSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/SubmitterSpec.scala
@@ -17,11 +17,9 @@ package nl.knaw.dans.easy.deposit
 
 import java.io.IOException
 import java.nio.file.Paths
-import java.nio.file.attribute.UserPrincipalNotFoundException
 
 import better.files.{ File, StringOps }
 import nl.knaw.dans.bag.DansBag
-import nl.knaw.dans.bag.v0.DansV0Bag
 import nl.knaw.dans.easy.deposit.docs.StateInfo.State
 import nl.knaw.dans.easy.deposit.docs._
 import nl.knaw.dans.lib.error._

--- a/src/test/scala/nl.knaw.dans.easy.deposit/SubmitterSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/SubmitterSpec.scala
@@ -19,7 +19,7 @@ import java.io.IOException
 import java.nio.file.Paths
 import java.nio.file.attribute.UserPrincipalNotFoundException
 
-import better.files.StringOps
+import better.files.{ File, StringOps }
 import nl.knaw.dans.bag.DansBag
 import nl.knaw.dans.easy.deposit.docs.StateInfo.State
 import nl.knaw.dans.easy.deposit.docs._
@@ -160,7 +160,7 @@ class SubmitterSpec extends TestSupportFixture with MockFactory {
     }
   }
 
-  private def addDoiToDepositProperties(bag: DansBag) = {
+  private def addDoiToDepositProperties(bag: DansBag): File = {
     (bag.baseDir.parent / "deposit.properties").append(s"identifier.doi=$doi")
   }
 

--- a/src/test/scala/nl.knaw.dans.easy.deposit/SubmitterSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/SubmitterSpec.scala
@@ -41,18 +41,9 @@ class SubmitterSpec extends TestSupportFixture with MockFactory {
   private val doi = datasetMetadata.doi
     .getOrElse(fail("could not get DOI from test input"))
 
-  "constructor" should "fail if invalid access permissions are configured" in {
+  "constructor" should "fail if the group does not exist" in {
     Try {
-      new Submitter(testDir / "staged", testDir / "submitted", "abcdefghi", userGroup)
-    } should matchPattern {
-      case Failure(e: IllegalArgumentException) if e.getMessage ==
-        "Invalid mode" =>
-    }
-  }
-
-  it should "fail if the group does not exist" in {
-    Try {
-      new Submitter(testDir / "staged", testDir / "submitted", "rwxrwx---", "non-existing-group-name")
+      new Submitter(testDir / "staged", testDir / "submitted", "non-existing-group-name")
     } should matchPattern {
       case Failure(e: UserPrincipalNotFoundException) =>
     }
@@ -63,7 +54,7 @@ class SubmitterSpec extends TestSupportFixture with MockFactory {
     val depositDir = createDeposit(datasetMetadata)
     addDoiToDepositProperties(getBag(depositDir))
 
-    new Submitter(testDir / "staged", testDir / "submitted", "rwxrwx---", unrelatedGroup)
+    new Submitter(testDir / "staged", testDir / "submitted", unrelatedGroup)
       .submit(depositDir) should matchPattern {
       case Failure(e: IOException) if e.getMessage matches
         ".*Probably the current user .* is not part of this group.*" =>
@@ -89,7 +80,7 @@ class SubmitterSpec extends TestSupportFixture with MockFactory {
 
     assume(DDM.triedSchema.isAvailable)
     // the test
-    new Submitter(testDir / "staged", testDir / "submitted", "rwxrwx---", userGroup)
+    new Submitter(testDir / "staged", testDir / "submitted", userGroup)
       .submit(depositDir) should matchPattern { case Success(()) => }
 
     // post conditions
@@ -117,7 +108,7 @@ class SubmitterSpec extends TestSupportFixture with MockFactory {
     addDoiToDepositProperties(getBag(depositDir))
 
     assume(DDM.triedSchema.isAvailable)
-    new Submitter(testDir / "staged", testDir / "submitted", "rwxrwx---", userGroup)
+    new Submitter(testDir / "staged", testDir / "submitted", userGroup)
       .submit(depositDir) should matchPattern { case Success(()) => }
 
     (testDir / "submitted" / depositDir.id.toString / "bag" / "metadata" / "message-from-depositor.txt")
@@ -135,7 +126,7 @@ class SubmitterSpec extends TestSupportFixture with MockFactory {
     (bag.baseDir / "manifest-sha1.txt").append("chk file")
 
     assume(DDM.triedSchema.isAvailable)
-    new Submitter(testDir / "staged", testDir / "submitted", "rwxrwx---", userGroup).submit(depositDir) should matchPattern {
+    new Submitter(testDir / "staged", testDir / "submitted", userGroup).submit(depositDir) should matchPattern {
       case Failure(e) if e.getMessage == s"invalid bag, missing [files, checksums]: [Set($testDir/drafts/user/${ depositDir.id }/bag/file), Set()]" =>
     }
   }
@@ -153,7 +144,7 @@ class SubmitterSpec extends TestSupportFixture with MockFactory {
 
     val checksum = "a57ec0c3239f30b29f1e9270581be50a70c74c04"
     assume(DDM.triedSchema.isAvailable)
-    new Submitter(testDir / "staged", testDir / "submitted", "rwxrwx---", userGroup).submit(depositDir) should matchPattern {
+    new Submitter(testDir / "staged", testDir / "submitted", userGroup).submit(depositDir) should matchPattern {
       case Failure(e)
         if e.getMessage == s"staged and draft bag [${ bag.baseDir.parent }] have different payload manifest elements: (Set((data/file.txt,$checksum)),Set((data/file.txt,${ checksum }xxx)))" =>
     }

--- a/src/test/scala/nl.knaw.dans.easy.deposit/SubmitterSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/SubmitterSpec.scala
@@ -18,7 +18,7 @@ package nl.knaw.dans.easy.deposit
 import java.io.IOException
 import java.nio.file.Paths
 
-import better.files.{ File, StringOps }
+import better.files.StringOps
 import nl.knaw.dans.bag.DansBag
 import nl.knaw.dans.easy.deposit.docs.StateInfo.State
 import nl.knaw.dans.easy.deposit.docs._
@@ -44,9 +44,8 @@ class SubmitterSpec extends TestSupportFixture with MockFactory {
     val props = minimalAppConfig.properties
     props.setProperty("deposit.permissions.group", "not-existing-group")
 
-    Try(new EasyDepositApiApp(new Configuration("", props))) should matchPattern {
-      case Failure(e: IOException) if e.getMessage == "Group not-existing-group could not be found" =>
-    }
+    the [IOException] thrownBy new EasyDepositApiApp(new Configuration("", props)) should
+      have message "Group not-existing-group could not be found"
   }
 
   "submit" should "fail if the user is not part of the given group" in {
@@ -150,7 +149,7 @@ class SubmitterSpec extends TestSupportFixture with MockFactory {
     }
   }
 
-  private def addDoiToDepositProperties(bag: DansBag): File = {
+  private def addDoiToDepositProperties(bag: DansBag): Unit = {
     (bag.baseDir.parent / "deposit.properties").append(s"identifier.doi=$doi")
   }
 

--- a/src/test/scala/nl.knaw.dans.easy.deposit/SubmitterSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/SubmitterSpec.scala
@@ -57,7 +57,7 @@ class SubmitterSpec extends TestSupportFixture with MockFactory {
 
     assume(DDM.triedSchema.isAvailable)
     // the test
-    new Submitter(testDir / "staged", testDir / "submitted", "rwxrwx---","deposits")
+    new Submitter(testDir / "staged", testDir / "submitted", "rwxrwx---", userGroup)
       .submit(depositDir) should matchPattern { case Success(()) => }
 
     // post conditions
@@ -87,7 +87,7 @@ class SubmitterSpec extends TestSupportFixture with MockFactory {
     (testDir / "submitted").createDirectories()
 
     assume(DDM.triedSchema.isAvailable)
-    new Submitter(testDir / "staged", testDir / "submitted", "rwxrwx---","deposits")
+    new Submitter(testDir / "staged", testDir / "submitted", "rwxrwx---", userGroup)
       .submit(depositDir) should matchPattern { case Success(()) => }
 
     (testDir / "submitted" / depositDir.id.toString / "bag" / "metadata" / "message-from-depositor.txt")
@@ -106,7 +106,7 @@ class SubmitterSpec extends TestSupportFixture with MockFactory {
     (bag.baseDir / "manifest-sha1.txt").append("chk file")
 
     assume(DDM.triedSchema.isAvailable)
-    new Submitter(testDir / "staged", testDir / "submitted", "rwxrwx---","deposits").submit(depositDir) should matchPattern {
+    new Submitter(testDir / "staged", testDir / "submitted", "rwxrwx---", userGroup).submit(depositDir) should matchPattern {
       case Failure(e) if e.getMessage == s"invalid bag, missing [files, checksums]: [Set($testDir/drafts/user/${ depositDir.id }/bag/file), Set()]" =>
     }
   }
@@ -125,7 +125,7 @@ class SubmitterSpec extends TestSupportFixture with MockFactory {
 
     val checksum = "a57ec0c3239f30b29f1e9270581be50a70c74c04"
     assume(DDM.triedSchema.isAvailable)
-    new Submitter(testDir / "staged", testDir / "submitted", "rwxrwx---","deposits").submit(depositDir) should matchPattern {
+    new Submitter(testDir / "staged", testDir / "submitted", "rwxrwx---", userGroup).submit(depositDir) should matchPattern {
       case Failure(e)
         if e.getMessage == s"staged and draft bag [${ bag.baseDir.parent }] have different payload manifest elements: (Set((data/file.txt,$checksum)),Set((data/file.txt,${ checksum }xxx)))" =>
     }

--- a/src/test/scala/nl.knaw.dans.easy.deposit/SubmitterSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/SubmitterSpec.scala
@@ -17,7 +17,6 @@ package nl.knaw.dans.easy.deposit
 
 import java.io.IOException
 import java.nio.file.Paths
-import java.nio.file.attribute.UserPrincipalNotFoundException
 
 import better.files.{ File, StringOps }
 import nl.knaw.dans.bag.DansBag
@@ -26,7 +25,7 @@ import nl.knaw.dans.easy.deposit.docs._
 import nl.knaw.dans.lib.error._
 import org.scalamock.scalatest.MockFactory
 
-import scala.util.{ Failure, Success, Try }
+import scala.util.{ Failure, Success }
 
 class SubmitterSpec extends TestSupportFixture with MockFactory {
   override def beforeEach(): Unit = {
@@ -40,14 +39,6 @@ class SubmitterSpec extends TestSupportFixture with MockFactory {
     .getOrRecover(e => fail("could not get test input", e))
   private val doi = datasetMetadata.doi
     .getOrElse(fail("could not get DOI from test input"))
-
-  "constructor" should "fail if the group does not exist" in {
-    Try {
-      new Submitter(testDir / "staged", testDir / "submitted", "non-existing-group-name")
-    } should matchPattern {
-      case Failure(e: UserPrincipalNotFoundException) =>
-    }
-  }
 
   "submit" should "fail if the user is not part of the given group" in {
     assume(DDM.triedSchema.isAvailable)

--- a/src/test/scala/nl.knaw.dans.easy.deposit/SubmitterSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/SubmitterSpec.scala
@@ -54,8 +54,7 @@ class SubmitterSpec extends TestSupportFixture with MockFactory {
     Try {
       new Submitter(testDir / "staged", testDir / "submitted", "rwxrwx---", "non-existing-group-name")
     } should matchPattern {
-      case Failure(e: UserPrincipalNotFoundException) if e.getMessage ==
-        "Group non-existing-group-name could not be found" =>
+      case Failure(e: UserPrincipalNotFoundException) =>
     }
   }
 

--- a/src/test/scala/nl.knaw.dans.easy.deposit/SubmitterSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/SubmitterSpec.scala
@@ -42,10 +42,10 @@ class SubmitterSpec extends TestSupportFixture with MockFactory {
 
   "lazy constructor" should "not be called by EasyDepositApiApp if the configured group does not exist" in {
     val props = minimalAppConfig.properties
-    props.setProperty("deposit.permissions.group", "nogroup")
+    props.setProperty("deposit.permissions.group", "not-existing-group")
 
     Try(new EasyDepositApiApp(new Configuration("", props))) should matchPattern {
-      case Failure(e: IOException) if e.getMessage == "Group nogroup could not be found" =>
+      case Failure(e: IOException) if e.getMessage == "Group not-existing-group could not be found" =>
     }
   }
 

--- a/src/test/scala/nl.knaw.dans.easy.deposit/SubmitterSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/SubmitterSpec.scala
@@ -25,7 +25,7 @@ import nl.knaw.dans.easy.deposit.docs._
 import nl.knaw.dans.lib.error._
 import org.scalamock.scalatest.MockFactory
 
-import scala.util.{ Failure, Success, Try }
+import scala.util.{ Failure, Success }
 
 class SubmitterSpec extends TestSupportFixture with MockFactory {
   override def beforeEach(): Unit = {
@@ -40,11 +40,12 @@ class SubmitterSpec extends TestSupportFixture with MockFactory {
   private val doi = datasetMetadata.doi
     .getOrElse(fail("could not get DOI from test input"))
 
-  "lazy constructor" should "not be called by EasyDepositApiApp if the configured group does not exist" in {
+  "constructor" should "fail if the configured group does not exist" in {
     val props = minimalAppConfig.properties
     props.setProperty("deposit.permissions.group", "not-existing-group")
 
-    the [IOException] thrownBy new EasyDepositApiApp(new Configuration("", props)) should
+    // the App creates the Submitter
+    the[IOException] thrownBy new EasyDepositApiApp(new Configuration("", props)) should
       have message "Group not-existing-group could not be found"
   }
 

--- a/src/test/scala/nl.knaw.dans.easy.deposit/SubmitterSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/SubmitterSpec.scala
@@ -54,7 +54,7 @@ class SubmitterSpec extends TestSupportFixture with MockFactory {
     val depositDir = createDeposit(datasetMetadata)
     addDoiToDepositProperties(getBag(depositDir))
 
-    new Submitter(testDir / "staged", testDir / "submitted", unrelatedGroup)
+    new Submitter(testDir / "stage-for-submit", testDir / "submitted", unrelatedGroup)
       .submit(depositDir) should matchPattern {
       case Failure(e: IOException) if e.getMessage matches
         ".*Probably the current user .* is not part of this group.*" =>
@@ -80,11 +80,11 @@ class SubmitterSpec extends TestSupportFixture with MockFactory {
 
     assume(DDM.triedSchema.isAvailable)
     // the test
-    new Submitter(testDir / "staged", testDir / "submitted", userGroup)
+    new Submitter(testDir / "stage-for-submit", testDir / "submitted", userGroup)
       .submit(depositDir) should matchPattern { case Success(()) => }
 
     // post conditions
-    (testDir / "staged").children.size shouldBe 0
+    (testDir / "stage-for-submit").children.size shouldBe 0
     (bagDir / "metadata" / "dataset.json").size shouldBe mdOldSize // no DOI added
     val submittedBagDir = testDir / "submitted" / depositDir.id.toString / "bag"
     (submittedBagDir / "metadata" / "message-from-depositor.txt").contentAsString shouldBe customMessage
@@ -108,7 +108,7 @@ class SubmitterSpec extends TestSupportFixture with MockFactory {
     addDoiToDepositProperties(getBag(depositDir))
 
     assume(DDM.triedSchema.isAvailable)
-    new Submitter(testDir / "staged", testDir / "submitted", userGroup)
+    new Submitter(testDir / "stage-for-submit", testDir / "submitted", userGroup)
       .submit(depositDir) should matchPattern { case Success(()) => }
 
     (testDir / "submitted" / depositDir.id.toString / "bag" / "metadata" / "message-from-depositor.txt")
@@ -126,7 +126,7 @@ class SubmitterSpec extends TestSupportFixture with MockFactory {
     (bag.baseDir / "manifest-sha1.txt").append("chk file")
 
     assume(DDM.triedSchema.isAvailable)
-    new Submitter(testDir / "staged", testDir / "submitted", userGroup).submit(depositDir) should matchPattern {
+    new Submitter(testDir / "stage-for-submit", testDir / "submitted", userGroup).submit(depositDir) should matchPattern {
       case Failure(e) if e.getMessage == s"invalid bag, missing [files, checksums]: [Set($testDir/drafts/user/${ depositDir.id }/bag/file), Set()]" =>
     }
   }
@@ -144,7 +144,7 @@ class SubmitterSpec extends TestSupportFixture with MockFactory {
 
     val checksum = "a57ec0c3239f30b29f1e9270581be50a70c74c04"
     assume(DDM.triedSchema.isAvailable)
-    new Submitter(testDir / "staged", testDir / "submitted", userGroup).submit(depositDir) should matchPattern {
+    new Submitter(testDir / "stage-for-submit", testDir / "submitted", userGroup).submit(depositDir) should matchPattern {
       case Failure(e)
         if e.getMessage == s"staged and draft bag [${ bag.baseDir.parent }] have different payload manifest elements: (Set((data/file.txt,$checksum)),Set((data/file.txt,${ checksum }xxx)))" =>
     }

--- a/src/test/scala/nl.knaw.dans.easy.deposit/TestSupportFixture.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/TestSupportFixture.scala
@@ -38,6 +38,7 @@ trait TestSupportFixture extends FlatSpec with Matchers with Inside with BeforeA
   lazy val testDir: File = currentWorkingDirectory / "target" / "test" / getClass.getSimpleName
   lazy val uuid: UUID = UUID.randomUUID()
 
+  // copied from https://github.com/DANS-KNAW/easy-split-multi-deposit/blob/ea7c2dc3d6/src/test/scala/nl.knaw.dans.easy.multideposit/actions/SetDepositPermissionsSpec.scala#L102
   lazy val (user, userGroup, unrelatedGroup) = {
     import scala.sys.process._
 

--- a/src/test/scala/nl.knaw.dans.easy.deposit/TestSupportFixture.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/TestSupportFixture.scala
@@ -75,8 +75,8 @@ trait TestSupportFixture extends FlatSpec with Matchers with Inside with BeforeA
 
   def minimalAppConfig: Configuration = {
     new Configuration("", new PropertiesConfiguration() {
-      addProperty("deposits.stage-zips", testSubDir("stage-upload").toString())
-      addProperty("deposits.stage-for-submit", testSubDir("stage").toString())
+      addProperty("deposits.stage-zips", testSubDir("stage-zips").toString())
+      addProperty("deposits.stage-for-submit", testSubDir("stage-for-submit").toString())
       addProperty("deposits.drafts", testSubDir("drafts").toString())
       addProperty("deposits.submit-to", testSubDir("easy-ingest-flow-inbox").toString())
       addProperty("deposit.permissions.group", userGroup)

--- a/src/test/scala/nl.knaw.dans.easy.deposit/TestSupportFixture.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/TestSupportFixture.scala
@@ -97,13 +97,6 @@ trait TestSupportFixture extends FlatSpec with Matchers with Inside with BeforeA
     })
   }
 
-  def dansBag: DansBag = {
-    val depositInfo = DepositInfo()
-    val deposit = DepositDir(testDir, "foo", depositInfo.id)
-    val depositDir = deposit.baseDir / "foo" / depositInfo.id.toString
-    DansV0Bag.empty(depositDir / "bag").getOrElse(null)
-  }
-
   private def testSubDir(drafts: String) = {
     (testDir / drafts)
       .delete(true)

--- a/src/test/scala/nl.knaw.dans.easy.deposit/TestSupportFixture.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/TestSupportFixture.scala
@@ -75,8 +75,8 @@ trait TestSupportFixture extends FlatSpec with Matchers with Inside with BeforeA
 
   def minimalAppConfig: Configuration = {
     new Configuration("", new PropertiesConfiguration() {
-      addProperty("deposits.stage.upload", testSubDir("stage-upload").toString())
-      addProperty("deposits.stage", testSubDir("stage").toString())
+      addProperty("deposits.stage-zips", testSubDir("stage-upload").toString())
+      addProperty("deposits.stage-for-submit", testSubDir("stage").toString())
       addProperty("deposits.drafts", testSubDir("drafts").toString())
       addProperty("deposits.submit-to", testSubDir("easy-ingest-flow-inbox").toString())
       addProperty("deposit.permissions.group", userGroup)

--- a/src/test/scala/nl.knaw.dans.easy.deposit/TestSupportFixture.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/TestSupportFixture.scala
@@ -19,12 +19,9 @@ import java.util.{ TimeZone, UUID }
 
 import better.files.File
 import better.files.File._
-import nl.knaw.dans.bag.DansBag
-import nl.knaw.dans.bag.v0.DansV0Bag
 import nl.knaw.dans.easy.deposit.PidRequesterComponent.PidRequester
 import nl.knaw.dans.easy.deposit.authentication.TokenSupport.TokenConfig
 import nl.knaw.dans.easy.deposit.authentication.{ AuthConfig, AuthUser, AuthenticationProvider, TokenSupport }
-import nl.knaw.dans.easy.deposit.docs._
 import org.apache.commons.configuration.PropertiesConfiguration
 import org.joda.time.{ DateTime, DateTimeUtils, DateTimeZone }
 import org.scalamock.scalatest.MockFactory

--- a/src/test/scala/nl.knaw.dans.easy.deposit/TestSupportFixture.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/TestSupportFixture.scala
@@ -46,12 +46,7 @@ trait TestSupportFixture extends FlatSpec with Matchers with Inside with BeforeA
     val userGroups = s"id -Gn $user".!!.split(" ").toList
 
     (userGroups, allGroups.diff(userGroups)) match {
-      case (ug :: _, diff :: _) =>
-        (
-          testDir.path.getFileSystem.getUserPrincipalLookupService.lookupPrincipalByName(user),
-          testDir.path.getFileSystem.getUserPrincipalLookupService.lookupPrincipalByGroupName(ug),
-          testDir.path.getFileSystem.getUserPrincipalLookupService.lookupPrincipalByGroupName(diff),
-        )
+      case (ug :: _, diff :: _) => (user, ug, diff)
       case (Nil, _) => throw new AssertionError("no suitable user group found")
       case (_, Nil) => throw new AssertionError("no suitable unrelated group found")
     }
@@ -84,7 +79,7 @@ trait TestSupportFixture extends FlatSpec with Matchers with Inside with BeforeA
       addProperty("deposits.stage", testSubDir("stage").toString())
       addProperty("deposits.drafts", testSubDir("drafts").toString())
       addProperty("deposits.submit-to", testSubDir("easy-ingest-flow-inbox").toString())
-      addProperty("deposit.permissions.group", userGroup.getName)
+      addProperty("deposit.permissions.group", userGroup)
       addProperty("pids.generator-service", "http://pidHostDoesNotExist.dans.knaw.nl")
       addProperty("users.ldap-url", "http://ldapHostDoesNotExist.dans.knaw.nl")
       addProperty("users.ldap-parent-entry", "-")

--- a/src/test/scala/nl.knaw.dans.easy.deposit/servlets/UploadSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/servlets/UploadSpec.scala
@@ -57,7 +57,7 @@ class UploadSpec extends DepositServletFixture {
         file.contentAsString shouldBe (testDir / "input" / file.name).contentAsString
       )
       (bagDir / "manifest-sha1.txt").lines.size shouldBe bodyParts.size
-      (testDir / "stage-upload").list.size shouldBe 0
+      (testDir / "stage-zips").list.size shouldBe 0
     }
   }
 
@@ -69,7 +69,7 @@ class UploadSpec extends DepositServletFixture {
       ("more", "4.txt", "Ut enim ad minim veniam"),
     ))
     val uuid = createDeposit
-    (testDir / s"stage-upload/foo-$uuid-XYZ").createDirectories() // mocks a concurrent post
+    (testDir / s"stage-zips/foo-$uuid-XYZ").createDirectories() // mocks a concurrent post
     post(
       uri = s"/deposit/$uuid/file/path/to/dir",
       params = Iterable(),
@@ -81,7 +81,7 @@ class UploadSpec extends DepositServletFixture {
       val bagDir = testDir / "drafts/foo" / uuid.toString / "bag"
       (bagDir / "data").list.size shouldBe 0
       (bagDir / "manifest-sha1.txt").lines.size shouldBe 0
-      (testDir / "stage-upload").list.size shouldBe 1
+      (testDir / "stage-zips").list.size shouldBe 1
     }
   }
 

--- a/src/test/scala/nl.knaw.dans.easy.deposit/servlets/UploadSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/servlets/UploadSpec.scala
@@ -198,10 +198,10 @@ class UploadSpec extends DepositServletFixture {
       headers = Seq(fooBarBasicAuthHeader),
     ) {
       status shouldBe OK_200
-      body should include ("""{"filename":"readme.md","dirpath":"path/to/dir",""")
-      body should include ("""{"filename":"._login.html","dirpath":"path/to/dir/__MACOSX",""")
-      body should include ("""{"filename":"upload.html","dirpath":"path/to/dir",""")
-      body should include ("""{"filename":"login.html","dirpath":"path/to/dir",""")
+      body should include("""{"filename":"readme.md","dirpath":"path/to/dir",""")
+      body should include("""{"filename":"._login.html","dirpath":"path/to/dir/__MACOSX",""")
+      body should include("""{"filename":"upload.html","dirpath":"path/to/dir",""")
+      body should include("""{"filename":"login.html","dirpath":"path/to/dir",""")
     }
   }
 
@@ -235,10 +235,10 @@ class UploadSpec extends DepositServletFixture {
       headers = Seq(fooBarBasicAuthHeader),
     ) {
       status shouldBe OK_200
-      body should include ("""{"filename":"readme.md","dirpath":"",""")
-      body should include ("""{"filename":"._login.html","dirpath":"__MACOSX",""")
-      body should include ("""{"filename":"upload.html","dirpath":"",""")
-      body should include ("""{"filename":"login.html","dirpath":"",""")
+      body should include("""{"filename":"readme.md","dirpath":"",""")
+      body should include("""{"filename":"._login.html","dirpath":"__MACOSX",""")
+      body should include("""{"filename":"upload.html","dirpath":"",""")
+      body should include("""{"filename":"login.html","dirpath":"",""")
     }
   }
 


### PR DESCRIPTION
Fixes EASY-1932 file rights before moving to ingest inbox

#### When applied it will
* add group "deposits" to files
* give write access to group
* as a consequence of the above bullets, a deposit with the ui (alias PUT /deposit/{id}/state SUBMITTED) will no longer cause a warning about not writeable files
* [x] decide on configuration parameter when updating dtap 
* [x] test that replaces the dropped one with a non existing group
* [x] rename actual directories to mimic the renamed configuration variables

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

workaround in #115 would no longer be needed 
will still cause validation errors unless the other known issues are fixed

#### Related pull requests on github
* https://github.com/DANS-KNAW/easy-dtap/pull/301 
* the draft #119 has already merge conflicts with this pull request
