### PR TITLE
EASY-1747 (continued) - all fields of [Possibly]Schemed[key]Value types are now optional

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.deposit/docs/DatasetMetadata.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/docs/DatasetMetadata.scala
@@ -36,10 +36,10 @@ case class DatasetMetadata(private val identifiers: Option[Seq[SchemedValue]] = 
                            creators: Option[Seq[Author]] = None,
                            contributors: Option[Seq[Author]] = None,
                            audiences: Option[Seq[SchemedKeyValue]] = None,
-                           subjects: Option[Seq[PossiblySchemedKeyValue]] = None,
+                           subjects: Option[Seq[SchemedKeyValue]] = None,
                            private val alternativeIdentifiers: Option[Seq[SchemedValue]] = None,
                            relations: Option[Seq[RelationType]] = None,
-                           languagesOfFiles: Option[Seq[PossiblySchemedKeyValue]] = None,
+                           languagesOfFiles: Option[Seq[SchemedKeyValue]] = None,
                            private val dates: Option[Seq[Date]] = None,
                            sources: Option[Seq[String]] = None,
                            instructionsForReuse: Option[Seq[String]] = None,
@@ -47,16 +47,17 @@ case class DatasetMetadata(private val identifiers: Option[Seq[SchemedValue]] = 
                            accessRights: Option[AccessRights] = None,
                            license: Option[String] = None,
                            private val typesDcmi: Option[Seq[String]] = None,
-                           private val types: Option[Seq[PossiblySchemedValue]] = None,
-                           formats: Option[Seq[PossiblySchemedValue]] = None,
-                           temporalCoverages: Option[Seq[PossiblySchemedKeyValue]] = None,
+                           private val types: Option[Seq[SchemedValue]] = None,
+                           formats: Option[Seq[SchemedValue]] = None,
+                           temporalCoverages: Option[Seq[SchemedKeyValue]] = None,
                            spatialPoints: Option[Seq[SpatialPoint]] = None,
                            spatialBoxes: Option[Seq[SpatialBox]] = None,
-                           spatialCoverages: Option[Seq[PossiblySchemedKeyValue]] = None,
+                           spatialCoverages: Option[Seq[SchemedKeyValue]] = None,
                            messageForDataManager: Option[String] = None,
                            private val privacySensitiveDataPresent: PrivacySensitiveDataPresent = PrivacySensitiveDataPresent.unspecified,
                            acceptDepositAgreement: Boolean = false,
                           ) {
+  // lazy so missing values are only reported when converting to XML
   lazy val hasPrivacySensitiveData: Try[Boolean] = privacySensitiveDataPresent match {
     case PrivacySensitiveDataPresent.yes => Success(true)
     case PrivacySensitiveDataPresent.no => Success(false)
@@ -77,17 +78,17 @@ case class DatasetMetadata(private val identifiers: Option[Seq[SchemedValue]] = 
 
   lazy val allIdentifiers: Seq[SchemedValue] = identifiers.getOrElse(Seq()) ++ alternativeIdentifiers.getOrElse(Seq())
 
-  lazy val allTypes: Seq[PossiblySchemedValue] = types.getOrElse(Seq()) ++ typesDcmi.getOrElse(Seq()).map(
-    PossiblySchemedValue(Some("dcterms:DCMIType"), _)
+  lazy val allTypes: Seq[SchemedValue] = types.getOrElse(Seq()) ++ typesDcmi.getOrElse(Seq()).map(
+    str => SchemedValue("dcterms:DCMIType", str)
   )
 
   //// doi
   lazy val doi: Option[String] = identifiers.flatMap(_.collectFirst {
-    case SchemedValue(`doiScheme`, value) => value
+    case SchemedValue(Some(`doiScheme`), Some(value)) => value
   })
 
   def setDoi(value: String): DatasetMetadata = {
-    val ids = identifiers.getOrElse(Seq.empty).filterNot(_.scheme == doiScheme)
+    val ids = identifiers.getOrElse(Seq.empty).filterNot(_.scheme.contains(doiScheme))
     this.copy(identifiers = Some(ids :+ SchemedValue(doiScheme, value)))
   }
 }
@@ -100,41 +101,5 @@ object DatasetMetadata {
   def missingValue(label: String): InvalidDocumentException = {
     InvalidDocumentException("DatasetMetadata", new Exception(s"Please set $label"))
   }
-
-  trait PossiblySchemed {
-    val scheme: Option[String]
-
-    def schemeAsString: String = scheme match {
-      case Some(s: String) if s.trim.nonEmpty => s.trim
-      case _ => null // will suppress the XML attribute
-    }
-  }
-
-  trait PossiblyKeyed {
-    val key: Option[String]
-
-    def keyAsString: String = key match {
-      case Some(s: String) if s.trim.nonEmpty => s.trim
-      case _ => null
-    }
-  }
-
-  case class SchemedValue(scheme: String,
-                          value: String,
-                         )
-
-  case class PossiblySchemedValue(override val scheme: Option[String],
-                                  value: String,
-                                 ) extends PossiblySchemed
-
-  case class SchemedKeyValue(scheme: String,
-                             key: String,
-                             value: String,
-                            )
-
-  case class PossiblySchemedKeyValue(override val scheme: Option[String],
-                                     override val key: Option[String],
-                                     value: String,
-                                    ) extends PossiblySchemed with PossiblyKeyed
 }
 

--- a/src/main/scala/nl.knaw.dans.easy.deposit/docs/dm/Author.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/docs/dm/Author.scala
@@ -15,12 +15,7 @@
  */
 package nl.knaw.dans.easy.deposit.docs.dm
 
-import nl.knaw.dans.easy.deposit.docs.DatasetMetadata.{ SchemedKeyValue, SchemedValue }
-import nl.knaw.dans.easy.deposit.docs.JsonUtil
-import nl.knaw.dans.easy.deposit.docs.StringUtils._
 import nl.knaw.dans.lib.string._
-
-import scala.util.{ Failure, Success, Try }
 
 case class Author(titles: Option[String] = None,
                   initials: Option[String] = None,
@@ -30,7 +25,7 @@ case class Author(titles: Option[String] = None,
                   ids: Option[Seq[SchemedValue]] = None,
                   organization: Option[String] = None,
                  ) {
-  def isRightsHolder: Boolean = role.exists(_.key == "RightsHolder")
+  def isRightsHolder: Boolean = role.exists(_.key.contains("RightsHolder"))
 
   override def toString: String = { // for <dcterms:rightsHolder>
     def name = Seq(titles, initials, insertions, surname)

--- a/src/main/scala/nl.knaw.dans.easy.deposit/docs/dm/Date.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/docs/dm/Date.scala
@@ -15,9 +15,7 @@
  */
 package nl.knaw.dans.easy.deposit.docs.dm
 
-import nl.knaw.dans.easy.deposit.docs.DatasetMetadata.PossiblySchemed
 import nl.knaw.dans.easy.deposit.docs.JsonUtil.toJson
-import nl.knaw.dans.easy.deposit.docs.StringUtils._
 import nl.knaw.dans.easy.deposit.docs.dm.DateQualifier.DateQualifier
 import org.joda.time.DateTime
 import org.joda.time.format.ISODateTimeFormat

--- a/src/main/scala/nl.knaw.dans.easy.deposit/docs/dm/Schemed.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/docs/dm/Schemed.scala
@@ -1,0 +1,55 @@
+/**
+ * Copyright (C) 2018 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.easy.deposit.docs.dm
+
+
+trait PossiblySchemed {
+  val scheme: Option[String]
+
+  def schemeAsString: String = scheme match {
+    case Some(s: String) if s.trim.nonEmpty => s.trim
+    case _ => null // will suppress the XML attribute
+  }
+}
+
+trait PossiblyKeyed {
+  val key: Option[String]
+
+  def keyAsString: String = key match {
+    case Some(s: String) if s.trim.nonEmpty => s.trim
+    case _ => null
+  }
+}
+
+case class SchemedValue(override val scheme: Option[String],
+                        value: Option[String],
+                       ) extends PossiblySchemed
+object SchemedValue {
+  def apply(scheme: String, value: String): SchemedValue = {
+    SchemedValue(Some(scheme), Some(value))
+  }
+}
+
+case class SchemedKeyValue(override val scheme: Option[String],
+                           override val key: Option[String],
+                           value: Option[String],
+                          ) extends PossiblySchemed with PossiblyKeyed
+
+object SchemedKeyValue {
+  def apply(scheme: String, key: String, value: String): SchemedKeyValue = {
+    SchemedKeyValue(Some(scheme), Some(key), Some(value))
+  }
+}

--- a/src/test/scala/nl.knaw.dans.easy.deposit/docs/DDMSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/docs/DDMSpec.scala
@@ -17,7 +17,6 @@ package nl.knaw.dans.easy.deposit.docs
 
 import javax.xml.validation.Schema
 import nl.knaw.dans.easy.deposit.TestSupportFixture
-import nl.knaw.dans.easy.deposit.docs.DatasetMetadata.{ SchemedKeyValue, SchemedValue }
 import nl.knaw.dans.easy.deposit.docs.JsonUtil.InvalidDocumentException
 import nl.knaw.dans.easy.deposit.docs.dm.DateScheme.W3CDTF
 import nl.knaw.dans.easy.deposit.docs.dm._
@@ -587,7 +586,10 @@ trait DdmBehavior {
       val ddm = triedDDM.getOrRecover(e => fail("should not get past the check above and fail here", e))
 
       assume(triedSchema.isAvailable)
-      triedSchema.validate(ddm) shouldBe a[Success[_]]
+      val result = triedSchema.validate(ddm)
+      if(result.isFailure) // trouble shoot broken tests
+        println(prettyPrinter.format(subset(triedDDM.getOrRecover(e => fail(e)))))
+      result shouldBe a[Success[_]]
     }
   }
 }

--- a/src/test/scala/nl.knaw.dans.easy.deposit/docs/DatasetMetadataSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/docs/DatasetMetadataSpec.scala
@@ -193,9 +193,8 @@ class DatasetMetadataSpec extends TestSupportFixture {
     DatasetMetadata("""{ "contributors": [ { "organization": "University of Zurich" } ] }""") shouldBe a[Success[_]]
   }
 
-  "DatasetMetadata.audience" should "reject an audience without a scheme" in {
-    """{"audiences": [{ "key": "yyy", "value": "" }]}"""
-      .causesInvalidDocumentException("""don't recognize {"audiences":[{"key":"yyy","value":""}]}""")
+  "DatasetMetadata.audience" should "accept an audience without a scheme" in {
+    DatasetMetadata("""{"audiences": [{ "key": "yyy", "value": "" }]}""") shouldBe a[Success[_]]
   }
 
   it should "accept both quoted and non quoted numbers" in {

--- a/src/test/scala/nl.knaw.dans.easy.deposit/docs/MinimalDatasetMetadata.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/docs/MinimalDatasetMetadata.scala
@@ -15,10 +15,9 @@
  */
 package nl.knaw.dans.easy.deposit.docs
 
-import nl.knaw.dans.easy.deposit.docs.DatasetMetadata.{ PossiblySchemedKeyValue, PossiblySchemedValue, SchemedKeyValue, SchemedValue }
 import nl.knaw.dans.easy.deposit.docs.dm.DateScheme.W3CDTF
 import nl.knaw.dans.easy.deposit.docs.dm.PrivacySensitiveDataPresent.PrivacySensitiveDataPresent
-import nl.knaw.dans.easy.deposit.docs.dm.{ Date, _ }
+import nl.knaw.dans.easy.deposit.docs.dm._
 
 class MinimalDatasetMetadata(
                               identifiers: Option[Seq[SchemedValue]] = Some(Seq(
@@ -39,10 +38,10 @@ class MinimalDatasetMetadata(
                               audiences: Option[Seq[SchemedKeyValue]] = Some(Seq(
                                 SchemedKeyValue(scheme = "blabla", key = "D35200", value = "some audience")
                               )),
-                              subjects: Option[Seq[PossiblySchemedKeyValue]] = None,
+                              subjects: Option[Seq[SchemedKeyValue]] = None,
                               alternativeIdentifiers: Option[Seq[SchemedValue]] = None,
                               relations: Option[Seq[RelationType]] = None,
-                              languagesOfFiles: Option[Seq[PossiblySchemedKeyValue]] = None,
+                              languagesOfFiles: Option[Seq[SchemedKeyValue]] = None,
                               dates: Option[Seq[Date]] = Some(Seq(
                                 Date(scheme = Some(W3CDTF.toString), value = Some("2018"), Some(DateQualifier.created)),
                                 Date(scheme = Some(W3CDTF.toString), value = Some("2018"), Some(DateQualifier.available))
@@ -55,12 +54,12 @@ class MinimalDatasetMetadata(
                               ),
                               license: Option[String] = None,
                               typesDcmi: Option[Seq[String]] = None,
-                              types: Option[Seq[PossiblySchemedValue]] = None,
-                              formats: Option[Seq[PossiblySchemedValue]] = None,
-                              temporalCoverages: Option[Seq[PossiblySchemedKeyValue]] = None,
+                              types: Option[Seq[SchemedValue]] = None,
+                              formats: Option[Seq[SchemedValue]] = None,
+                              temporalCoverages: Option[Seq[SchemedKeyValue]] = None,
                               spatialPoints: Option[Seq[SpatialPoint]] = None,
                               spatialBoxes: Option[Seq[SpatialBox]] = None,
-                              spatialCoverages: Option[Seq[PossiblySchemedKeyValue]] = None,
+                              spatialCoverages: Option[Seq[SchemedKeyValue]] = None,
                               messageForDataManager: Option[String] = None,
                               privacySensitiveDataPresent: PrivacySensitiveDataPresent = PrivacySensitiveDataPresent.unspecified,
                               acceptDepositAgreement: Boolean = false,


### PR DESCRIPTION
Fixes EASY-1747 another step of making subfields optional while the deposit is in draft state

#### When applied it will
* 
* 
* 

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### Related pull requests on github
repo                       | PR                | note
-------------------------- | ----------------- | ----
easy-                      | [PR#](PRlink)     | ..
