### PR TITLE
EASY-1902 : flatten AccessRights.category (breaks ui and pending drafts)

### DIFF
--- a/docs/api/api.yml
+++ b/docs/api/api.yml
@@ -864,15 +864,10 @@ components:
     # Components of DatasetMetadata below
 
     AccessRights:
-      type: object
-      required:
-      - category
-      properties:
-        category:
-          type: string
-          enum:
-          - OPEN_ACCESS
-          - REQUEST_PERMISSION
+      type: string
+      enum:
+      - OPEN_ACCESS
+      - REQUEST_PERMISSION
 
     Author:
       type: object

--- a/src/main/scala/nl.knaw.dans.easy.deposit/docs/DDM.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/docs/DDM.scala
@@ -50,7 +50,7 @@ object DDM extends SchemedXml with DebugEnhancedLogging {
         { dm.datesCreated.flatMap(_.value).withNonEmpty.map(str => <ddm:created>{ str }</ddm:created>) }
         { dm.datesAvailable.flatMap(_.value).withNonEmpty.map(str => <ddm:available>{ str }</ddm:available>) }
         { dm.audiences.toSeq.flatten.map(_.key).withNonEmpty.map(key => <ddm:audience>{ key }</ddm:audience>) }
-        { dm.accessRights.toSeq.map(src => <ddm:accessRights>{ src.category.toString }</ddm:accessRights>) }
+        { dm.accessRights.toSeq.map(src => <ddm:accessRights>{ src.toString }</ddm:accessRights>) }
       </ddm:profile>
       <ddm:dcmiMetadata>
         { dm.allIdentifiers.map(id => <dcterms:identifier xsi:type={ id.scheme.nonBlankOrNull }>{ id.value.nonBlankOrEmpty }</dcterms:identifier>) }

--- a/src/main/scala/nl.knaw.dans.easy.deposit/docs/DatasetMetadata.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/docs/DatasetMetadata.scala
@@ -17,6 +17,7 @@ package nl.knaw.dans.easy.deposit.docs
 
 import nl.knaw.dans.easy.deposit.docs.DatasetMetadata._
 import nl.knaw.dans.easy.deposit.docs.JsonUtil.{ InvalidDocumentException, RichJsonInput }
+import nl.knaw.dans.easy.deposit.docs.dm.AccessRights.AccessRights
 import nl.knaw.dans.easy.deposit.docs.dm.Date._
 import nl.knaw.dans.easy.deposit.docs.dm.PrivacySensitiveDataPresent.PrivacySensitiveDataPresent
 import nl.knaw.dans.easy.deposit.docs.dm._

--- a/src/main/scala/nl.knaw.dans.easy.deposit/docs/JsonUtil.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/docs/JsonUtil.scala
@@ -50,10 +50,10 @@ object JsonUtil {
   class RelationTypeSerializer extends CustomSerializer[RelationType](_ =>
     ( {
       case JNull => null
-      case s: JValue =>
-        if (s.asInstanceOf[JObject].obj.values.keySet.subsetOf(Set("qualifier", "url", "title")))
-          Extraction.extract[Relation](s)
-        else Extraction.extract[RelatedIdentifier](s)
+      case obj: JObject =>
+        if (obj.values.keySet.subsetOf(Set("qualifier", "url", "title")))
+          Extraction.extract[Relation](obj)
+        else Extraction.extract[RelatedIdentifier](obj)
     }, {
       // case x: RelationType => JString(x.toString) // would break rejectNotExpectedContent
       case Relation(qualifier, url, title) =>

--- a/src/main/scala/nl.knaw.dans.easy.deposit/docs/JsonUtil.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/docs/JsonUtil.scala
@@ -72,7 +72,7 @@ object JsonUtil {
     RelationQualifier,
     DateQualifier,
     State,
-    AccessCategory,
+    AccessRights,
     PrivacySensitiveDataPresent,
   )
 

--- a/src/main/scala/nl.knaw.dans.easy.deposit/docs/SchemedXml.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/docs/SchemedXml.scala
@@ -15,8 +15,6 @@
  */
 package nl.knaw.dans.easy.deposit.docs
 
-import nl.knaw.dans.lib.logging.DebugEnhancedLogging
-
 trait SchemedXml {
   val schemaLocation: String // TODO property per object?
   val schemaNameSpace: String

--- a/src/main/scala/nl.knaw.dans.easy.deposit/docs/dm/AccessRights.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/docs/dm/AccessRights.scala
@@ -15,12 +15,8 @@
  */
 package nl.knaw.dans.easy.deposit.docs.dm
 
-import nl.knaw.dans.easy.deposit.docs.dm.AccessCategory.AccessCategory
-
-object AccessCategory extends Enumeration {
-  type AccessCategory = Value
-  val open: AccessCategory = Value("OPEN_ACCESS")
-  val restrictedRequest: AccessCategory = Value("REQUEST_PERMISSION")
+object AccessRights extends Enumeration {
+  type AccessRights = Value
+  val open: AccessRights = Value("OPEN_ACCESS")
+  val restrictedRequest: AccessRights = Value("REQUEST_PERMISSION")
 }
-
-case class AccessRights(category: AccessCategory)

--- a/src/main/scala/nl.knaw.dans.easy.deposit/servlets/package.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/servlets/package.scala
@@ -20,7 +20,6 @@ import java.nio.file.Files
 import java.util.zip.{ ZipEntry, ZipException, ZipInputStream }
 
 import better.files.File
-import nl.knaw.dans.easy.deposit.docs.JsonUtil.InvalidDocumentException
 import nl.knaw.dans.easy.deposit.servlets.DepositServlet.{ BadRequestException, ZipMustBeOnlyFileException }
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
 import org.scalatra.servlet.FileItem

--- a/src/test/resources/manual-test/datasetmetadata-from-ui-all.json
+++ b/src/test/resources/manual-test/datasetmetadata-from-ui-all.json
@@ -217,9 +217,7 @@
     "pub1",
     "pub2"
   ],
-  "accessRights": {
-    "category": "OPEN_ACCESS"
-  },
+  "accessRights": "OPEN_ACCESS",
   "license": "http://creativecommons.org/publicdomain/zero/1.0",
   "types": [
     {

--- a/src/test/resources/manual-test/datasetmetadata-from-ui-some.json
+++ b/src/test/resources/manual-test/datasetmetadata-from-ui-some.json
@@ -47,9 +47,7 @@
       "qualifier": "dcterms:available"
     }
   ],
-  "accessRights": {
-    "category": "REQUEST_PERMISSION"
-  },
+  "accessRights": "REQUEST_PERMISSION",
   "license": "http://creativecommons.org/publicdomain/zero/1.0",
   "privacySensitiveDataPresent": "yes",
   "acceptDepositAgreement": false

--- a/src/test/resources/manual-test/datasetmetadata.json
+++ b/src/test/resources/manual-test/datasetmetadata.json
@@ -116,9 +116,7 @@
   "publishers": [
     "string"
   ],
-  "accessRights": {
-    "category": "OPEN_ACCESS"
-  },
+  "accessRights": "OPEN_ACCESS",
   "license": "string",
   "types": [
     {

--- a/src/test/resources/manual-test/issue-1538.json
+++ b/src/test/resources/manual-test/issue-1538.json
@@ -142,9 +142,7 @@
   "sources": ["source 1"],
   "instructionsForReuse": ["how to use this data"],
   "publishers": ["publisher1"],
-  "accessRights": {
-    "category": "OPEN_ACCESS"
-  },
+  "accessRights": "OPEN_ACCESS",
   "license": "http://license/cc",
   "types": [
     {

--- a/src/test/scala/nl.knaw.dans.easy.deposit/docs/DatasetMetadataSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/docs/DatasetMetadataSpec.scala
@@ -79,43 +79,6 @@ class DatasetMetadataSpec extends TestSupportFixture {
     DatasetMetadata(example).getOrRecover(e => fail(e.toString, e))
   }
 
-  "deserialization" should "report additional json info" in {
-    """{"titles":["foo bar"],"x":[1]}""".stripMargin.causesInvalidDocumentException( """don't recognize {"x":[1]}""")
-  }
-
-  it should "extract just the last object" in {
-    val s =
-      """{"languageOfDescription": "string"}
-        |{  "identifiers": [
-        |    {
-        |      "scheme": "id-type:DOI",
-        |      "value": "10.17632/DANS.6wg5xccnjd.1"
-        |    }
-        |  ]
-        |}""".stripMargin
-    inside(DatasetMetadata(s)) {
-      case Success(dm: DatasetMetadata) =>
-        dm.doi shouldBe Some("10.17632/DANS.6wg5xccnjd.1")
-        dm.languageOfDescription shouldBe None
-    }
-  }
-
-  it should "be happy with empty objects" in {
-    // this is not desired behaviour but documents what actually happens
-    DatasetMetadata("""{}{}""") shouldBe a[Success[_]]
-  }
-
-  it should "fail on an empty array" in {
-    "[]".causesInvalidDocumentException("expected an object, got a class org.json4s.JsonAST$JArray")
-  }
-
-  it should "not accept a literal number" in {
-    "123".causesInvalidDocumentException(
-      """expected field or array
-        |Near: 12""".stripMargin
-    )
-  }
-
   "DatasetMetadata.dates" should "accept a date without a scheme" in {
     val s: JsonInput =
       """{"dates": [

--- a/src/test/scala/nl.knaw.dans.easy.deposit/docs/JsonUtilSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/docs/JsonUtilSpec.scala
@@ -69,19 +69,19 @@ class JsonUtilSpec extends TestSupportFixture {
         |{"xs": [ "123abc" ]
         |}""".stripMargin
     ) should matchPattern {
-      case Success(AllOptions(None, Some(_))) =>
+      case Success(AllOptions(None, Some(Seq("123abc")))) =>
     }
   }
 
   it should "reject an empty array" in {
-    deserializeAllOptions("""[]""") should matchPattern {
+    deserializeAllOptions("[]") should matchPattern {
       case Failure(InvalidDocumentException("AllOptions", e))
-        if e.getMessage == """expected an object, got a class org.json4s.JsonAST$JArray""" =>
+        if e.getMessage == "expected an object, got a class org.json4s.JsonAST$JArray" =>
     }
   }
 
   it should "reject a literal number" in {
-    deserializeAllOptions("""123""") should matchPattern {
+    deserializeAllOptions("123") should matchPattern {
       case Failure(InvalidDocumentException("AllOptions", e)) if e.getMessage ==
         """expected field or array
           |Near: 12""".stripMargin =>
@@ -90,18 +90,18 @@ class JsonUtilSpec extends TestSupportFixture {
 
   it should "be happy with empty optional objects" in {
     // this is not desired behaviour but documents what actually happens
-    deserializeAllOptions("""{}{}""") shouldBe a[Success[_]]
+    deserializeAllOptions("{}{}") shouldBe a[Success[_]]
   }
 
   it should "reject empty input" in {
     deserializeAllOptions(" ") should matchPattern {
       case Failure(InvalidDocumentException("AllOptions", e))
-        if e.getMessage == """expected an object, got a class org.json4s.JsonAST$JNothing$""" =>
+        if e.getMessage == "expected an object, got a class org.json4s.JsonAST$JNothing$" =>
     }
   }
 
   it should "reject empty objects when mandatory fields are expected" in {
-    deserializeNoOptions("""{}{}""") should matchPattern {
+    deserializeNoOptions("{}{}") should matchPattern {
       case Failure(InvalidDocumentException("NoOptions", e)) if e.getMessage ==
         """No usable value for x
           |Did not find value which can be converted into java.lang.String""".stripMargin =>

--- a/src/test/scala/nl.knaw.dans.easy.deposit/docs/JsonUtilSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/docs/JsonUtilSpec.scala
@@ -82,15 +82,15 @@ class JsonUtilSpec extends TestSupportFixture {
 
   it should "reject a literal number" in {
     deserializeAllOptions("""123""") should matchPattern {
-      case Failure(InvalidDocumentException("AllOptions", e))
-        if e.getMessage == """expected field or array
-                             |Near: 12""".stripMargin =>
+      case Failure(InvalidDocumentException("AllOptions", e)) if e.getMessage ==
+        """expected field or array
+          |Near: 12""".stripMargin =>
     }
   }
 
   it should "be happy with empty optional objects" in {
     // this is not desired behaviour but documents what actually happens
-    deserializeAllOptions("""{}{}""")  shouldBe a[Success[_]]
+    deserializeAllOptions("""{}{}""") shouldBe a[Success[_]]
   }
 
   it should "reject empty input" in {
@@ -102,9 +102,9 @@ class JsonUtilSpec extends TestSupportFixture {
 
   it should "reject empty objects when mandatory fields are expected" in {
     deserializeNoOptions("""{}{}""") should matchPattern {
-      case Failure(InvalidDocumentException("NoOptions", e))
-        if e.getMessage == """No usable value for x
-                             |Did not find value which can be converted into java.lang.String""".stripMargin =>
+      case Failure(InvalidDocumentException("NoOptions", e)) if e.getMessage ==
+        """No usable value for x
+          |Did not find value which can be converted into java.lang.String""".stripMargin =>
     }
   }
 

--- a/src/test/scala/nl.knaw.dans.easy.deposit/docs/JsonUtilSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/docs/JsonUtilSpec.scala
@@ -19,8 +19,10 @@ import java.nio.file.Paths
 
 import nl.knaw.dans.easy.deposit.TestSupportFixture
 import nl.knaw.dans.easy.deposit.docs.JsonUtil._
+import org.json4s.JsonInput
 
 import scala.reflect.runtime.universe.typeOf
+import scala.util.{ Failure, Success }
 
 class JsonUtilSpec extends TestSupportFixture {
 
@@ -53,4 +55,66 @@ class JsonUtilSpec extends TestSupportFixture {
     val fileInfo = FileInfo("test.txt", Paths.get("a/b"), "abc123")
     toJson(fileInfo) shouldBe """{"filename":"test.txt","dirpath":"a/b","sha1sum":"abc123"}"""
   }
+
+  "deserialize" should "reject additional json info" in {
+    deserializeAllOptions("""{"x":"foo bar","extra":[1]}""") should matchPattern {
+      case Failure(InvalidDocumentException("AllOptions", e))
+        if e.getMessage == """don't recognize {"extra":[1]}""" =>
+    }
+  }
+
+  it should "extract just the last object" in {
+    deserializeAllOptions(
+      """{"x": "foo bar"}
+        |{"xs": [ "123abc" ]
+        |}""".stripMargin
+    ) should matchPattern {
+      case Success(AllOptions(None, Some(_))) =>
+    }
+  }
+
+  it should "reject an empty array" in {
+    deserializeAllOptions("""[]""") should matchPattern {
+      case Failure(InvalidDocumentException("AllOptions", e))
+        if e.getMessage == """expected an object, got a class org.json4s.JsonAST$JArray""" =>
+    }
+  }
+
+  it should "reject a literal number" in {
+    deserializeAllOptions("""123""") should matchPattern {
+      case Failure(InvalidDocumentException("AllOptions", e))
+        if e.getMessage == """expected field or array
+                             |Near: 12""".stripMargin =>
+    }
+  }
+
+  it should "be happy with empty optional objects" in {
+    // this is not desired behaviour but documents what actually happens
+    deserializeAllOptions("""{}{}""")  shouldBe a[Success[_]]
+  }
+
+  it should "reject empty input" in {
+    deserializeAllOptions(" ") should matchPattern {
+      case Failure(InvalidDocumentException("AllOptions", e))
+        if e.getMessage == """expected an object, got a class org.json4s.JsonAST$JNothing$""" =>
+    }
+  }
+
+  it should "reject empty objects when mandatory fields are expected" in {
+    deserializeNoOptions("""{}{}""") should matchPattern {
+      case Failure(InvalidDocumentException("NoOptions", e))
+        if e.getMessage == """No usable value for x
+                             |Did not find value which can be converted into java.lang.String""".stripMargin =>
+    }
+  }
+
+  private def deserializeAllOptions(input: JsonInput) = {
+    input.deserialize[AllOptions]
+  }
+
+  private def deserializeNoOptions(input: JsonInput) = {
+    input.deserialize[NoOptions]
+  }
 }
+case class AllOptions(x: Option[String], xs: Option[Seq[String]])
+case class NoOptions(x: String, xs: Seq[String])

--- a/src/test/scala/nl.knaw.dans.easy.deposit/docs/MinimalDatasetMetadata.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/docs/MinimalDatasetMetadata.scala
@@ -15,6 +15,7 @@
  */
 package nl.knaw.dans.easy.deposit.docs
 
+import nl.knaw.dans.easy.deposit.docs.dm.AccessRights.AccessRights
 import nl.knaw.dans.easy.deposit.docs.dm.DateScheme.W3CDTF
 import nl.knaw.dans.easy.deposit.docs.dm.PrivacySensitiveDataPresent.PrivacySensitiveDataPresent
 import nl.knaw.dans.easy.deposit.docs.dm._
@@ -49,9 +50,7 @@ class MinimalDatasetMetadata(
                               sources: Option[Seq[String]] = None,
                               instructionsForReuse: Option[Seq[String]] = None,
                               publishers: Option[Seq[String]] = None,
-                              accessRights: Option[AccessRights] = Some(
-                                AccessRights(category = AccessCategory.open)
-                              ),
+                              accessRights: Option[AccessRights] = Some(AccessRights.open),
                               license: Option[String] = None,
                               typesDcmi: Option[Seq[String]] = None,
                               types: Option[Seq[SchemedValue]] = None,

--- a/src/test/scala/nl.knaw.dans.easy.deposit/servlets/DoiSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/servlets/DoiSpec.scala
@@ -36,7 +36,7 @@ class DoiSpec extends DepositServletFixture {
        |    { "scheme": "dcterms:W3CDTF", "value": "2018-05-31", "qualifier": "dcterms:created" },
        |  ],
        |  "audiences": [ { "scheme": "string", "value": "string", "key": "D33000" } ],
-       |  "accessRights": {"category": "OPEN_ACCESS"},
+       |  "accessRights": "OPEN_ACCESS",
        |  "privacySensitiveDataPresent": "no",
        |  "acceptDepositAgreement": true,
        |""".stripMargin


### PR DESCRIPTION
Fixes EASY-1902 : flatten AccessRights.category

#### When applied it will
* reduce a complex json field to a simple one:
  old: ` "accessRights": { "category": "OPEN_ACCESS" },`
  new: `"accessRights": "OPEN_ACCESS",`
* 
* 

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

* [x] avoid class cast
* [x] more unit tests

#### Related pull requests on github
* [x] easy-deposit-ui -> https://github.com/DANS-KNAW/easy-deposit-ui/pull/137