### PR TITLE
EASY-2013 document how lat/long is mapped to x/y

### DIFF
--- a/docs/api/api.yml
+++ b/docs/api/api.yml
@@ -1059,7 +1059,7 @@ components:
       properties:
         scheme:
           type: string
-          description: "Possible values: degrees, RD."
+          description: "Recommended values: http://www.opengis.net/def/crs/EPSG/0/4326 (degrees), http://www.opengis.net/def/crs/EPSG/0/28992 (RD)."
         x:
           type: string
           format: "number"

--- a/docs/api/api.yml
+++ b/docs/api/api.yml
@@ -1059,12 +1059,15 @@ components:
       properties:
         scheme:
           type: string
+          description: "Possible values: degrees, RD."
         x:
           type: string
           format: "number"
+          description: "In case of degrees: latitude, range from -90 to 90."
         y:
           type: string
           format: "number"
+          description: "In case of degrees: longitude, range from -180 to 180."
 
     # Note: it is not possible to provide examples in combination with a reference to this
     # schema. If you need examples, you'll have to spell out the complete type.

--- a/docs/api/api.yml
+++ b/docs/api/api.yml
@@ -1063,11 +1063,11 @@ components:
         x:
           type: string
           format: "number"
-          description: "In case of degrees: latitude, range from -90 to 90."
+          description: "In case of RD: range from -7000 to 300000. In case of degrees: latitude, range from -90 to 90."
         y:
           type: string
           format: "number"
-          description: "In case of degrees: longitude, range from -180 to 180."
+          description: "In case of RD: range from 289000 to 629000. In case of degrees: longitude, range from -180 to 180."
 
     # Note: it is not possible to provide examples in combination with a reference to this
     # schema. If you need examples, you'll have to spell out the complete type.

--- a/docs/api/api.yml
+++ b/docs/api/api.yml
@@ -1059,7 +1059,7 @@ components:
       properties:
         scheme:
           type: string
-          description: "Recommended values: http://www.opengis.net/def/crs/EPSG/0/4326 (degrees), http://www.opengis.net/def/crs/EPSG/0/28992 (RD)."
+          description: "Recommended values: 'http://www.opengis.net/def/crs/EPSG/0/4326' (degrees), 'http://www.opengis.net/def/crs/EPSG/0/28992' (RD)."
         x:
           type: string
           format: "number"

--- a/src/test/scala/nl.knaw.dans.easy.deposit/docs/DDMSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/docs/DDMSpec.scala
@@ -160,6 +160,12 @@ class DDMSpec extends TestSupportFixture with DdmBehavior {
     )
   }
 
+  "minimal with missing scheme for a SpatialPoint" should behave like validDatasetMetadata(
+    input = Try(new MinimalDatasetMetadata(spatialPoints = Some(Seq(
+      SpatialPoint(None, Some("1"), Some("2"))
+    ))))
+  )
+
   "minimal with rightsHolders" should behave like {
     val someCreators = Some(Seq(
       Author(


### PR DESCRIPTION
Fixes EASY-2013 document how lat/long is mapped to x/y

#### When applied it will
* 
* 
* 

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### Related pull requests on github
repo                       | PR                | note
-------------------------- | ----------------- | ----
easy-                      | [PR#](PRlink)     | ..
