### PR TITLE
Easy-1948 check status before deposit updates

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.deposit/DepositDir.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/DepositDir.scala
@@ -93,7 +93,7 @@ case class DepositDir private(baseDir: File, user: String, id: UUID) extends Deb
    */
   def delete(): Try[Unit] = for {
     stateInfo <- getStateInfo
-    _ <- stateInfo.isDeletable
+    _ <- stateInfo.canDelete
     _ = bagDir.parent.delete()
   } yield ()
 

--- a/src/main/scala/nl.knaw.dans.easy.deposit/EasyDepositApiApp.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/EasyDepositApiApp.scala
@@ -218,6 +218,8 @@ class EasyDepositApiApp(configuration: Configuration) extends DebugEnhancedLoggi
    */
   def writeDataMetadataToDeposit(dm: DatasetMetadata, user: String, id: UUID): Try[Unit] = for {
     deposit <- getDeposit(user, id)
+    depositState <- deposit.getStateInfo
+    _ <- depositState.canUpdate
     _ <- deposit.writeDatasetMetadataJson(dm)
   } yield ()
 
@@ -264,6 +266,7 @@ class EasyDepositApiApp(configuration: Configuration) extends DebugEnhancedLoggi
    */
   def writeDepositFile(is: => InputStream, user: String, id: UUID, path: Path): Try[Boolean] = {
     for {
+
       dataFiles <- getDataFiles(user, id)
       _ = logger.info(s"uploading to [${ dataFiles.bag.baseDir }] of [$path]")
       created <- dataFiles.write(is, path)

--- a/src/main/scala/nl.knaw.dans.easy.deposit/docs/StateInfo.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/docs/StateInfo.scala
@@ -23,7 +23,7 @@ import scala.collection.Seq
 import scala.util.{ Failure, Success, Try }
 
 case class StateInfo(state: State, stateDescription: String) {
-  def isDeletable: Try[Unit] = {
+  def canDelete: Try[Unit] = {
     if (StateInfo.deletableStates.contains(state)) Success(())
     else Failure(new IllegalStateException(s"Deposit has state $state, can only delete deposits with one of the states: ${ StateInfo.deletableStates.mkString(", ") }"))
   }

--- a/src/main/scala/nl.knaw.dans.easy.deposit/docs/StateInfo.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/docs/StateInfo.scala
@@ -27,10 +27,16 @@ case class StateInfo(state: State, stateDescription: String) {
     if (StateInfo.deletableStates.contains(state)) Success(())
     else Failure(new IllegalStateException(s"Deposit has state $state, can only delete deposits with one of the states: ${ StateInfo.deletableStates.mkString(", ") }"))
   }
+
+  def canUpdate: Try[Unit] = {
+    if (StateInfo.updatableStates.contains(state)) Success(())
+    else Failure(new IllegalStateException(s"Deposit has state $state, can only update deposits with one of the states: ${ StateInfo.updatableStates.mkString(", ") }"))
+  }
 }
 
 object StateInfo {
   val deletableStates: Seq[State] = Seq(State.draft, State.archived, State.rejected)
+  val updatableStates: Seq[State] = Seq(State.draft, State.rejected)
 
   object State extends Enumeration {
     type State = Value

--- a/src/main/scala/nl.knaw.dans.easy.deposit/servlets/DepositServlet.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/servlets/DepositServlet.scala
@@ -105,8 +105,7 @@ class DepositServlet(app: EasyDepositApiApp)
         _ <- app.checkDoi(user.id, uuid, datasetMetadata)
         _ <- app.writeDataMetadataToDeposit(datasetMetadata, user.id, uuid)
       } yield NoContent()
-    }.doIfFailure{ case t: Throwable => println(t.getMessage)}
-      .getOrRecover(respond)
+    }.getOrRecover(respond)
       .logResponse
   }
   get("/:uuid/state") {

--- a/src/test/scala/nl.knaw.dans.easy.deposit/docs/StateInfoSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/docs/StateInfoSpec.scala
@@ -22,25 +22,25 @@ import scala.util.{ Failure, Success }
 class StateInfoSpec extends TestSupportFixture {
 
   "isDeletable" should "succeed when the state is DRAFT" in {
-    new StateInfo(StateInfo.State.draft, "drafted").isDeletable shouldBe a[Success[_]]
+    new StateInfo(StateInfo.State.draft, "drafted").canDelete shouldBe a[Success[_]]
   }
 
-  it should "succeed if the the state if archived" in {
-    new StateInfo(StateInfo.State.archived, "archived").isDeletable shouldBe a[Success[_]]
+  it should "succeed if the state is archived" in {
+    new StateInfo(StateInfo.State.archived, "archived").canDelete shouldBe a[Success[_]]
   }
 
-  it should "succeed if the the state if rejected" in {
-    new StateInfo(StateInfo.State.archived, "rejected").isDeletable shouldBe a[Success[_]]
+  it should "succeed if the state is rejected" in {
+    new StateInfo(StateInfo.State.archived, "rejected").canDelete shouldBe a[Success[_]]
   }
 
   it should "fail if the state is submitted" in {
-    new StateInfo(StateInfo.State.submitted, "submitted").isDeletable should matchPattern {
+    new StateInfo(StateInfo.State.submitted, "submitted").canDelete should matchPattern {
       case Failure(ise: IllegalStateException) if ise.getMessage == s"Deposit has state SUBMITTED, can only delete deposits with one of the states: ${ StateInfo.deletableStates.mkString(", ") }" =>
     }
   }
 
   it should "fail if the state is in progress" in {
-    new StateInfo(StateInfo.State.inProgress, "IN_PROGRESS").isDeletable should matchPattern {
+    new StateInfo(StateInfo.State.inProgress, "IN_PROGRESS").canDelete should matchPattern {
       case Failure(ise: IllegalStateException) if ise.getMessage == s"Deposit has state IN_PROGRESS, can only delete deposits with one of the states: ${ StateInfo.deletableStates.mkString(", ") }" =>
     }
   }
@@ -49,23 +49,23 @@ class StateInfoSpec extends TestSupportFixture {
     new StateInfo(StateInfo.State.rejected, "rejected").canUpdate shouldBe a[Success[_]]
   }
 
-  it should "succeed if the the state if draft" in {
+  it should "succeed if the state is draft" in {
     new StateInfo(StateInfo.State.draft, "draft").canUpdate shouldBe a[Success[_]]
   }
 
-  it should "fail if the the state if submitted" in {
+  it should "fail if the state is submitted" in {
     new StateInfo(StateInfo.State.submitted, "submitted").canUpdate should matchPattern {
       case Failure(ise: IllegalStateException) if ise.getMessage == s"Deposit has state SUBMITTED, can only update deposits with one of the states: ${ StateInfo.updatableStates.mkString(", ") }" =>
     }
   }
 
-  it should "fail if the the state if in progress" in {
+  it should "fail if the state is in progress" in {
     new StateInfo(StateInfo.State.inProgress, "IN_PROGRESS").canUpdate should matchPattern {
       case Failure(ise: IllegalStateException) if ise.getMessage == s"Deposit has state IN_PROGRESS, can only update deposits with one of the states: ${ StateInfo.updatableStates.mkString(", ") }" =>
     }
   }
 
-  it should "fail if the the state if archived" in {
+  it should "fail if the state is archived" in {
     new StateInfo(StateInfo.State.archived, "archived").canUpdate should matchPattern {
       case Failure(ise: IllegalStateException) if ise.getMessage == s"Deposit has state ARCHIVED, can only update deposits with one of the states: ${ StateInfo.updatableStates.mkString(", ") }" =>
     }

--- a/src/test/scala/nl.knaw.dans.easy.deposit/docs/StateInfoSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/docs/StateInfoSpec.scala
@@ -1,0 +1,73 @@
+/**
+ * Copyright (C) 2018 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.easy.deposit.docs
+
+import nl.knaw.dans.easy.deposit.TestSupportFixture
+
+import scala.util.{ Failure, Success }
+
+class StateInfoSpec extends TestSupportFixture {
+
+  "isDeletable" should "succeed when the state is DRAFT" in {
+    new StateInfo(StateInfo.State.draft, "drafted").isDeletable shouldBe a[Success[_]]
+  }
+
+  it should "succeed if the the state if archived" in {
+    new StateInfo(StateInfo.State.archived, "archived").isDeletable shouldBe a[Success[_]]
+  }
+
+  it should "succeed if the the state if rejected" in {
+    new StateInfo(StateInfo.State.archived, "rejected").isDeletable shouldBe a[Success[_]]
+  }
+
+  it should "fail if the state is submitted" in {
+    new StateInfo(StateInfo.State.submitted, "submitted").isDeletable should matchPattern {
+      case Failure(ise: IllegalStateException) if ise.getMessage == s"Deposit has state SUBMITTED, can only delete deposits with one of the states: ${ StateInfo.deletableStates.mkString(", ") }" =>
+    }
+  }
+
+  it should "fail if the state is in progress" in {
+    new StateInfo(StateInfo.State.inProgress, "IN_PROGRESS").isDeletable should matchPattern {
+      case Failure(ise: IllegalStateException) if ise.getMessage == s"Deposit has state IN_PROGRESS, can only delete deposits with one of the states: ${ StateInfo.deletableStates.mkString(", ") }" =>
+    }
+  }
+
+  "canUpdate" should "succeed if the state is rejected" in {
+    new StateInfo(StateInfo.State.rejected, "rejected").canUpdate shouldBe a[Success[_]]
+  }
+
+  it should "succeed if the the state if draft" in {
+    new StateInfo(StateInfo.State.draft, "draft").canUpdate shouldBe a[Success[_]]
+  }
+
+  it should "fail if the the state if submitted" in {
+    new StateInfo(StateInfo.State.submitted, "submitted").canUpdate should matchPattern {
+      case Failure(ise: IllegalStateException) if ise.getMessage == s"Deposit has state SUBMITTED, can only update deposits with one of the states: ${ StateInfo.updatableStates.mkString(", ") }" =>
+    }
+  }
+
+  it should "fail if the the state if in progress" in {
+    new StateInfo(StateInfo.State.inProgress, "IN_PROGRESS").canUpdate should matchPattern {
+      case Failure(ise: IllegalStateException) if ise.getMessage == s"Deposit has state IN_PROGRESS, can only update deposits with one of the states: ${ StateInfo.updatableStates.mkString(", ") }" =>
+    }
+  }
+
+  it should "fail if the the state if archived" in {
+    new StateInfo(StateInfo.State.archived, "archived").canUpdate should matchPattern {
+      case Failure(ise: IllegalStateException) if ise.getMessage == s"Deposit has state ARCHIVED, can only update deposits with one of the states: ${ StateInfo.updatableStates.mkString(", ") }" =>
+    }
+  }
+}

--- a/src/test/scala/nl.knaw.dans.easy.deposit/servlets/HappyRoutesSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/servlets/HappyRoutesSpec.scala
@@ -209,6 +209,4 @@ class HappyRoutesSpec extends TestSupportFixture with ServletFixture with Scalat
       body shouldBe s"""Deposit has state ${ stateInfo.state }, can only update deposits with one of the states: DRAFT, REJECTED"""
     }
   }
-
-
 }

--- a/src/test/scala/nl.knaw.dans.easy.deposit/servlets/HappyRoutesSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/servlets/HappyRoutesSpec.scala
@@ -164,8 +164,6 @@ class HappyRoutesSpec extends TestSupportFixture with ServletFixture with Scalat
 
   "put /deposit/:uuid/metadata" should "reject invalid datasetmetadata.json" in {
     authMocker.expectsUserFooBar
-    (mockedApp.getDepositState(_: String, _: UUID)) expects("foo", uuid) returning
-      Success(StateInfo(StateInfo.State.draft, "a draft"))
     put(
       uri = s"/deposit/$uuid/metadata",
       body = """{"title":"blabla"}""", // N.B: key should be plural
@@ -173,40 +171,6 @@ class HappyRoutesSpec extends TestSupportFixture with ServletFixture with Scalat
     ) {
       status shouldBe BAD_REQUEST_400
       body shouldBe """Bad Request. invalid DatasetMetadata: don't recognize {"title":"blabla"}"""
-    }
-  }
-
-  it should "reject the deposit if the deposit has archived as state" in {
-    val stateInfo = StateInfo(StateInfo.State.archived, "archived")
-    authMocker.expectsUserFooBar
-    (mockedApp.getDepositState(_: String, _: UUID)) expects("foo", uuid) returning
-      Success(stateInfo)
-    expectPutMetaDataToFail(stateInfo)
-  }
-
-  it should "reject the deposit if the deposit has submitted as state" in {
-    val stateInfo = StateInfo(StateInfo.State.submitted, "submitted")
-    authMocker.expectsUserFooBar
-    (mockedApp.getDepositState(_: String, _: UUID)) expects("foo", uuid) returning
-      Success(stateInfo)
-    expectPutMetaDataToFail(stateInfo)
-  }
-
-  it should "reject the deposit if the deposit has in progress as state" in {
-    val stateInfo = StateInfo(StateInfo.State.inProgress, "in progress")
-    authMocker.expectsUserFooBar
-    (mockedApp.getDepositState(_: String, _: UUID)) expects("foo", uuid) returning
-      Success(stateInfo)
-    expectPutMetaDataToFail(stateInfo)
-  }
-
-  private def expectPutMetaDataToFail(stateInfo: StateInfo): Unit = {
-    put(
-      uri = s"/deposit/$uuid/metadata",
-      headers = Seq(fooBarBasicAuthHeader)
-    ) {
-      status shouldBe FORBIDDEN_403
-      body shouldBe s"""Deposit has state ${ stateInfo.state }, can only update deposits with one of the states: DRAFT, REJECTED"""
     }
   }
 }

--- a/src/test/scala/nl.knaw.dans.easy.deposit/servlets/HappyRoutesSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/servlets/HappyRoutesSpec.scala
@@ -164,7 +164,8 @@ class HappyRoutesSpec extends TestSupportFixture with ServletFixture with Scalat
 
   "put /deposit/:uuid/metadata" should "reject invalid datasetmetadata.json" in {
     authMocker.expectsUserFooBar
-
+    (mockedApp.getDepositState(_: String, _: UUID)) expects("foo", uuid) returning
+      Success(StateInfo(StateInfo.State.draft, "a draft"))
     put(
       uri = s"/deposit/$uuid/metadata",
       body = """{"title":"blabla"}""", // N.B: key should be plural

--- a/src/test/scala/nl.knaw.dans.easy.deposit/servlets/HappyRoutesSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/servlets/HappyRoutesSpec.scala
@@ -175,4 +175,40 @@ class HappyRoutesSpec extends TestSupportFixture with ServletFixture with Scalat
       body shouldBe """Bad Request. invalid DatasetMetadata: don't recognize {"title":"blabla"}"""
     }
   }
+
+  it should "reject the deposit if the deposit has archived as state" in {
+    val stateInfo = StateInfo(StateInfo.State.archived, "archived")
+    authMocker.expectsUserFooBar
+    (mockedApp.getDepositState(_: String, _: UUID)) expects("foo", uuid) returning
+      Success(stateInfo)
+    expectPutMetaDataToFail(stateInfo)
+  }
+
+  it should "reject the deposit if the deposit has submitted as state" in {
+    val stateInfo = StateInfo(StateInfo.State.submitted, "submitted")
+    authMocker.expectsUserFooBar
+    (mockedApp.getDepositState(_: String, _: UUID)) expects("foo", uuid) returning
+      Success(stateInfo)
+    expectPutMetaDataToFail(stateInfo)
+  }
+
+  it should "reject the deposit if the deposit has in progress as state" in {
+    val stateInfo = StateInfo(StateInfo.State.inProgress, "in progress")
+    authMocker.expectsUserFooBar
+    (mockedApp.getDepositState(_: String, _: UUID)) expects("foo", uuid) returning
+      Success(stateInfo)
+    expectPutMetaDataToFail(stateInfo)
+  }
+
+  private def expectPutMetaDataToFail(stateInfo: StateInfo): Unit = {
+    put(
+      uri = s"/deposit/$uuid/metadata",
+      headers = Seq(fooBarBasicAuthHeader)
+    ) {
+      status shouldBe FORBIDDEN_403
+      body shouldBe s"""Deposit has state ${ stateInfo.state }, can only update deposits with one of the states: DRAFT, REJECTED"""
+    }
+  }
+
+
 }

--- a/src/test/scala/nl.knaw.dans.easy.deposit/servlets/IntegrationSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/servlets/IntegrationSpec.scala
@@ -45,7 +45,6 @@ class IntegrationSpec extends TestSupportFixture with ServletFixture with Scalat
   mountServlets(app, authMocker.mockedAuthenticationProvider)
 
   "scenario: /deposit/:uuid/metadata life cycle" should "return default dataset metadata" in {
-
     // create dataset
     authMocker.expectsUserFooBar
     val responseBody = post(uri = s"/deposit", headers = Seq(fooBarBasicAuthHeader)) { body }
@@ -78,7 +77,6 @@ class IntegrationSpec extends TestSupportFixture with ServletFixture with Scalat
   }
 
   "scenario: POST /deposit twice; GET /deposit" should "return a list of datasets" in {
-
     // create two deposits
     val responseBodies: Seq[String] = (0 until 2).map { _ =>
       authMocker.expectsUserFooBar
@@ -102,7 +100,6 @@ class IntegrationSpec extends TestSupportFixture with ServletFixture with Scalat
   }
 
   "scenario: POST /deposit; PUT /deposit/:uuid/file/...; GET /deposit/$uuid/file/..." should "return single FileInfo object respective an array of objects" in {
-
     // create dataset
     authMocker.expectsUserFooBar
     val responseBody = post(uri = s"/deposit", headers = Seq(fooBarBasicAuthHeader)) { body }
@@ -145,8 +142,20 @@ class IntegrationSpec extends TestSupportFixture with ServletFixture with Scalat
     }
   }
 
-  "scenario: POST /deposit; twice GET /deposit/:uuid/doi" should "return 200" in {
+  "scenario: POST /deposit; PUT /deposit/:uuid/state; PUT /deposit/$uuid/file/..." should "return forbidden cannot update SUBMITTED deposit" in {
+    val uuid: String = setupSubmittedDeposit
 
+    authMocker.expectsUserFooBar
+    put(
+      uri = s"/deposit/$uuid/file/path/to/test.txt", headers = Seq(fooBarBasicAuthHeader),
+      body = "Lorum ipsum"
+    ) {
+      body shouldBe "Deposit has state SUBMITTED, can only update deposits with one of the states: DRAFT, REJECTED"
+      status shouldBe FORBIDDEN_403
+    }
+  }
+
+  "scenario: POST /deposit; twice GET /deposit/:uuid/doi" should "return 200" in {
     // create dataset
     authMocker.expectsUserFooBar
     val responseBody = post(uri = s"/deposit", headers = Seq(fooBarBasicAuthHeader)) { body }
@@ -174,52 +183,11 @@ class IntegrationSpec extends TestSupportFixture with ServletFixture with Scalat
   }
 
   "scenario: create - ... - sumbit" should "create submitted dataset copied from a draft" in {
-
-    val datasetMetadata = getManualTestResource("datasetmetadata-from-ui-all.json")
-    val doi = DatasetMetadata(datasetMetadata)
-      .getOrRecover(fail(_))
-      .doi
-      .getOrElse(fail("could not get DOI from test input"))
-
-    (testDir / "easy-ingest-flow-inbox").createDirectories()
-    (testDir / "stage").createDirectories()
-
-    // create dataset
-    authMocker.expectsUserFooBar
-    val responseBody = post(uri = s"/deposit", headers = Seq(fooBarBasicAuthHeader)) { body }
-    val uuid = DepositInfo(responseBody).map(_.id.toString).getOrRecover(e => fail(e.toString, e))
-    val depositDir = testDir / "drafts" / "foo" / uuid.toString
-
-    // copy DOI from metadata into deposit.properties
-    (depositDir / "deposit.properties").append(s"identifier.doi=$doi")
-
-    // upload dataset metadata
-    authMocker.expectsUserFooBar
-    put(
-      uri = s"/deposit/$uuid/metadata",
-      headers = Seq(fooBarBasicAuthHeader),
-      body = datasetMetadata
-    ) {
-      body shouldBe ""
-      status shouldBe NO_CONTENT_204
-    }
-
-    // submit
-    authMocker.expectsUserFooBar
-    put(
-      uri = s"/deposit/$uuid/state", headers = Seq(fooBarBasicAuthHeader),
-      body = """{"state":"SUBMITTED","stateDescription":"blabla"}"""
-    ) {
-      body shouldBe ""
-      status shouldBe NO_CONTENT_204
-
-      // +3 is difference in number of files in metadata directory: json versus xml's
-      (depositDir.walk().size + 3) shouldBe (testDir / "easy-ingest-flow-inbox" / uuid.toString).walk().size
-    }
+    val uuid: String = setupSubmittedDeposit
 
     // failing delete
     authMocker.expectsUserFooBar
-    delete (uri = s"/deposit/$uuid", headers = Seq(fooBarBasicAuthHeader)) {
+    delete(uri = s"/deposit/$uuid", headers = Seq(fooBarBasicAuthHeader)) {
       body shouldBe "Deposit has state SUBMITTED, can only delete deposits with one of the states: DRAFT, ARCHIVED, REJECTED"
       status shouldBe FORBIDDEN_403
     }
@@ -228,7 +196,7 @@ class IntegrationSpec extends TestSupportFixture with ServletFixture with Scalat
     // deposit still exists
     get(
       uri = s"/deposit/$uuid/state", headers = Seq(fooBarBasicAuthHeader),
-    ){
+    ) {
       body shouldBe """{"state":"SUBMITTED","stateDescription":"Deposit is ready for processing."}"""
       status shouldBe OK_200
     }
@@ -272,7 +240,7 @@ class IntegrationSpec extends TestSupportFixture with ServletFixture with Scalat
 
     // delete
     authMocker.expectsUserFooBar
-    delete (uri = s"/deposit/$uuid", headers = Seq(fooBarBasicAuthHeader)) {
+    delete(uri = s"/deposit/$uuid", headers = Seq(fooBarBasicAuthHeader)) {
       body shouldBe ""
       status shouldBe NO_CONTENT_204
     }
@@ -281,14 +249,13 @@ class IntegrationSpec extends TestSupportFixture with ServletFixture with Scalat
     authMocker.expectsUserFooBar
     get(
       uri = s"/deposit/$uuid/state", headers = Seq(fooBarBasicAuthHeader),
-    ){
+    ) {
       body shouldBe s"Deposit $uuid not found"
       status shouldBe NOT_FOUND_404
     }
   }
 
   "scenario: POST /deposit; hack state to ARCHIVED; SUBMIT" should "reject state transition" in {
-
     // create dataset
     authMocker.expectsUserFooBar
     val responseBody = post(uri = s"/deposit", headers = Seq(fooBarBasicAuthHeader)) { body }
@@ -311,5 +278,50 @@ class IntegrationSpec extends TestSupportFixture with ServletFixture with Scalat
 
     // submit did not complain about missing metadata, so the state transition check indeed came first
     (testDir / "drafts" / "foo" / uuid.toString / "bag" / "metatada") shouldNot exist
+  }
+
+  private def setupSubmittedDeposit: String = {
+    val datasetMetadata = getManualTestResource("datasetmetadata-from-ui-all.json")
+    val doi = DatasetMetadata(datasetMetadata)
+      .getOrRecover(fail(_))
+      .doi
+      .getOrElse(fail("could not get DOI from test input"))
+
+    (testDir / "easy-ingest-flow-inbox").createDirectories()
+    (testDir / "stage").createDirectories()
+
+    // create dataset
+    authMocker.expectsUserFooBar
+    val responseBody = post(uri = s"/deposit", headers = Seq(fooBarBasicAuthHeader)) { body }
+    val uuid = DepositInfo(responseBody).map(_.id.toString).getOrRecover(e => fail(e.toString, e))
+    val depositDir = testDir / "drafts" / "foo" / uuid.toString
+
+    // copy DOI from metadata into deposit.properties
+    (depositDir / "deposit.properties").append(s"identifier.doi=$doi")
+
+    // upload dataset metadata
+    authMocker.expectsUserFooBar
+    put(
+      uri = s"/deposit/$uuid/metadata",
+      headers = Seq(fooBarBasicAuthHeader),
+      body = datasetMetadata
+    ) {
+      body shouldBe ""
+      status shouldBe NO_CONTENT_204
+    }
+
+    // submit
+    authMocker.expectsUserFooBar
+    put(
+      uri = s"/deposit/$uuid/state", headers = Seq(fooBarBasicAuthHeader),
+      body = """{"state":"SUBMITTED","stateDescription":"blabla"}"""
+    ) {
+      body shouldBe ""
+      status shouldBe NO_CONTENT_204
+
+      // +3 is difference in number of files in metadata directory: json versus xml's
+      (depositDir.walk().size + 3) shouldBe (testDir / "easy-ingest-flow-inbox" / uuid.toString).walk().size
+    }
+    uuid
   }
 }


### PR DESCRIPTION
Fixes EASY-1948

#### When applied it will
*  validate the state of deposit before changing files of the deposit

- [x] more unit tests?
- [ ]   Test on DEASY
- [ ] verify the check is done everywhere it is needed
- [ ] update swagger


#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### Related pull requests on github
repo                       | PR                | note
-------------------------- | ----------------- | ----
easy-                      | [PR#](PRlink)     | ..