### PR TITLE
EASY-1949 + EASY-1950 checks on PUT file (no zip, no file overwriting directory)

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.deposit/EasyDepositApiApp.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/EasyDepositApiApp.scala
@@ -262,8 +262,8 @@ class EasyDepositApiApp(configuration: Configuration) extends DebugEnhancedLoggi
    * @param id          the deposit ID
    * @param path        the path of the file to (over)write, relative to the content base directory
    * @param is          the input stream to write from
-   * @param contentType the contentType of the stream, it originates from an HTTP request header
-   *                    which is optional by nature but mandatory in this context
+   * @param contentType the contentType of the stream, mandatory in this context
+   *                    but optional by the nature of an HTTP request header
    * @return `true` if a new file was created, `false` otherwise
    */
   def writeDepositFile(is: => InputStream, user: String, id: UUID, path: Path, contentType: Option[String]): Try[Boolean] = {

--- a/src/main/scala/nl.knaw.dans.easy.deposit/EasyDepositApiApp.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/EasyDepositApiApp.scala
@@ -258,23 +258,35 @@ class EasyDepositApiApp(configuration: Configuration) extends DebugEnhancedLoggi
    * If a new file is created the function returns `true`, otherwise an existing file was overwritten.
    * (We hope the reader will forgive us this minor violation of the Command-Query separation principle.)
    *
-   * @param user the user ID
-   * @param id   the deposit ID
-   * @param path the path of the file to (over)write, relative to the content base directory
-   * @param is   the input stream to write from
+   * @param user        the user ID
+   * @param id          the deposit ID
+   * @param path        the path of the file to (over)write, relative to the content base directory
+   * @param is          the input stream to write from
+   * @param contentType the contentType of the stream, it originates from an HTTP request header
+   *                    which is optional by nature but mandatory in this context
    * @return `true` if a new file was created, `false` otherwise
    */
-  def writeDepositFile(is: => InputStream, user: String, id: UUID, path: Path, contentType: String): Try[Boolean] = {
+  def writeDepositFile(is: => InputStream, user: String, id: UUID, path: Path, contentType: Option[String]): Try[Boolean] = {
     for {
-      _ <- if (Option(contentType).toSeq.exists(!_.trim.matches(contentTypeZipPattern))) Success(())
-           else Failure(BadRequestException("Content-Type must not be application/zip."))
+      _ <- contentTypeAnythingButZip(contentType)
       dataFiles <- getDataFiles(user, id)
-      _ <- if (!(dataFiles.bag / "data" / path.toString).isDirectory) Success(())
-           else Failure(ConflictException("Attempt to overwrite a directory with a file."))
+      _ <- pathNotADirectory(path, dataFiles)
       _ = logger.info(s"uploading to [${ dataFiles.bag.baseDir }] of [$path]")
       created <- dataFiles.write(is, path)
       _ = logger.info(s"created=$created $user/$id/$path")
     } yield created
+  }
+
+  private def pathNotADirectory(path: Path, dataFiles: DataFiles) = {
+    if ((dataFiles.bag / "data" / path.toString).isDirectory)
+      Failure(ConflictException("Attempt to overwrite a directory with a file."))
+    else Success(())
+  }
+
+  private def contentTypeAnythingButZip(contentType: Option[String]) = {
+    if (contentType.exists(!_.trim.matches(contentTypeZipPattern)))
+      Success(())
+    else Failure(BadRequestException("Content-Type must not be application/zip."))
   }
 
   def stageFiles(userId: String, id: UUID, destination: Path): Try[(Dispose[File], StagedFilesTarget)] = {

--- a/src/main/scala/nl.knaw.dans.easy.deposit/EasyDepositApiApp.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/EasyDepositApiApp.scala
@@ -284,7 +284,7 @@ class EasyDepositApiApp(configuration: Configuration) extends DebugEnhancedLoggi
   }
 
   private def contentTypeAnythingButZip(contentType: Option[String]) = {
-    if (contentType.exists(!_.trim.matches(contentTypeZipPattern)))
+    if (contentType.exists(str => str.trim.nonEmpty && !str.trim.matches(contentTypeZipPattern)))
       Success(())
     else Failure(BadRequestException("Content-Type must not be application/zip."))
   }

--- a/src/main/scala/nl.knaw.dans.easy.deposit/servlets/DepositServlet.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/servlets/DepositServlet.scala
@@ -171,7 +171,7 @@ class DepositServlet(app: EasyDepositApiApp)
         uuid <- getUUID
         path <- getPath
         managedIS <- getRequestBodyAsManagedInputStream
-        newFileWasCreated <- managedIS.apply(app.writeDepositFile(_, user.id, uuid, path, request.getContentType))
+        newFileWasCreated <- managedIS.apply(app.writeDepositFile(_, user.id, uuid, path, Option(request.getContentType)))
       } yield if (newFileWasCreated)
                 Created(headers = Map("Location" -> request.uri.toASCIIString))
               else NoContent()

--- a/src/main/scala/nl.knaw.dans.easy.deposit/servlets/DepositServlet.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/servlets/DepositServlet.scala
@@ -21,8 +21,8 @@ import java.util.UUID
 
 import nl.knaw.dans.easy.deposit.docs.JsonUtil.{ InvalidDocumentException, toJson }
 import nl.knaw.dans.easy.deposit.docs.{ DatasetMetadata, StateInfo }
-import nl.knaw.dans.easy.deposit.servlets.DepositServlet.{ BadRequestException, InvalidResourceException, ZipMustBeOnlyFileException }
-import nl.knaw.dans.easy.deposit.{ EasyDepositApiApp, _ }
+import nl.knaw.dans.easy.deposit.servlets.DepositServlet._
+import nl.knaw.dans.easy.deposit._
 import nl.knaw.dans.lib.error._
 import nl.knaw.dans.lib.logging.servlet._
 import org.apache.commons.lang.NotImplementedException
@@ -171,7 +171,7 @@ class DepositServlet(app: EasyDepositApiApp)
         uuid <- getUUID
         path <- getPath
         managedIS <- getRequestBodyAsManagedInputStream
-        newFileWasCreated <- managedIS.apply(app.writeDepositFile(_, user.id, uuid, path))
+        newFileWasCreated <- managedIS.apply(app.writeDepositFile(_, user.id, uuid, path, request.getContentType))
       } yield if (newFileWasCreated)
                 Created(headers = Map("Location" -> request.uri.toASCIIString))
               else NoContent()
@@ -196,6 +196,7 @@ class DepositServlet(app: EasyDepositApiApp)
     case e: NoSuchFileException => NotFound(body = s"${ e.getMessage } not found", Map(contentTypePlainText))
     case e: InvalidResourceException => invalidResourceResponse(e)
     case e: InvalidDocumentException => badDocResponse(e)
+    case e: ConflictException => Conflict(e.getMessage, Map(contentTypePlainText))
     case e: ConcurrentUploadException => Conflict(e.getMessage, Map(contentTypePlainText))
     case e: FileAlreadyExistsException => Conflict("Conflict. The following file(s) already exist on the server: " + e.getMessage, Map(contentTypePlainText))
     case e: InvalidDoiException => BadRequest(e.getMessage, Map(contentTypePlainText))
@@ -258,5 +259,6 @@ object DepositServlet {
 
   private case class InvalidResourceException(s: String) extends Exception(s)
   case class BadRequestException(s: String) extends Exception(s)
+  case class ConflictException(s: String) extends Exception(s)
   case class ZipMustBeOnlyFileException(s: String) extends Exception(s"A multipart/form-data message contained a ZIP [$s] part but also other parts.")
 }

--- a/src/main/scala/nl.knaw.dans.easy.deposit/servlets/package.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/servlets/package.scala
@@ -42,7 +42,7 @@ import scala.util.{ Failure, Success, Try }
  */
 package object servlets extends DebugEnhancedLogging {
 
-  val extensionZipPattern = ".*.g?z(ip)?"
+  val extensionZipPattern = ".+[.]g?z(ip)?"
   private val pre = "(x-)?g?zip"
   private val post = "-compress(ed)?"
   val contentTypeZipPattern = s"application/(($pre($post)?)|(x$post))"

--- a/src/main/scala/nl.knaw.dans.easy.deposit/servlets/package.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/servlets/package.scala
@@ -42,10 +42,10 @@ import scala.util.{ Failure, Success, Try }
  */
 package object servlets extends DebugEnhancedLogging {
 
-  private val extensionZipPattern = ".*.g?z(ip)?"
+  val extensionZipPattern = ".*.g?z(ip)?"
   private val pre = "(x-)?g?zip"
   private val post = "-compress(ed)?"
-  private val contentTypeZipPattern = s"application/(($pre($post)?)|(x$post))"
+  val contentTypeZipPattern = s"application/(($pre($post)?)|(x$post))"
 
   val contentTypeJson: (String, String) = "content-type" -> "application/json;charset=UTF-8"
   val contentTypePlainText: (String, String) = "content-type" -> "text/plain;charset=UTF-8"

--- a/src/test/scala/nl.knaw.dans.easy.deposit/servlets/NotFoundSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/servlets/NotFoundSpec.scala
@@ -16,6 +16,7 @@
 package nl.knaw.dans.easy.deposit.servlets
 
 import better.files.File
+import nl.knaw.dans.easy.deposit.servlets
 import org.eclipse.jetty.http.HttpStatus._
 
 class NotFoundSpec extends DepositServletFixture {
@@ -78,7 +79,7 @@ class NotFoundSpec extends DepositServletFixture {
     get(s"/deposit/$uuid/file/path/to/file.txt", headers = Seq(fooBarBasicAuthHeader)) { shouldBeNoSuchDeposit }
   }
   it should "be returned by PUT /deposit/{id}/file/{file_path}" in {
-    put(s"/deposit/$uuid/file/path/to/file.txt", headers = Seq(fooBarBasicAuthHeader)) { shouldBeNoSuchDeposit }
+    put(s"/deposit/$uuid/file/path/to/file.txt", headers = Seq(fooBarBasicAuthHeader, contentTypePlainText)) { shouldBeNoSuchDeposit }
   }
   it should "be returned by DELETE /deposit/{id}/file/{file_path}" in {
     delete(s"/deposit/$uuid/file/path/to/file.txt", headers = Seq(fooBarBasicAuthHeader)) { shouldBeNoSuchDeposit }

--- a/src/test/scala/nl.knaw.dans.easy.deposit/servlets/UploadSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/servlets/UploadSpec.scala
@@ -304,7 +304,7 @@ class UploadSpec extends DepositServletFixture {
     // first upload
     put(
       uri = s"/deposit/$uuid/file/path/to/text.txt",
-      headers = Seq(fooBarBasicAuthHeader),
+      headers = Seq(fooBarBasicAuthHeader, contentTypePlainText),
       body = longContent
     ) {
       status shouldBe CREATED_201
@@ -316,7 +316,7 @@ class UploadSpec extends DepositServletFixture {
     val sha = "c5b8de8cc3587aef4e118a481115391033621e06"
     put(
       uri = s"/deposit/$uuid/file/path/to/text.txt",
-      headers = Seq(fooBarBasicAuthHeader),
+      headers = Seq(fooBarBasicAuthHeader, contentTypePlainText),
       body = shortContent
     ) {
       status shouldBe NO_CONTENT_204
@@ -342,7 +342,7 @@ class UploadSpec extends DepositServletFixture {
     val sha = "c5b8de8cc3587aef4e118a481115391033621e06"
     put(
       uri = s"/deposit/$uuid/file/text.txt",
-      headers = Seq(fooBarBasicAuthHeader),
+      headers = Seq(fooBarBasicAuthHeader, contentTypePlainText),
       body = shortContent
     ) {
       status shouldBe CREATED_201


### PR DESCRIPTION
Fixes EASY-1949 + EASY-1950 checks on PUT file (no zip, no file overwriting directory)

#### When applied it will
* Fix EASY-1949 reject zip files for PUT file requests
* Fix EASY-1950 reject a file that would overwrite a directory
* 

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### Related pull requests on github
repo                       | PR                | note
-------------------------- | ----------------- | ----
easy-                      | [PR#](PRlink)     | ..
