### PR TITLE
EASY-2044 upload of large files

### DIFF
--- a/src/main/assembly/dist/cfg/application.properties
+++ b/src/main/assembly/dist/cfg/application.properties
@@ -10,6 +10,7 @@
 daemon.http.port=20190
 
 # https://javaee.github.io/tutorial/servlets011.html
+# threshold: 3145728 = 3MB
 multipart.location=
 multipart.max-file-size=-1
 multipart.max-request-size=-1

--- a/src/main/assembly/dist/cfg/application.properties
+++ b/src/main/assembly/dist/cfg/application.properties
@@ -9,6 +9,12 @@
 #
 daemon.http.port=20190
 
+# https://javaee.github.io/tutorial/servlets011.html
+multipart.location=
+multipart.max-file-size=-1
+multipart.max-request-size=-1
+multipart.file-size-threshold=3145728
+
 #
 # Directories for managing the deposits.
 #

--- a/src/main/scala/nl.knaw.dans.easy.deposit/EasyDepositApiApp.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/EasyDepositApiApp.scala
@@ -59,10 +59,11 @@ class EasyDepositApiApp(configuration: Configuration) extends DebugEnhancedLoggi
     logger.info(s"users.ldap-admin-principal = $ldapAdminPrincipal")
   }
   val multipartConfig: MultipartConfig = MultipartConfig(
-    location = Some(properties.getString("multipart.location","")),
-    maxFileSize = Some(properties.getLong("multipart.max-file-size", -1)),
-    maxRequestSize = Some(properties.getLong("multipart.max-request-size", -1)),
+    location = Option(properties.getString("multipart.location", null)),
+    maxFileSize = Option(properties.getLong("multipart.max-file-size", null)),
+    maxRequestSize = Option(properties.getLong("multipart.max-request-size", null)),
     fileSizeThreshold = Some(properties.getInt("multipart.file-size-threshold", 0)),
+    // getInt doesn't compile with null as default
   )
 
   def getVersion: String = {

--- a/src/main/scala/nl.knaw.dans.easy.deposit/EasyDepositApiApp.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/EasyDepositApiApp.scala
@@ -58,12 +58,21 @@ class EasyDepositApiApp(configuration: Configuration) extends DebugEnhancedLoggi
     logger.info(s"users.ldap-user-id-attr-name = $ldapUserIdAttrName")
     logger.info(s"users.ldap-admin-principal = $ldapAdminPrincipal")
   }
+
   val multipartConfig: MultipartConfig = MultipartConfig(
     location = Option(properties.getString("multipart.location", null)),
     maxFileSize = Option(properties.getLong("multipart.max-file-size", null)),
     maxRequestSize = Option(properties.getLong("multipart.max-request-size", null)),
-    fileSizeThreshold = Some(properties.getInt("multipart.file-size-threshold", 0)),
-    // getInt doesn't compile with null as default
+    fileSizeThreshold = {
+      val integerValue = properties.getInteger("multipart.file-size-threshold", null)
+      // we can't postpone next check to the constructor of DepositServlet
+      // because in case of null next line would print: Some(0) None
+      // println(s"${Option[Int](integerValue)} ${Option[Integer](integerValue)}")
+      Option(integerValue).getOrElse(
+        throw ConfigurationException("Please configure multipart.file-size-threshold to prevent heap space exceptions on large uploads")
+      )
+      Option(integerValue)
+    },
   )
 
   def getVersion: String = {

--- a/src/main/scala/nl.knaw.dans.easy.deposit/EasyDepositApiApp.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/EasyDepositApiApp.scala
@@ -63,16 +63,7 @@ class EasyDepositApiApp(configuration: Configuration) extends DebugEnhancedLoggi
     location = Option(properties.getString("multipart.location", null)),
     maxFileSize = Option(properties.getLong("multipart.max-file-size", null)),
     maxRequestSize = Option(properties.getLong("multipart.max-request-size", null)),
-    fileSizeThreshold = {
-      val integerValue = properties.getInteger("multipart.file-size-threshold", null)
-      // we can't postpone next check to the constructor of DepositServlet
-      // because in case of null next line would print: Some(0) None
-      // println(s"${Option[Int](integerValue)} ${Option[Integer](integerValue)}")
-      Option(integerValue).getOrElse(
-        throw ConfigurationException("Please configure multipart.file-size-threshold to prevent heap space exceptions on large uploads")
-      )
-      Option(integerValue)
-    },
+    fileSizeThreshold = Some(properties.getInt("multipart.file-size-threshold")),//throws if not provided
   )
 
   def getVersion: String = {

--- a/src/main/scala/nl.knaw.dans.easy.deposit/EasyDepositApiApp.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/EasyDepositApiApp.scala
@@ -60,7 +60,7 @@ class EasyDepositApiApp(configuration: Configuration) extends DebugEnhancedLoggi
   }
 
   val multipartConfig: MultipartConfig = MultipartConfig(
-    location = Option(properties.getString("multipart.location", null)),
+    location = Option(properties.getString("multipart.location")),
     maxFileSize = Option(properties.getLong("multipart.max-file-size", null)),
     maxRequestSize = Option(properties.getLong("multipart.max-request-size", null)),
     fileSizeThreshold = Some(properties.getInt("multipart.file-size-threshold")),//throws if not provided

--- a/src/main/scala/nl.knaw.dans.easy.deposit/EasyDepositApiApp.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/EasyDepositApiApp.scala
@@ -32,6 +32,7 @@ import nl.knaw.dans.easy.deposit.servlets.contentTypeZipPattern
 import nl.knaw.dans.lib.error._
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
 import org.apache.commons.configuration.PropertiesConfiguration
+import org.scalatra.servlet.MultipartConfig
 
 import scala.util.{ Failure, Success, Try }
 
@@ -57,6 +58,12 @@ class EasyDepositApiApp(configuration: Configuration) extends DebugEnhancedLoggi
     logger.info(s"users.ldap-user-id-attr-name = $ldapUserIdAttrName")
     logger.info(s"users.ldap-admin-principal = $ldapAdminPrincipal")
   }
+  val multipartConfig: MultipartConfig = MultipartConfig(
+    location = Some(properties.getString("multipart.location","")),
+    maxFileSize = Some(properties.getLong("multipart.max-file-size", -1)),
+    maxRequestSize = Some(properties.getLong("multipart.max-request-size", -1)),
+    fileSizeThreshold = Some(properties.getInt("multipart.file-size-threshold", 0)),
+  )
 
   def getVersion: String = {
     configuration.version

--- a/src/main/scala/nl.knaw.dans.easy.deposit/EasyDepositApiApp.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/EasyDepositApiApp.scala
@@ -63,7 +63,7 @@ class EasyDepositApiApp(configuration: Configuration) extends DebugEnhancedLoggi
     location = Option(properties.getString("multipart.location")),
     maxFileSize = Option(properties.getLong("multipart.max-file-size", null)),
     maxRequestSize = Option(properties.getLong("multipart.max-request-size", null)),
-    fileSizeThreshold = Some(properties.getInt("multipart.file-size-threshold")),//throws if not provided
+    fileSizeThreshold = Some(properties.getInt("multipart.file-size-threshold")), //throws if not provided
   )
 
   def getVersion: String = {

--- a/src/main/scala/nl.knaw.dans.easy.deposit/servlets/DepositServlet.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/servlets/DepositServlet.scala
@@ -39,8 +39,10 @@ class DepositServlet(app: EasyDepositApiApp)
   configureMultipartHandling(app.multipartConfig.copy(location = app.multipartConfig.location
       .filter(_.trim.nonEmpty)
       .map { s =>
-        val absolutePath = File(s).path.toAbsolutePath
-        if (!File(s).isDirectory) throw ConfigurationException(s"$absolutePath not found or not a directory")
+        val dir = File(s)
+        val absolutePath = dir.path.toAbsolutePath
+        if (!dir.isDirectory && !dir.isReadable && !dir.isWriteable)
+          throw ConfigurationException(s"$absolutePath not found/readable/writable or not a directory")
         absolutePath.toString
       }
   ))

--- a/src/main/scala/nl.knaw.dans.easy.deposit/servlets/DepositServlet.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/servlets/DepositServlet.scala
@@ -37,14 +37,14 @@ class DepositServlet(app: EasyDepositApiApp)
     with FileUploadSupport {
 
   configureMultipartHandling(app.multipartConfig.copy(location = app.multipartConfig.location
-      .filter(_.trim.nonEmpty)
-      .map { s =>
-        val dir = File(s)
-        val absolutePath = dir.path.toAbsolutePath
-        if (!dir.isDirectory && !dir.isReadable && !dir.isWriteable)
-          throw ConfigurationException(s"$absolutePath not found/readable/writable or not a directory")
-        absolutePath.toString
-      }
+    .filter(_.trim.nonEmpty)
+    .map { s =>
+      val dir = File(s)
+      val absolutePath = dir.path.toAbsolutePath
+      if (!dir.isDirectory && !dir.isReadable && !dir.isWriteable)
+        throw ConfigurationException(s"$absolutePath not found/readable/writable or not a directory")
+      absolutePath.toString
+    }
   ))
 
   error {

--- a/src/main/scala/nl.knaw.dans.easy.deposit/servlets/DepositServlet.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/servlets/DepositServlet.scala
@@ -34,7 +34,7 @@ import scala.util.{ Failure, Success, Try }
 class DepositServlet(app: EasyDepositApiApp)
   extends ProtectedServlet(app)
     with FileUploadSupport {
-  configureMultipartHandling(MultipartConfig())
+  configureMultipartHandling(app.multipartConfig)
   error {
     case e: SizeConstraintExceededException => RequestEntityTooLarge(s"too much! ${ e.getMessage }")
     case e: IOException => s"MultipartHandling Exception: $e"

--- a/src/main/scala/nl.knaw.dans.easy.deposit/servlets/package.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/servlets/package.scala
@@ -24,7 +24,6 @@ import nl.knaw.dans.easy.deposit.Errors.{ MalformedZipException, ZipMustBeOnlyFi
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
 import org.scalatra.servlet.FileItem
 import org.scalatra.util.RicherString._
-import org.scalatra.{ ActionResult, InternalServerError }
 import resource.{ ManagedResource, managed }
 
 import scala.util.{ Failure, Success, Try }

--- a/src/test/resources/debug-config/application.properties
+++ b/src/test/resources/debug-config/application.properties
@@ -1,6 +1,6 @@
 daemon.http.port=20190
 
-# https://javaee.github.io/tutorial/servlets011.html
+# threshold: 3145728 = 3MB
 multipart.location=
 multipart.max-file-size=-1
 multipart.max-request-size=-1

--- a/src/test/resources/debug-config/application.properties
+++ b/src/test/resources/debug-config/application.properties
@@ -1,5 +1,11 @@
 daemon.http.port=20190
 
+# https://javaee.github.io/tutorial/servlets011.html
+multipart.location=
+multipart.max-file-size=-1
+multipart.max-request-size=-1
+multipart.file-size-threshold=3145728
+
 deposits.stage-zips=data/stage-zips
 deposits.drafts=data/drafts
 deposits.stage-for-submit=data/stage-for-submit

--- a/src/test/scala/nl.knaw.dans.easy.deposit/SubmitterSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/SubmitterSpec.scala
@@ -23,7 +23,6 @@ import nl.knaw.dans.bag.DansBag
 import nl.knaw.dans.easy.deposit.docs.StateInfo.State
 import nl.knaw.dans.easy.deposit.docs._
 import nl.knaw.dans.lib.error._
-import org.apache.commons.configuration.PropertiesConfiguration
 import org.scalamock.scalatest.MockFactory
 
 import scala.util.{ Failure, Success }

--- a/src/test/scala/nl.knaw.dans.easy.deposit/SubmitterSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/SubmitterSpec.scala
@@ -23,6 +23,7 @@ import nl.knaw.dans.bag.DansBag
 import nl.knaw.dans.easy.deposit.docs.StateInfo.State
 import nl.knaw.dans.easy.deposit.docs._
 import nl.knaw.dans.lib.error._
+import org.apache.commons.configuration.PropertiesConfiguration
 import org.scalamock.scalatest.MockFactory
 
 import scala.util.{ Failure, Success }
@@ -41,7 +42,7 @@ class SubmitterSpec extends TestSupportFixture with MockFactory {
     .getOrElse(fail("could not get DOI from test input"))
 
   "constructor" should "fail if the configured group does not exist" in {
-    val props = minimalAppConfig.properties
+    val props = minimalAppConfig.properties.clone().asInstanceOf[PropertiesConfiguration]
     props.setProperty("deposit.permissions.group", "not-existing-group")
 
     // the App creates the Submitter

--- a/src/test/scala/nl.knaw.dans.easy.deposit/SubmitterSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/SubmitterSpec.scala
@@ -42,7 +42,7 @@ class SubmitterSpec extends TestSupportFixture with MockFactory {
     .getOrElse(fail("could not get DOI from test input"))
 
   "constructor" should "fail if the configured group does not exist" in {
-    val props = minimalAppConfig.properties.clone().asInstanceOf[PropertiesConfiguration]
+    val props = minimalAppConfig.properties
     props.setProperty("deposit.permissions.group", "not-existing-group")
 
     // the App creates the Submitter

--- a/src/test/scala/nl.knaw.dans.easy.deposit/TestSupportFixture.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/TestSupportFixture.scala
@@ -86,6 +86,7 @@ trait TestSupportFixture extends FlatSpec with Matchers with Inside with BeforeA
       addProperty("users.ldap-admin-principal", "-")
       addProperty("users.ldap-admin-password", "-")
       addProperty("users.ldap-user-id-attr-name", "-")
+      addProperty("multipart.file-size-threshold", "3145728") // 3MB
     })
   }
 

--- a/src/test/scala/nl.knaw.dans.easy.deposit/servlets/DepositServletErrorSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/servlets/DepositServletErrorSpec.scala
@@ -50,15 +50,19 @@ class DepositServletErrorSpec extends TestSupportFixture with ServletFixture wit
 
   it should "fail with empty threshold value" in {
     val props = minimalAppConfig.properties.clone().asInstanceOf[PropertiesConfiguration]
+    props.clearProperty("multipart.file-size-threshold")
     props.addProperty("multipart.file-size-threshold", "")
     the[ConversionException] thrownBy new DepositServlet(new EasyDepositApiApp(new Configuration("", props))) should
       have message s"'multipart.file-size-threshold' doesn't map to an Integer object"
   }
 
-  it should "succeed without threshold property" in {
+  it should "fail without threshold property" in {
     val props = minimalAppConfig.properties
-    Option(props.getProperty("multipart.file-size-threshold")) shouldBe None // precondition
-    new DepositServlet(new EasyDepositApiApp(new Configuration("", props))) shouldBe a[DepositServlet]
+    props.clearProperty("multipart.file-size-threshold")
+    Option(props.getInteger("multipart.file-size-threshold",null)) shouldBe None // precondition
+
+    the[ConfigurationException] thrownBy new DepositServlet(new EasyDepositApiApp(Configuration("",props))) should
+      have message "Configuration error: Please configure multipart.file-size-threshold to prevent heap space exceptions on large uploads"
   }
 
   "post /" should "return 500 (Internal Server Error) on a not expected exception and basic authentication" in {

--- a/src/test/scala/nl.knaw.dans.easy.deposit/servlets/DepositServletErrorSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/servlets/DepositServletErrorSpec.scala
@@ -61,8 +61,8 @@ class DepositServletErrorSpec extends TestSupportFixture with ServletFixture wit
     props.clearProperty("multipart.file-size-threshold")
     Option(props.getInteger("multipart.file-size-threshold",null)) shouldBe None // precondition
 
-    the[ConfigurationException] thrownBy new DepositServlet(new EasyDepositApiApp(Configuration("",props))) should
-      have message "Configuration error: Please configure multipart.file-size-threshold to prevent heap space exceptions on large uploads"
+    the[NoSuchElementException] thrownBy new DepositServlet(new EasyDepositApiApp(Configuration("",props))) should
+      have message s"'multipart.file-size-threshold' doesn't map to an existing object"
   }
 
   "post /" should "return 500 (Internal Server Error) on a not expected exception and basic authentication" in {

--- a/src/test/scala/nl.knaw.dans.easy.deposit/servlets/DepositServletErrorSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/servlets/DepositServletErrorSpec.scala
@@ -27,7 +27,7 @@ import org.eclipse.jetty.http.HttpStatus._
 import org.scalatra.auth.Scentry
 import org.scalatra.test.scalatest.ScalatraSuite
 
-import scala.util.{ Failure, Success }
+import scala.util.Failure
 
 class DepositServletErrorSpec extends TestSupportFixture with ServletFixture with ScalatraSuite {
 
@@ -42,14 +42,14 @@ class DepositServletErrorSpec extends TestSupportFixture with ServletFixture wit
   addServlet(depositServlet, "/*")
 
   "constructor" should "fail with not existing multipart location" in {
-    val props = minimalAppConfig.properties.clone().asInstanceOf[PropertiesConfiguration]
+    val props = minimalAppConfig.properties
     props.addProperty("multipart.location", "notExistingLocation")
     the[ConfigurationException] thrownBy new DepositServlet(new EasyDepositApiApp(new Configuration("", props))) should
       have message s"Configuration error: ${ File("notExistingLocation").path.toAbsolutePath } not found/readable/writable or not a directory"
   }
 
   it should "fail with empty threshold value" in {
-    val props = minimalAppConfig.properties.clone().asInstanceOf[PropertiesConfiguration]
+    val props = minimalAppConfig.properties
     props.clearProperty("multipart.file-size-threshold")
     props.addProperty("multipart.file-size-threshold", "")
     the[ConversionException] thrownBy new DepositServlet(new EasyDepositApiApp(new Configuration("", props))) should
@@ -59,9 +59,9 @@ class DepositServletErrorSpec extends TestSupportFixture with ServletFixture wit
   it should "fail without threshold property" in {
     val props = minimalAppConfig.properties
     props.clearProperty("multipart.file-size-threshold")
-    Option(props.getInteger("multipart.file-size-threshold",null)) shouldBe None // precondition
+    Option(props.getInteger("multipart.file-size-threshold", null)) shouldBe None // precondition
 
-    the[NoSuchElementException] thrownBy new DepositServlet(new EasyDepositApiApp(Configuration("",props))) should
+    the[NoSuchElementException] thrownBy new DepositServlet(new EasyDepositApiApp(Configuration("", props))) should
       have message s"'multipart.file-size-threshold' doesn't map to an existing object"
   }
 

--- a/src/test/scala/nl.knaw.dans.easy.deposit/servlets/DepositServletErrorSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/servlets/DepositServletErrorSpec.scala
@@ -45,7 +45,7 @@ class DepositServletErrorSpec extends TestSupportFixture with ServletFixture wit
     val props = minimalAppConfig.properties.clone().asInstanceOf[PropertiesConfiguration]
     props.addProperty("multipart.location", "notExistingLocation")
     the[ConfigurationException] thrownBy new DepositServlet(new EasyDepositApiApp(new Configuration("", props))) should
-      have message s"Configuration error: ${ File("notExistingLocation").path.toAbsolutePath } not found or not a directory"
+      have message s"Configuration error: ${ File("notExistingLocation").path.toAbsolutePath } not found/readable/writable or not a directory"
   }
 
   it should "fail with empty threshold value" in {
@@ -57,8 +57,8 @@ class DepositServletErrorSpec extends TestSupportFixture with ServletFixture wit
 
   it should "succeed without threshold property" in {
     val props = minimalAppConfig.properties
-    Option(props.getProperty("multipart.file-size-threshold")) shouldBe None
-    new DepositServlet(new EasyDepositApiApp(new Configuration("", props))) shouldBe a[Success[_]]
+    Option(props.getProperty("multipart.file-size-threshold")) shouldBe None // precondition
+    new DepositServlet(new EasyDepositApiApp(new Configuration("", props))) shouldBe a[DepositServlet]
   }
 
   "post /" should "return 500 (Internal Server Error) on a not expected exception and basic authentication" in {


### PR DESCRIPTION
Fixes EASY-2044 upload of large files

#### When applied it will
* read at most 3MB in memory for uploads
* 
* 

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?
* create a big file: `head -c 1073741824 < /dev/urandom > 1GB.txt`
* try to upload it before deploy
* try to upload it after deploy
  * while the progess bar is growing you will see a file growing in size:
    `/var/opt/dans.knaw.nl/tmp/easy-deposit-api/multipart-location/MultiPart*`
  * when the request completes (with success or not) it disppears

#### Related pull requests on github
https://github.com/DANS-KNAW/easy-dtap/pull/319
