### PR TITLE
EASY-1947 multipart not allowed for PUT file requests

### DIFF
--- a/docs/api/api.yml
+++ b/docs/api/api.yml
@@ -407,10 +407,6 @@ paths:
         unzipped in `dir_path`. For each file in the ZIP file, the path in the deposit will be `dir_path`/`path_in_zip`.
         The ZIP file may contain `nested ZIP files`, which will **not** be extracted, but stored as ZIP file.
 
-        In all other cases the files are all stored in the directory pointed to by `dir_path` and **it is not
-        allowed** to include any files with `Content-Type: application/zip`. Note, that this means that only a flat
-        list of files can be sent this way, i.e. not including any directory hierarchy.
-
         Concurrent POST calls to the same deposit are not allowed. The result of concurrent PUT and POST calls is
         undefined.
       parameters:
@@ -503,7 +499,7 @@ paths:
        - $ref: "#/components/parameters/FilePath"
       description: |
         If any of `file_path`'s parent do not yet exist, they are first created. The parameter `file_path` must not refer
-        to an existing directory. The Content-Type may be anything except `application/zip`.
+        to an existing directory. The Content-Type may be not be `application/zip` nor `multipart`.
       operationId: writeFile
       requestBody:
         description: file data
@@ -685,7 +681,7 @@ components:
       description: Bad Request. The request body must be multipart/form-data.
 
     ZipFileNotAllowed:
-      description: Bad request. Content-Type must not be application/zip.
+      description: Bad request. Content-Type must not be application/zip nor start with multipart.
 
   schemas:
 

--- a/src/main/scala/nl.knaw.dans.easy.deposit/EasyDepositApiApp.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/EasyDepositApiApp.scala
@@ -294,12 +294,12 @@ class EasyDepositApiApp(configuration: Configuration) extends DebugEnhancedLoggi
   }
 
   private def contentTypeAnythingBut(contentType: Option[String]): Try[Unit] = {
-    if (contentType.map(_.trim.toLowerCase).exists(str =>
-      str.nonEmpty &&
-      !str.matches(contentTypeZipPattern) &&
-      !str.startsWith("multipart")
-    )) Success(())
-    else Failure(InvalidContentTypeException(contentType, "must not be application/zip nor start with multipart."))
+    contentType.map(_.trim.toLowerCase) match {
+      case Some(str) if str.nonEmpty
+        && !str.startsWith("multipart")
+        && !str.matches(contentTypeZipPattern) => Success(())
+      case _ => Failure(InvalidContentTypeException(contentType, "must not be application/zip nor start with multipart."))
+    }
   }
 
   def stageFiles(userId: String, id: UUID, destination: Path): Try[(Dispose[File], StagedFilesTarget)] = {

--- a/src/test/scala/nl.knaw.dans.easy.deposit/servlets/IntegrationSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/servlets/IntegrationSpec.scala
@@ -115,7 +115,7 @@ class IntegrationSpec extends TestSupportFixture with ServletFixture with Scalat
       headers = Seq(fooBarBasicAuthHeader),
       body = "Lorum ipsum"
     ) {
-      body shouldBe "Content-Type is a mandatory request header and must not be a zip."
+      body shouldBe "Content-Type is a mandatory request header and must not be application/zip nor start with multipart."
       status shouldBe BAD_REQUEST_400
     }
 


### PR DESCRIPTION
Fixes EASY-1947 PUT file with Content-Type: multipart/form-data results in corrupt upload

#### When applied it will
* fix an oversight in documentation of nested zips in #132
* document/check no multipart is PUT file request

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### Related pull requests on github
repo                       | PR                | note
-------------------------- | ----------------- | ----
easy-                      | [PR#](PRlink)     | ..
