### PR TITLE
EASY-1905 add more unit tests for DatasetMetadataSpec, only return the part that is invalid

### DIFF
--- a/src/test/scala/nl.knaw.dans.easy.deposit/docs/DatasetMetadataSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/docs/DatasetMetadataSpec.scala
@@ -200,7 +200,7 @@ class DatasetMetadataSpec extends TestSupportFixture {
     expectErrorMessage(creators, """invalid DatasetMetadata: don't recognize {"creators":[{"ids":{"organization":"overheid"}},{"FirstName":"jan-willem-hendrik"},{"role":{"waarde":"invalid","andereWaarde":"invalid"}}]}""")
   }
 
-  "DatasetMetadata.creators" should "report the unrecocginzed value in roles" in {
+  "DatasetMetadata.creators" should "report the unrecognized value in roles" in {
     val creators =
       """{ "creators": [{"role": [{ "scheme": "datacite:contributorType", "key": "ContactPerson""waarde": "invalid", "andereWaarde": "invalid"}]}]}"""
     DatasetMetadata(creators) shouldBe a[Success[_]] //TODO this is not correct, creators[0].role[0].waarde should probably fail! Perhaps it succeeds since it is seen as an option?

--- a/src/test/scala/nl.knaw.dans.easy.deposit/docs/DatasetMetadataSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/docs/DatasetMetadataSpec.scala
@@ -234,17 +234,15 @@ class DatasetMetadataSpec extends TestSupportFixture {
     val creatorValid = """{"titles": "Msc", "initials": "H.A.M.", "surname": "Boter", "ids": [ { "scheme": "DAI", "value":  "93313935x"}, {"scheme": "BSN", "value": "1234"} ], "organization" :"DANS"}"""
     val creatorInvalidIdElement = """{"titles": "Msc", "initials": "B.A.M.", "surname": "Hoter", "ids": [ { "scheme": "DAI", "value":  "93313935Z"}, {"scheme": "BSN", "value": "1235", "organization": "overheid"} ], "organization" :"DANS"}"""
     val creatorInvalidElementAtRootLevel = """{"titles": "Aartshertog", "FirstName": "jan-willem-hendrik", "surname": "Oranje", "ids": [ { "scheme": "DAI", "value":  "93313935y"}, {"scheme": "BSN", "value": "9999"} ], "organization" :"DANS"}"""
+    val creatorInvalidRole = """{"titles": "Dr", "initials": "S.", "surname": "Pieterzoon", "ids": [ { "scheme": "DAI", "value":  "93313935i"} ], "organization" :"DANS", "roles": [ { "scheme": "datacite:contributorType", "key": "ContactPerson", "waarde": "invalid"} ] }"""
 
-    val replaceWith = s""""creators": [$creatorValid, $creatorInvalidIdElement, $creatorInvalidElementAtRootLevel]"""
+    val replaceWith = s""""creators": [$creatorValid, $creatorInvalidIdElement, $creatorInvalidElementAtRootLevel, $creatorInvalidRole]"""
     val alteredData = createCorruptMetadataJsonString(placeHolder, replaceWith)
 
     DatasetMetadata(alteredData) should matchPattern {
-      case Failure(ide: InvalidDocumentException) if ide.getMessage == "invalid DatasetMetadata: don't recognize {\"creators\":[{\"ids\":{\"organization\":\"overheid\"}},{\"FirstName\":\"jan-willem-hendrik\"}]}" =>
+      case Failure(ide: InvalidDocumentException) if ide.getMessage == "invalid DatasetMetadata: don't recognize {\"creators\":[{\"ids\":{\"organization\":\"overheid\"}},{\"FirstName\":\"jan-willem-hendrik\"},{\"roles\":[{\"scheme\":\"datacite:contributorType\",\"key\":\"ContactPerson\",\"waarde\":\"invalid\"}]}]}" =>
     }
   }
-
-
-
 
   private def createCorruptMetadataJsonString(pattern: String, replacement: String): String = {
     val bigMetadata = File("src/test/resources/manual-test/datasetmetadata.json").contentAsString

--- a/src/test/scala/nl.knaw.dans.easy.deposit/docs/DatasetMetadataSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/docs/DatasetMetadataSpec.scala
@@ -182,7 +182,7 @@ class DatasetMetadataSpec extends TestSupportFixture {
   "DatasetMetadata.spatialCoverages" should "only report someCoverage if is supplied instead of spatialCoverages" in {
     val alteredData = createCorruptMetadataJsonString(" \"spatialCoverages\"", " \"someCoverage\"")
     DatasetMetadata(alteredData) should matchPattern {
-      case Failure(ide: InvalidDocumentException) if ide.getMessage == "invalid DatasetMetadata: don't recognize {\"someCoverage\":[{\"scheme\":\"dcterms:ISO3166\",\"value\":\"string\",\"key\":\"string\"}]}" =>
+      case Failure(ide: InvalidDocumentException) if ide.getMessage == """invalid DatasetMetadata: don't recognize {"someCoverage":[{"scheme":"dcterms:ISO3166","value":"string","key":"string"}]}""" =>
     }
   }
 

--- a/src/test/scala/nl.knaw.dans.easy.deposit/docs/DatasetMetadataSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/docs/DatasetMetadataSpec.scala
@@ -270,7 +270,6 @@ class DatasetMetadataSpec extends TestSupportFixture {
   }
 
   private def createCorruptMetadataJsonString(pattern: String, replacement: String): String = {
-    val bigMetadata = File("src/test/resources/manual-test/datasetmetadata.json").contentAsString
-    bigMetadata.replaceAll(pattern, replacement)
+    File("src/test/resources/manual-test/datasetmetadata.json").contentAsString.replaceAll(pattern, replacement)
   }
 }

--- a/src/test/scala/nl.knaw.dans.easy.deposit/docs/DatasetMetadataSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/docs/DatasetMetadataSpec.scala
@@ -165,7 +165,7 @@ class DatasetMetadataSpec extends TestSupportFixture {
   "DatasetMetadata.*" should "only report the item in the list that are invalid" in {
     val alteredData = createCorruptMetadataJsonString(""""scheme": "string"""", """"invalid": "property"""")
     DatasetMetadata(alteredData) should matchPattern {
-      case Failure(ide: InvalidDocumentException) if ide.getMessage.contains("""{"languageOfDescription":{"invalid":"property"},"audiences":{"invalid":"property"},"subjects":{"invalid":"property"},"languagesOfFiles":{"invalid":"property"},"temporalCoverages":{"invalid":"property"}}""") =>
+      case Failure(ide: InvalidDocumentException) if ide.getMessage == """invalid DatasetMetadata: don't recognize {"languageOfDescription":{"invalid":"property"},"audiences":{"invalid":"property"},"subjects":{"invalid":"property"},"languagesOfFiles":{"invalid":"property"},"temporalCoverages":{"invalid":"property"}}""" =>
     }
   }
 
@@ -173,12 +173,12 @@ class DatasetMetadataSpec extends TestSupportFixture {
     val boxes: String =
       """{ "spatialBoxes": [{"north-west": 2,"south-east": 3,"north": 4,"east": 5,"south": 9,"west": 10}]}"""
     DatasetMetadata(boxes) should matchPattern {
-      case Failure(ide: InvalidDocumentException) if ide.getMessage == "invalid DatasetMetadata: don't recognize {\"spatialBoxes\":{\"north-west\":2,\"south-east\":3}}" =>
+      case Failure(ide: InvalidDocumentException) if ide.getMessage == """invalid DatasetMetadata: don't recognize {"spatialBoxes":{"north-west":2,"south-east":3}}""" =>
     }
   }
 
   "DatasetMetadata.spatialCoverages" should "only report someCoverage if is supplied instead of spatialCoverages" in {
-    val alteredData = createCorruptMetadataJsonString(" \"spatialCoverages\"", " \"someCoverage\"")
+    val alteredData = createCorruptMetadataJsonString(""" "spatialCoverages"""", """ "someCoverage"""")
     DatasetMetadata(alteredData) should matchPattern {
       case Failure(ide: InvalidDocumentException) if ide.getMessage == """invalid DatasetMetadata: don't recognize {"someCoverage":[{"scheme":"dcterms:ISO3166","value":"string","key":"string"}]}""" =>
     }

--- a/src/test/scala/nl.knaw.dans.easy.deposit/docs/DatasetMetadataSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/docs/DatasetMetadataSpec.scala
@@ -165,24 +165,15 @@ class DatasetMetadataSpec extends TestSupportFixture {
   }
 
   "DatasetMetadata.*" should "only report the item in the list that are invalid" in {
-    val alteredData = createCorruptMetadataJsonString("\"scheme\": \"string\"", "\"invalid\": \"property\"")
+    val alteredData = createCorruptMetadataJsonString(""""scheme": "string"""", """"invalid": "property"""")
     DatasetMetadata(alteredData) should matchPattern {
-      case Failure(ide: InvalidDocumentException) if ide.getMessage.contains("{\"languageOfDescription\":{\"invalid\":\"property\"},\"audiences\":{\"invalid\":\"property\"},\"subjects\":{\"invalid\":\"property\"},\"languagesOfFiles\":{\"invalid\":\"property\"},\"temporalCoverages\":{\"invalid\":\"property\"}}") =>
+      case Failure(ide: InvalidDocumentException) if ide.getMessage.contains("""{"languageOfDescription":{"invalid":"property"},"audiences":{"invalid":"property"},"subjects":{"invalid":"property"},"languagesOfFiles":{"invalid":"property"},"temporalCoverages":{"invalid":"property"}}""") =>
     }
   }
 
   "DatasetMetadata.spatialBoxes" should "only report spatial points of the box that are invalid" in {
     val boxes: String =
-      """{
-        |	"spatialBoxes": [{
-        |		"north-west": 2,
-        |		"south-east": 3,
-        |		"north": 4,
-        |		"east": 5,
-        |		"south": 9,
-        |		"west": 10
-        |	}],
-        |}""".stripMargin
+      """{ "spatialBoxes": [{"north-west": 2,"south-east": 3,"north": 4,"east": 5,"south": 9,"west": 10}]}"""
     DatasetMetadata(boxes) should matchPattern {
       case Failure(ide: InvalidDocumentException) if ide.getMessage == "invalid DatasetMetadata: don't recognize {\"spatialBoxes\":{\"north-west\":2,\"south-east\":3}}" =>
     }

--- a/src/test/scala/nl.knaw.dans.easy.deposit/docs/DatasetMetadataSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/docs/DatasetMetadataSpec.scala
@@ -137,15 +137,13 @@ class DatasetMetadataSpec extends TestSupportFixture {
 
   "DatasetMetadata.author" should "accept an author with initials and surname" in {
     DatasetMetadata(
-      """{ "creators": [ {
+      """{ "creators": [{
         | "initials": "A",
         |  "surname": "Einstein",
-        |  "role": {
-        |        "scheme": "datacite:contributorType",
-        |        "key": "RightsHolder",
-        |        "value": "rightsholder"
-        |      }
-        |} ] }""".stripMargin)
+        |  "role": { "scheme": "datacite:contributorType","key": "RightsHolder","value": "rightsholder" }
+        |  }
+        | ]
+        |}""".stripMargin)
       .map(_.rightsHolders.map(_.toString).mkString(";")) shouldBe Success("A Einstein")
   }
 
@@ -189,17 +187,10 @@ class DatasetMetadataSpec extends TestSupportFixture {
   "DatasetMetadata.Dates" should "only report the dates that are not correct" in {
     val dates =
       """{
-        |	"dates": [{
-        |			"scheme": "dcterms:W3CDTF",
-        |			"value": "2018-05-31",
-        |			"qualifier": "dcterms:created"
-        |		},
-        |		{
-        |			"invalidOne": "invalid",
-        |			"invalidValue": "2018-05-31",
-        |			"invalidQualifier": "dcterms:created"
-        |		}
-        |	]
+        |"dates": [{
+        |"scheme": "dcterms:W3CDTF","value": "2018-05-31","qualifier": "dcterms:created"},
+        |{"invalidOne": "invalid","invalidValue": "2018-05-31","invalidQualifier": "dcterms:created"}
+        ]
         |}""".stripMargin
     DatasetMetadata(dates) should matchPattern {
       case Failure(ide: InvalidDocumentException) if ide.getMessage == """invalid DatasetMetadata: don't recognize {"dates":{"invalidOne":"invalid","invalidValue":"2018-05-31","invalidQualifier":"dcterms:created"}}""" =>
@@ -207,49 +198,36 @@ class DatasetMetadataSpec extends TestSupportFixture {
   }
 
   "DatasetMetadata.creators" should "only report the part of the creators that are wrong" in {
-    val creatorValid = """{"titles": "Msc", "initials": "H.A.M.", "surname": "Boter", "ids": [ { "scheme": "DAI", "value":  "93313935x"}, {"scheme": "BSN", "value": "1234"} ], "organization" :"DANS"}"""
-    val creatorInvalidIdElement = """{"titles": "Msc", "initials": "B.A.M.", "surname": "Hoter", "ids": [ { "scheme": "DAI", "value":  "93313935Z"}, {"scheme": "BSN", "value": "1235", "organization": "overheid"} ], "organization" :"DANS"}"""
-    val creatorInvalidElementAtRootLevel = """{"titles": "Aartshertog", "FirstName": "jan-willem-hendrik", "surname": "Oranje", "ids": [ { "scheme": "DAI", "value":  "93313935y"}, {"scheme": "BSN", "value": "9999"} ], "organization" :"DANS"}"""
-    //TODO moet hij hier niet struikelen over het veld role[0].waarde?
-    val creatorInvalidRole =
-      """{"titles": "Dr", "initials": "S.", "surname": "Pieterzoon", "ids": [ { "scheme": "DAI", "value":  "93313935i"} ], "organization" :"DANS", "role": [ { "scheme": "datacite:contributorType", "key": "ContactPerson", "waarde": "invalid", "andereWaarde": "invalid"} ] }"""
-    val creators = s"""{ "creators": [$creatorValid, $creatorInvalidIdElement, $creatorInvalidElementAtRootLevel, $creatorInvalidRole] }"""
+    val creators =
+      s"""{ "creators": [
+         |  {"titles": "Msc", "initials": "H.A.M.", "surname": "Boter", "ids": [ { "scheme": "DAI", "value":  "93313935x"}, {"scheme": "BSN", "value": "1234"} ], "organization" :"DANS"},
+         |  {"titles": "Msc", "initials": "B.A.M.", "surname": "Hoter", "ids": [ { "scheme": "DAI", "value":  "93313935Z"}, {"scheme": "BSN", "value": "1235", "organization": "overheid"} ], "organization" :"DANS"},
+         |  {"titles": "Aartshertog", "FirstName": "jan-willem-hendrik", "surname": "Oranje", "ids": [ { "scheme": "DAI", "value":  "93313935y"}, {"scheme": "BSN", "value": "9999"} ], "organization" :"DANS"},
+         |  {"role": { "scheme": "datacite:contributorType", "key": "ContactPerson", "waarde": "invalid", "andereWaarde": "invalid"} }
+         | ]
+         |}""".stripMargin
     DatasetMetadata(creators) should matchPattern {
-      case Failure(ide: InvalidDocumentException) if ide.getMessage == """invalid DatasetMetadata: don't recognize {"creators":[{"ids":{"organization":"overheid"}},{"FirstName":"jan-willem-hendrik"}]}""" =>
+      case Failure(ide: InvalidDocumentException) if ide.getMessage == """invalid DatasetMetadata: don't recognize {"creators":[{"ids":{"organization":"overheid"}},{"FirstName":"jan-willem-hendrik"},{"role":{"waarde":"invalid","andereWaarde":"invalid"}}]}""" =>
     }
+  }
+
+  "DatasetMetadata.creators" should "report the unrecocginzed value in roles" in {
+    val creators =
+      """{ "creators": [{"role": [{ "scheme": "datacite:contributorType", "key": "ContactPerson""waarde": "invalid", "andereWaarde": "invalid"}]}]}"""
+    DatasetMetadata(creators) shouldBe a[Success[_]] //TODO dit klopt niet, creators[0].role[0].waarde zou fout moeten gaan! Wordt gezien als option wellicht?
   }
 
   "DatasetMetadata.[creators, contributors]" should "only report the part of the creators and contributors that are wrong" in {
     val metaData =
       s"""{
-         |	"contributors": [{
-         |			"organization": "rightsHolder1",
-         |			"role": {
-         |				"scheme": "datacite:contributorType",
-         |				"key": "RightsHolder",
-         |				"value": "rightsholder"
-         |			},
-         |			"ids": [{
-         |				"scheme": "aScheme",
-         |				"key": "aKey",
-         |				"value": "aValue",
-         |				"waarde": "invalidProperty"
-         |			}]
-         |		},
-         |		{
-         |			"titles": "Dr.",
-         |			"initials": "A.S.",
-         |			"insertions": "van",
-         |			"surname": "Terix",
-         |			"role": {
-         |				"scheme": "datacite:contributorType",
-         |				"key": "RightsHolder",
-         |				"value": "rightsholder",
-         |				"otherKey": "placeHolder",
-         |				"otherValue": "placeHolder"
-         |			}
-         |		}
-         |	]
+         |"contributors": [{
+         |  "organization": "rightsHolder1",
+         |  "role": {"scheme": "datacite:contributorType","key": "RightsHolder","value": "rightsholder"},
+         |  "ids": [{"scheme": "aScheme","key": "aKey","value": "aValue","waarde": "invalidProperty"}]
+         |  },
+         |  { "role": {"scheme": "datacite:contributorType","key": "RightsHolder","value": "rightsholder","otherKey": "placeHolder","otherValue": "placeHolder"}
+         |  }
+         | ]
          |}""".stripMargin
 
     //TODO it also complains about the the field "key" in ids along with the invlaid field "waarde"


### PR DESCRIPTION
Fixes EASY-1905 add more tests for DatasetMetadataSpec

#### When applied it will
* add more tests for DatasetMetadataSpec

- [x]  ~~find and repair the part that returns more (valid) parts than needed~~

#### Where should the reviewer @DANS-KNAW/easy start?