### PR TITLE
EASY-2055 generate bag-store.bag-id at submit

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.deposit/Errors.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/Errors.scala
@@ -83,16 +83,11 @@ object Errors extends DebugEnhancedLogging {
       else s"invalid $document: ${ t.getMessage }"
     )
 
-  /**
-   * Note 1: submit area == easy-ingest-flow-inbox
-   * Note 2: Resubmit may follow a reject, be a concurrent submit request or ...
-   * The end user can compare the UUID with the URL of a deposit.
-   * The UUID can help communication with trouble shooters.
-   */
+  /** Note: submit area == easy-ingest-flow-inbox */
   case class AlreadySubmittedException(uuid: UUID)
     extends ServletResponseException(
-      CONFLICT_409,
-      s"The deposit (UUID $uuid) already exists in the submit area. Possibly due to a resubmit."
+      INTERNAL_SERVER_ERROR_500,
+      s"The submit-id (UUID $uuid) already exists in the submit area."
     )
 
   case class InvalidDoiException(uuid: UUID)

--- a/src/main/scala/nl.knaw.dans.easy.deposit/Submitter.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/Submitter.scala
@@ -64,7 +64,7 @@ class Submitter(stagingBaseDir: File,
    * and moving that copy to the submit-to area.
    *
    * @param draftDeposit the deposit object to submit
-   * @return the UUID of the deposit in the ingest-flow-inbox
+   * @return the UUID of the deposit in the submit area (easy-ingest-flow-inbox)
    */
   def submit(draftDeposit: DepositDir): Try[UUID] = {
     val propsFileName = "deposit.properties"

--- a/src/test/scala/nl.knaw.dans.easy.deposit/DepositDirSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/DepositDirSpec.scala
@@ -72,7 +72,6 @@ class DepositDirSpec extends TestSupportFixture with MockFactory {
           "curation.required" -> "yes",
           "identifier.dans-doi.registered" -> "no",
           "creation.timestamp" -> "2018-03-22T20:43:01.000Z",
-          "bag-store.bag-id" -> d.id.toString,
           "state.description" -> "Deposit is open for changes.",
           "identifier.dans-doi.action" -> "create",
         )

--- a/src/test/scala/nl.knaw.dans.easy.deposit/SubmitterSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/SubmitterSpec.scala
@@ -121,7 +121,14 @@ class SubmitterSpec extends TestSupportFixture with MockFactory {
     depositProps.write(depositProps.contentAsString.replace("SUBMITTED", "DRAFT"))
     val bagStoreBagId2 = succeedingSubmit(depositDir)
 
-    // we only have the second bag-store.bag-id
+    // we have both submits
+    bagStoreBagId1 should not be depositDir.id.toString
+    bagStoreBagId2 should not be depositDir.id.toString
+    bagStoreBagId1 should not be bagStoreBagId2
+    (testDir / "submitted" / bagStoreBagId1) should exist
+    (testDir / "submitted" / bagStoreBagId2) should exist
+
+    // we only have the second bag-store.bag-id in the properties
     bagStoreBagId1 should not be bagStoreBagId2
     val lines = depositProps.contentAsString.split("\n")
     lines.count(_.contains("bag-store.bag-id")) shouldBe 1

--- a/src/test/scala/nl.knaw.dans.easy.deposit/SubmitterSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/SubmitterSpec.scala
@@ -104,9 +104,9 @@ class SubmitterSpec extends TestSupportFixture with MockFactory {
     val depositDir = createDeposit(datasetMetadata.copy(messageForDataManager = None))
     addDoiToDepositProperties(getBag(depositDir))
 
-    val bagStoreBagId1 = succeedingSubmit(depositDir)
+    val bagStoreBagId = succeedingSubmit(depositDir)
 
-    (testDir / "submitted" / bagStoreBagId1 / "bag" / "metadata" / "message-from-depositor.txt")
+    (testDir / "submitted" / bagStoreBagId / "bag" / "metadata" / "message-from-depositor.txt")
       .contentAsString shouldBe ""
   }
 

--- a/src/test/scala/nl.knaw.dans.easy.deposit/SubmitterSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/SubmitterSpec.scala
@@ -115,7 +115,7 @@ class SubmitterSpec extends TestSupportFixture with MockFactory {
     val depositDir = createDeposit(datasetMetadata.copy(messageForDataManager = None))
     addDoiToDepositProperties(getBag(depositDir))
 
-    // submit twice
+    // submit twice (skipping ingest-flow or a curator changed the state to rejected)
     val bagStoreBagId1 = succeedingSubmit(depositDir)
     val depositProps = depositDir.bagDir.parent / "deposit.properties"
     depositProps.write(depositProps.contentAsString.replace("SUBMITTED", "DRAFT"))

--- a/src/test/scala/nl.knaw.dans.easy.deposit/SubmitterSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/SubmitterSpec.scala
@@ -122,13 +122,13 @@ class SubmitterSpec extends TestSupportFixture with MockFactory {
     val bagStoreBagId2 = succeedingSubmit(depositDir)
 
     // we only have the second bag-store.bag-id
-    bagStoreBagId1 shouldNot be(bagStoreBagId2)
+    bagStoreBagId1 should not be bagStoreBagId2
     val lines = depositProps.contentAsString.split("\n")
     lines.count(_.contains("bag-store.bag-id")) shouldBe 1
     lines.count(_ == s"bag-store.bag-id = $bagStoreBagId2") shouldBe 1
   }
 
-  private def succeedingSubmit(deposit: DepositDir) = {
+  private def succeedingSubmit(deposit: DepositDir): String = {
     val triedBagStoreBagID = createSubmitter(userGroup).submit(deposit)
     triedBagStoreBagID shouldBe a[Success[_]]
     triedBagStoreBagID


### PR DESCRIPTION
Fixes EASY-2055 

#### When applied it will
* generate a new `bag-store.bag-id` at each (re)submit
* use this ID as directory in ingest-flow-inbox
* [x] don't add a second value to the desposit.properties, but overwrite a previous

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### Related pull requests on github
repo                       | PR                | note
-------------------------- | ----------------- | ----
easy-                      | [PR#](PRlink)     | ..
