### PR TITLE
EASY-2068 don't store uploads twice

### DIFF
--- a/src/main/assembly/dist/cfg/application.properties
+++ b/src/main/assembly/dist/cfg/application.properties
@@ -3,16 +3,19 @@
 #
 # Please, modify the configuration below to match your environment. Also, delete and/or modify
 # this description.
+
 #
 # Port that the HTTP-service listens on.
 #
 daemon.http.port=20190
+
 # https://javaee.github.io/tutorial/servlets011.html
 # threshold: 3145728 = 3MB
 multipart.location=
 multipart.max-file-size=-1
 multipart.max-request-size=-1
 multipart.file-size-threshold=3145728
+
 #
 # Directories for managing the deposits.
 #
@@ -35,8 +38,10 @@ deposits.stage-zips=/var/opt/dans.knaw.nl/tmp/easy-deposit-api/stage-zips
 deposits.drafts=/var/opt/dans.knaw.nl/tmp/easy-deposit-api/drafts
 deposits.stage-for-submit=/var/opt/dans.knaw.nl/tmp/easy-deposit-api/stage-for-submit
 deposits.submit-to=/var/opt/dans.knaw.nl/tmp/easy-ingest-flow-inbox
+
 # The group to assign to the files and directories making up the deposit, before moving it to submit-to.
 deposit.permissions.group=deposits
+
 #
 # Settings for user authentication. The LDAP directory at ldap-url is used to check the credentials
 # of the user by trying to access the entry:
@@ -53,20 +58,24 @@ deposit.permissions.group=deposits
 users.ldap-url=ldap://localhost
 users.ldap-parent-entry=ou=users,ou=easy,dc=dans,dc=knaw,dc=nl
 users.ldap-user-id-attr-name=uid
+
 #
 # Settings required to fetch user data when we no longer have the user's password.
 #
 users.ldap-admin-principal=cn=ldapadmin,dc=dans,dc=knaw,dc=nl
 users.ldap-admin-password=changeme
+
 #
 # Base URL of the easy-pid-generator service to use for minting DOIs.
 #
 pids.generator-service=http://localhost:20140/
+
 #
 # Lifetime for JSON Web Token cookie (named "scentry.auth.default.user") in seconds.
 # (Example: 3600 ( = 60 * 60 = is one hour ).
 #
 auth.cookie.expiresIn=3600
+
 #
 # Symmetric algorithm and secret key to use for JSON Web Token. Algorithm can be any of the values implementing JwtHmacAlgorithm, see fromString in:
 #
@@ -74,6 +83,7 @@ auth.cookie.expiresIn=3600
 #
 auth.jwt.hmac.algorithm=HS256
 auth.jwt.secret.key=changeMe
+
 # will be extended with "/datasets/id/easy-dataset:NNN" or "/mydatasets"
 # depending on presence of "identifier.fedora" in submitted deposit.properties
 easy.home=https://deasy.dans.knaw.nl/ui

--- a/src/main/assembly/dist/cfg/application.properties
+++ b/src/main/assembly/dist/cfg/application.properties
@@ -3,19 +3,16 @@
 #
 # Please, modify the configuration below to match your environment. Also, delete and/or modify
 # this description.
-
 #
 # Port that the HTTP-service listens on.
 #
 daemon.http.port=20190
-
 # https://javaee.github.io/tutorial/servlets011.html
 # threshold: 3145728 = 3MB
 multipart.location=
 multipart.max-file-size=-1
 multipart.max-request-size=-1
 multipart.file-size-threshold=3145728
-
 #
 # Directories for managing the deposits.
 #
@@ -38,10 +35,8 @@ deposits.stage-zips=/var/opt/dans.knaw.nl/tmp/easy-deposit-api/stage-zips
 deposits.drafts=/var/opt/dans.knaw.nl/tmp/easy-deposit-api/drafts
 deposits.stage-for-submit=/var/opt/dans.knaw.nl/tmp/easy-deposit-api/stage-for-submit
 deposits.submit-to=/var/opt/dans.knaw.nl/tmp/easy-ingest-flow-inbox
-
 # The group to assign to the files and directories making up the deposit, before moving it to submit-to.
 deposit.permissions.group=deposits
-
 #
 # Settings for user authentication. The LDAP directory at ldap-url is used to check the credentials
 # of the user by trying to access the entry:
@@ -58,24 +53,20 @@ deposit.permissions.group=deposits
 users.ldap-url=ldap://localhost
 users.ldap-parent-entry=ou=users,ou=easy,dc=dans,dc=knaw,dc=nl
 users.ldap-user-id-attr-name=uid
-
 #
 # Settings required to fetch user data when we no longer have the user's password.
 #
 users.ldap-admin-principal=cn=ldapadmin,dc=dans,dc=knaw,dc=nl
 users.ldap-admin-password=changeme
-
 #
 # Base URL of the easy-pid-generator service to use for minting DOIs.
 #
 pids.generator-service=http://localhost:20140/
-
 #
 # Lifetime for JSON Web Token cookie (named "scentry.auth.default.user") in seconds.
 # (Example: 3600 ( = 60 * 60 = is one hour ).
 #
 auth.cookie.expiresIn=3600
-
 #
 # Symmetric algorithm and secret key to use for JSON Web Token. Algorithm can be any of the values implementing JwtHmacAlgorithm, see fromString in:
 #
@@ -83,7 +74,6 @@ auth.cookie.expiresIn=3600
 #
 auth.jwt.hmac.algorithm=HS256
 auth.jwt.secret.key=changeMe
-
 # will be extended with "/datasets/id/easy-dataset:NNN" or "/mydatasets"
 # depending on presence of "identifier.fedora" in submitted deposit.properties
 easy.home=https://deasy.dans.knaw.nl/ui

--- a/src/main/assembly/dist/cfg/application.properties
+++ b/src/main/assembly/dist/cfg/application.properties
@@ -27,8 +27,9 @@ multipart.file-size-threshold=3145728
 #                     of a submit request.  As moving is an atomic action this prevents further
 #                     processing of incomplete deposits.
 #
-# N.B. stage-zips and drafts must be located on the same partition in order to support atomic moving.
-# The same holds for stage-for-submit and submit-to.
+# N.B. multipart.location, stage-zips and drafts must all be located on the same partition
+# in order to support atomic moving.
+# The same holds for the couple stage-for-submit and submit-to.
 #
 # Note that the stage-* directories only have temporary content, so the service should clear them
 # automatically on completion of a request.

--- a/src/main/scala/nl.knaw.dans.easy.deposit/EasyDepositApiApp.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/EasyDepositApiApp.scala
@@ -98,7 +98,7 @@ class EasyDepositApiApp(configuration: Configuration) extends DebugEnhancedLoggi
   )
 
   // possible trailing slash is dropped
-  private val easyHome: URL = new URL(configuration.properties.getString("easy.home").replaceAll("/?$",""))
+  private val easyHome: URL = new URL(configuration.properties.getString("easy.home").replaceAll("/?$", ""))
 
   @throws[ConfigurationException]("when no existing readable directory is configured")
   private def getConfiguredDirectory(key: String): File = {

--- a/src/main/scala/nl.knaw.dans.easy.deposit/EasyDepositApiApp.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/EasyDepositApiApp.scala
@@ -77,12 +77,12 @@ class EasyDepositApiApp(configuration: Configuration) extends DebugEnhancedLoggi
   private val draftBase: File = getConfiguredDirectory("deposits.drafts")
   private val submitBase: File = getConfiguredDirectory("deposits.submit-to")
   private val uploadProvider: FileSystemProvider = uploadStagingDir.fileSystem.provider()
-  StartupValidation.sameMounts(uploadProvider, uploadStagingDir, draftBase)
+  StartupValidation.allowsAtomicMove(uploadProvider, srcDir = uploadStagingDir, targetDir = draftBase)
 
   val multipartConfig: MultipartConfig = {
     val multipartLocation = getConfiguredDirectory("multipart.location")
     logger.info(s"Uploads are received at multipart.location: $multipartLocation")
-    StartupValidation.sameMounts(uploadProvider, multipartLocation, uploadStagingDir)
+    StartupValidation.allowsAtomicMove(uploadProvider, srcDir = multipartLocation, targetDir = uploadStagingDir)
     MultipartConfig(
       location = Some(multipartLocation.toString()),
       maxFileSize = Option(properties.getLong("multipart.max-file-size", null)),

--- a/src/main/scala/nl.knaw.dans.easy.deposit/StartupValidation.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/StartupValidation.scala
@@ -27,7 +27,7 @@ import scala.util.Try
 object StartupValidation {
 
   @throws[IOException]("when files can not be moved atomically from src to target")
-  def sameMounts(srcProvider: FileSystemProvider, srcDir: File, targetDir: File): Unit = {
+  def allowsAtomicMove(srcProvider: FileSystemProvider, srcDir: File, targetDir: File): Unit = {
     val fileName = "same-mount-check"
     val srcFile = srcDir / fileName
     val targetFile = targetDir / fileName

--- a/src/main/scala/nl.knaw.dans.easy.deposit/StartupValidation.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/StartupValidation.scala
@@ -27,15 +27,15 @@ import scala.util.Try
 object StartupValidation {
 
   @throws[IOException]("when files can not be moved atomically from src to target")
-  def sameMounts(srcProvider: FileSystemProvider, src: File, target: File): Unit = {
+  def sameMounts(srcProvider: FileSystemProvider, srcDir: File, targetDir: File): Unit = {
     val fileName = "same-mount-check"
-    val tempFile = src / fileName
-    val movedTempFile = target / fileName
+    val srcFile = srcDir / fileName
+    val targetFile = targetDir / fileName
     Try {
-      if (tempFile.notExists) tempFile.createFile()
-      srcProvider.move(tempFile.path, movedTempFile.path, StandardCopyOption.ATOMIC_MOVE)
-      movedTempFile.delete()
-    }.doIfFailure { case _ => tempFile.delete() }
+      if (srcFile.notExists) srcFile.createFile()
+      srcProvider.move(srcFile.path, targetFile.path, StandardCopyOption.ATOMIC_MOVE)
+      targetFile.delete()
+    }.doIfFailure { case _ => srcFile.delete() }
       .unsafeGetOrThrow
   }
 }

--- a/src/main/scala/nl.knaw.dans.easy.deposit/Submitter.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/Submitter.scala
@@ -58,7 +58,7 @@ class Submitter(stagingBaseDir: File,
     }
   }
   val srcProvider: FileSystemProvider = stagingBaseDir.fileSystem.provider()
-  StartupValidation.sameMounts(srcProvider, stagingBaseDir, submitToBaseDir)
+  StartupValidation.allowsAtomicMove(srcProvider, srcDir = stagingBaseDir, targetDir = submitToBaseDir)
 
   /**
    * Submits `depositDir` by writing the file metadata, updating the bag checksums, staging a copy

--- a/src/main/scala/nl.knaw.dans.easy.deposit/package.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/package.scala
@@ -44,10 +44,10 @@ package object deposit {
       bag.addTagFile(content.inputStream, Paths.get(s"metadata/$target"))
     }
   }
-  implicit class FailFastStream[T](val stream: Stream[Try[T]]) extends AnyVal {
+  implicit class RichTries[T](val tries: TraversableOnce[Try[T]]) extends AnyVal {
     // TODO candidate for nl.knaw.dans.lib.error ?
     def failFastOr[R](onSuccess: => Try[R]): Try[R] = {
-      stream
+      tries
         .collectFirst { case Failure(e) => Failure(e) }
         .getOrElse(onSuccess)
     }

--- a/src/main/scala/nl.knaw.dans.easy.deposit/servlets/DepositServlet.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/servlets/DepositServlet.scala
@@ -157,7 +157,7 @@ class DepositServlet(app: EasyDepositApiApp)
         _ <- managedStagingDir.apply(stagingDir =>
           maybeZipInputStream
             .map(_.unzipPlainEntriesTo(stagingDir))
-            .getOrElse(fileItems.copyPlainItemsTo(stagingDir))
+            .getOrElse(app.multipartConfig.moveNonZips(fileItems, stagingDir))
             .flatMap(_ => stagedFilesTarget.moveAllFrom(stagingDir))
         )
       } yield Created()

--- a/src/main/scala/nl.knaw.dans.easy.deposit/servlets/DepositServlet.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/servlets/DepositServlet.scala
@@ -152,10 +152,10 @@ class DepositServlet(app: EasyDepositApiApp)
         path <- getPath
         _ <- isMultipart
         fileItems = fileMultiParams.valuesIterator.flatten.buffered
-        maybeZipInputStream <- fileItems.nextAsZipIfOnlyOne
+        maybeManagedZipInputStream <- fileItems.nextAsZipIfOnlyOne
         (managedStagingDir, stagedFilesTarget) <- app.stageFiles(user.id, uuid, path)
         _ <- managedStagingDir.apply(stagingDir =>
-          maybeZipInputStream
+          maybeManagedZipInputStream
             .map(_.unzipPlainEntriesTo(stagingDir))
             .getOrElse(app.multipartConfig.moveNonZips(fileItems, stagingDir))
             .flatMap(_ => stagedFilesTarget.moveAllFrom(stagingDir))

--- a/src/main/scala/nl.knaw.dans.easy.deposit/servlets/package.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/servlets/package.scala
@@ -107,7 +107,7 @@ package object servlets extends DebugEnhancedLogging {
 
   implicit class RichMultipartConfig(config: MultipartConfig) {
     def moveNonZips(srcItems: Iterator[FileItem], targetDir: File): Try[Unit] = {
-      srcItems.toStream
+      srcItems
         .map(moveIfNonZip(_, targetDir))
         .failFastOr(Success(()))
     }

--- a/src/main/scala/nl.knaw.dans.easy.deposit/servlets/package.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/servlets/package.scala
@@ -119,9 +119,12 @@ package object servlets extends DebugEnhancedLogging {
       else Try {
         val f = UUID.randomUUID().toString
         val location = File(config.location.getOrElse(throw ConfigurationException("multipart.location is missing")))
-        // Depending on the configuration, the upload is kept in memory or saved to disk with an unknown file name.
-        // The following call tries to move the file to a known name, or writes it if is kept in memory.
+
+        // Try to move the (big) uploaded file to a known name,
+        // otherwise write the in-memory content, depending on the MultipartConfig values of the servlet.
         srcItem.part.write(f)
+
+        // now we can move the upload to the location we really want
         (location / f).moveTo(targetDir / srcItem.name, overwrite = true)
       }
     }

--- a/src/main/scala/nl.knaw.dans.easy.deposit/servlets/package.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/servlets/package.scala
@@ -119,7 +119,9 @@ package object servlets extends DebugEnhancedLogging {
       else Try {
         val f = UUID.randomUUID().toString
         val location = File(config.location.getOrElse(throw ConfigurationException("multipart.location is missing")))
-        srcItem.part.write(f) // for big files in practice a rename to a known file in location
+        // Depending on the configuration, the upload is kept in memory or saved to disk with an unknown file name.
+        // The following call tries to move the file to a known name, or writes it if is kept in memory.
+        srcItem.part.write(f)
         (location / f).moveTo(targetDir / srcItem.name, overwrite = true)
       }
     }

--- a/src/test/resources/manual-test/upload.html
+++ b/src/test/resources/manual-test/upload.html
@@ -7,10 +7,12 @@
                document.getElementById('path').value
             return true
         }
+
     </script>
     <style>
         label {width: 50px}
         input[type="text"] {width: 300px}
+
     </style>
 </head>
 <body>

--- a/src/test/resources/manual-test/upload.html
+++ b/src/test/resources/manual-test/upload.html
@@ -15,12 +15,12 @@
 </head>
 <body>
 <h1>Manual test for upload.</h1>
-<a href="login.html">login</a>
 <form id="form"
       action="http://deasy.dans.knaw.nl:20190/deposit/UUID/file/some.png"
       method="post"
       enctype="multipart/form-data"
 >
+    <p>First <a href="http://deasy.dans.knaw.nl/deposit/login">login</a></p>
     <label for="uuid">UUID</label><input id="uuid" type="text" onchange="setAction(this)">
     <br>
     <label for="path">path</label><input id="path" type="text" onchange="setAction(this)">

--- a/src/test/scala/nl.knaw.dans.easy.deposit/TestSupportFixture.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/TestSupportFixture.scala
@@ -86,6 +86,7 @@ trait TestSupportFixture extends FlatSpec with Matchers with Inside with BeforeA
       addProperty("users.ldap-admin-principal", "-")
       addProperty("users.ldap-admin-password", "-")
       addProperty("users.ldap-user-id-attr-name", "-")
+      addProperty("multipart.location", (testDir / "multipart").createDirectories().toString())
       addProperty("multipart.file-size-threshold", "3145728") // 3MB
       addProperty("easy.home", "https://easy.dans.knaw.nl/ui")
     })

--- a/src/test/scala/nl.knaw.dans.easy.deposit/servlets/DepositServletErrorSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/servlets/DepositServletErrorSpec.scala
@@ -43,15 +43,14 @@ class DepositServletErrorSpec extends TestSupportFixture with ServletFixture wit
 
   "constructor" should "fail with not existing multipart location" in {
     val props = minimalAppConfig.properties
-    props.addProperty("multipart.location", "notExistingLocation")
-    the[ConfigurationException] thrownBy new DepositServlet(new EasyDepositApiApp(new Configuration("", props))) should
-      have message s"Configuration error: ${ File("notExistingLocation").path.toAbsolutePath } not found/readable/writable or not a directory"
+    props.setProperty("multipart.location", "notExistingLocation")
+    the[ConfigurationException] thrownBy new EasyDepositApiApp(new Configuration("", props)) should
+      have message s"Configuration error: Configured directory 'multipart.location' does not exist: ${ File("notExistingLocation").path.toAbsolutePath }"
   }
 
   it should "fail with empty threshold value" in {
     val props = minimalAppConfig.properties
-    props.clearProperty("multipart.file-size-threshold")
-    props.addProperty("multipart.file-size-threshold", "")
+    props.setProperty("multipart.file-size-threshold", "")
     the[ConversionException] thrownBy new DepositServlet(new EasyDepositApiApp(new Configuration("", props))) should
       have message s"'multipart.file-size-threshold' doesn't map to an Integer object"
   }

--- a/src/test/scala/nl.knaw.dans.easy.deposit/servlets/DepositServletErrorSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/servlets/DepositServletErrorSpec.scala
@@ -22,7 +22,7 @@ import nl.knaw.dans.easy.deposit.Errors.{ ConfigurationException, CorruptDeposit
 import nl.knaw.dans.easy.deposit.authentication.AuthUser.UserState
 import nl.knaw.dans.easy.deposit.authentication.{ AuthUser, AuthenticationMocker, AuthenticationProvider }
 import nl.knaw.dans.easy.deposit.{ EasyDepositApiApp, _ }
-import org.apache.commons.configuration.{ ConversionException, PropertiesConfiguration }
+import org.apache.commons.configuration.ConversionException
 import org.eclipse.jetty.http.HttpStatus._
 import org.scalatra.auth.Scentry
 import org.scalatra.test.scalatest.ScalatraSuite

--- a/src/test/scala/nl.knaw.dans.easy.deposit/servlets/RichFileItemsSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/servlets/RichFileItemsSpec.scala
@@ -90,36 +90,6 @@ class RichFileItemsSpec extends TestSupportFixture with MockFactory {
     }
   }
 
-  "copyPlainItemsTo" should "copy the plain item between form fields without selected files" in {
-    val stagingDir = (testDir / "staging").createDirectories()
-    val fileItems = Iterator(
-      mockFileItem(""),
-      mockFileItem("some.txt"),
-      mockFileItem(""),
-      mockFileItem("more.txt"),
-      mockFileItem(""),
-    ).buffered
-    fileItems.nextAsZipIfOnlyOne shouldBe Success(None)
-    fileItems.copyPlainItemsTo(stagingDir) shouldBe Success(())
-    stagingDir.walk().map(_.name).toList should
-      contain theSameElementsAs List("staging", "some.txt", "more.txt")
-  }
-
-  it should "refuse to copy a zip as plain item" in {
-    val stagingDir = (testDir / "staging").createDirectories()
-    val fileItems = Iterator(
-      mockFileItem("some.txt"),
-      mockFileItem("other.zip"),
-    ).buffered
-    fileItems.nextAsZipIfOnlyOne shouldBe Success(None)
-    fileItems.copyPlainItemsTo(stagingDir) should matchPattern {
-      case Failure(e: ZipMustBeOnlyFileException) if e.getMessage ==
-        "A multipart/form-data message contained a ZIP part [other.zip] but also other parts." =>
-    }
-    stagingDir.walk().map(_.name).toList should
-      contain theSameElementsAs List("staging", "some.txt")
-  }
-
   private def mockFileItem(fileName: String, contentType: String = null) = {
     val mocked = mock[Part]
     (() => mocked.getSize) expects() returning 20 anyNumberOfTimes()

--- a/src/test/scala/nl.knaw.dans.easy.deposit/servlets/RichFileItemsSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/servlets/RichFileItemsSpec.scala
@@ -97,7 +97,6 @@ class RichFileItemsSpec extends TestSupportFixture with MockFactory {
     mocked.getHeader _ expects "content-disposition" returning "filename=" + fileName anyNumberOfTimes()
     mocked.getHeader _ expects "content-type" returning contentType anyNumberOfTimes()
     (() => mocked.getContentType) expects() returning contentType anyNumberOfTimes()
-    (() => mocked.getInputStream) expects() returning new ByteArrayInputStream("Lorem ipsum est".getBytes(StandardCharsets.UTF_8)) anyNumberOfTimes()
     FileItem(mocked)
   }
 }


### PR DESCRIPTION
Fixes part of EASY-2068 don't store uploads twice

#### When applied it will
* store files initially as `/var/opt/dans.knaw.nl/tmp/easy-deposit-api/multipart-location/multipartSOMETHING`
* once all files are uploaded (the status bar reaches 100%)
  * deposit-api logs the request
  * files will be renamed within `multipart-location` and moved to `stage-zips`
* the sha will be calculated and the files moved to the draft bag
  while busy for too long the ui can get a status 502
* deposit-api logs the reseponse

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

* uploading multiple files can be tested with `src/test/resources/manual-test/upload.html` for a single file you can use http://deasy.dans.knaw.nl/deposit
* monitor logging of deposit-api
* monitor files and space availabel with something like
   ```
  cd /var/opt/dans.knaw.nl/tmp/easy-deposit-api/drafts/user001/d5cf201f-e742-4e37-83f7-bd49df650a6b/bag
  watch "ls -la /var/opt/dans.knaw.nl/tmp/easy-deposit-api/* metadata data ;df -h /var"
  ```
* [x] check for sufficient filerights, scalatra might created them with less right than the copies used to be created

#### Related pull requests on github
repo                       | PR                | note
-------------------------- | ----------------- | ----
easy-                      | [PR#](PRlink)     | ..
