### PR TITLE
EASY-2079: Deposit api does not write message-from-depositor and agreements.xml to correct Dir

### DIFF
--- a/src/test/scala/nl.knaw.dans.easy.deposit/SubmitterSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/SubmitterSpec.scala
@@ -86,8 +86,8 @@ class SubmitterSpec extends TestSupportFixture with MockFactory {
     (bagDir / "metadata" / "dataset.json").size shouldBe mdOldSize
     // no DOI added
     val submittedBagDir = testDir / "submitted" / bagStoreBagID / "bag"
-    (submittedBagDir / "metadata" / "message-from-depositor.txt").contentAsString shouldBe customMessage
-    (submittedBagDir / "metadata" / "agreements.xml").lineIterator.next() shouldBe prologue
+    (submittedBagDir / "metadata" / "depositor-info" / "message-from-depositor.txt").contentAsString shouldBe customMessage
+    (submittedBagDir / "metadata" / "depositor-info" / "agreements.xml").lineIterator.next() shouldBe prologue
     (submittedBagDir / "metadata" / "dataset.xml").lineIterator.next() shouldBe prologue
     (submittedBagDir / "data").children.size shouldBe (bagDir / "data").children.size
     (submittedBagDir / "tagmanifest-sha1.txt").lines.size shouldBe 7 // tag files including metadata/*
@@ -107,7 +107,7 @@ class SubmitterSpec extends TestSupportFixture with MockFactory {
 
     val bagStoreBagId = succeedingSubmit(depositDir)
 
-    (testDir / "submitted" / bagStoreBagId / "bag" / "metadata" / "message-from-depositor.txt")
+    (testDir / "submitted" / bagStoreBagId / "bag" / "metadata" / "depositor-info" / "message-from-depositor.txt")
       .contentAsString shouldBe ""
   }
 

--- a/src/test/scala/nl.knaw.dans.easy.deposit/servlets/IntegrationSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/servlets/IntegrationSpec.scala
@@ -359,8 +359,8 @@ class IntegrationSpec extends TestSupportFixture with ServletFixture with Scalat
       val updatesProps = new PropertiesConfiguration((depositDir / "deposit.properties").toJava)
       updatesProps.containsKey("bag-store.bag-id") shouldBe true
 
-      // +3 is difference in number of files in metadata directory: json versus xml's
-      (depositDir.walk().size + 3) shouldBe
+      // +4 is the difference in the number of files (and directories) in the metadata directory: json versus xml's
+      (depositDir.walk().size + 4) shouldBe
         (testDir / "easy-ingest-flow-inbox" / updatesProps.getString("bag-store.bag-id")).walk().size
     }
     uuid


### PR DESCRIPTION
Fixes EASY-2079: Deposit api does not write message-from-depositor and agreements.xml to correct Dir

#### Where should the reviewer @DANS-KNAW/easy start?

#### Related pull requests on github
repo                       | PR                | note
-------------------------- | ----------------- | ----
easy-stage-dataset                      | [PR#138](https://github.com/DANS-KNAW/easy-stage-dataset/pull/138)     | ..