### PR TITLE
EASY-2109 skip corrupt deposits

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.deposit/DepositDir.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/DepositDir.scala
@@ -176,10 +176,11 @@ object DepositDir {
     if (userDir.exists)
       userDir
         .list
-        .filter(_.isDirectory)
+        .withFilter(_.isDirectory)
         .map(deposit => Try {
           DepositDir(draftDir, user, UUID.fromString(deposit.name))
         }.recoverWith { case t: Throwable => Failure(CorruptDepositException(user, deposit.name, t)) })
+        .withFilter(_.isSuccess)// CorruptDepositException logged itself
         .toSeq
         .collectResults
     else Try { Seq.empty }

--- a/src/main/scala/nl.knaw.dans.easy.deposit/DepositDir.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/DepositDir.scala
@@ -26,7 +26,6 @@ import nl.knaw.dans.easy.deposit.Errors._
 import nl.knaw.dans.easy.deposit.PidRequesterComponent.{ PidRequester, PidType }
 import nl.knaw.dans.easy.deposit.docs.JsonUtil.toJson
 import nl.knaw.dans.easy.deposit.docs._
-import nl.knaw.dans.lib.error._
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
 import org.apache.commons.configuration.PropertiesConfiguration
 import org.joda.time.DateTime
@@ -171,7 +170,7 @@ object DepositDir {
    * @param user     the user name
    * @return a list of [[DepositDir]] objects
    */
-  def list(draftDir: File, user: String): Try[Seq[DepositDir]] = {
+  def list(draftDir: File, user: String): Seq[DepositDir] = {
     val userDir = draftDir / user
     if (userDir.exists)
       userDir
@@ -180,10 +179,9 @@ object DepositDir {
         .map(deposit => Try {
           DepositDir(draftDir, user, UUID.fromString(deposit.name))
         }.recoverWith { case t: Throwable => Failure(CorruptDepositException(user, deposit.name, t)) })
-        .withFilter(_.isSuccess)// CorruptDepositException logged itself
+        .collect { case Success(deposit: DepositDir) => deposit }
         .toSeq
-        .collectResults
-    else Try { Seq.empty }
+    else Seq.empty
   }
 
   /**

--- a/src/main/scala/nl.knaw.dans.easy.deposit/EasyDepositApiApp.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/EasyDepositApiApp.scala
@@ -139,8 +139,8 @@ class EasyDepositApiApp(configuration: Configuration) extends DebugEnhancedLoggi
    */
   def getDeposits(user: String): Try[Seq[DepositInfo]] = {
     implicit val timestampOrdering: Ordering[DateTime] = Ordering.fromLessThan[DateTime](_ isBefore _)
+    val deposits = DepositDir.list(draftBase, user)
     for {
-      deposits <- DepositDir.list(draftBase, user)
       infos <- deposits.map(_.getDepositInfo(submitBase, easyHome)).collectResults
       sortedInfos = infos.sortBy(deposit => (deposit.state, deposit.date))
     } yield sortedInfos

--- a/src/test/scala/nl.knaw.dans.easy.deposit/DepositDirSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/DepositDirSpec.scala
@@ -80,28 +80,17 @@ class DepositDirSpec extends TestSupportFixture with MockFactory {
 
   "list" should """show no deposits of "user001" user""" in {
     val tryDeposits = DepositDir.list(draftsDir, "user001")
-    tryDeposits shouldBe a[Success[_]]
-    inside(tryDeposits) {
-      case Success(list) => list shouldBe empty
-    }
+    tryDeposits shouldBe empty
   }
 
   it should """show one deposit of "user001" user""" in {
     DepositDir.create(draftsDir, "user001")
-    val tryDeposits = DepositDir.list(draftsDir, "user001")
-    tryDeposits shouldBe a[Success[_]]
-    inside(tryDeposits) {
-      case Success(list) => list should have length 1
-    }
+    DepositDir.list(draftsDir, "user001") should have length 1
   }
 
   it should """show more than two deposits of "user001" user""" in {
     for (_ <- 1 to 3) DepositDir.create(draftsDir, "user001")
-    val tryDeposits = DepositDir.list(draftsDir, "user001")
-    tryDeposits shouldBe a[Success[_]]
-    inside(tryDeposits) {
-      case Success(list) => list should have length 3
-    }
+    DepositDir.list(draftsDir, "user001") should have length 3
   }
 
   "get" should """return a specified deposit""" in {

--- a/src/test/scala/nl.knaw.dans.easy.deposit/DepositDirSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/DepositDirSpec.scala
@@ -79,8 +79,7 @@ class DepositDirSpec extends TestSupportFixture with MockFactory {
   }
 
   "list" should """show no deposits of "user001" user""" in {
-    val tryDeposits = DepositDir.list(draftsDir, "user001")
-    tryDeposits shouldBe empty
+    DepositDir.list(draftsDir, "user001") shouldBe empty
   }
 
   it should """show one deposit of "user001" user""" in {


### PR DESCRIPTION
Fixes EASY-2109 skip corrupt deposits

#### When applied it will
* Won't fail when one of the deposit directories is corrupt
* 
* 

#### Where should the reviewer @DANS-KNAW/easy start?

* add a directory between the drafts of a user that is not a UUID,
* try to show the list of deposits
* it will no longer fail, the problematic directory is logged

#### How should this be manually tested?

#### Related pull requests on github
repo                       | PR                | note
-------------------------- | ----------------- | ----
easy-                      | [PR#](PRlink)     | ..
