### PR TITLE
EASY-2116: add language of files to DDM

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.deposit/docs/DDM.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/docs/DDM.scala
@@ -69,7 +69,7 @@ object DDM extends SchemedXml with DebugEnhancedLogging {
         { dm.spatialPoints.withNonEmpty.map(point => <dcx-gml:spatial srsName={ point.srsName }>{ details(point) }</dcx-gml:spatial>) }
         { dm.spatialBoxes.withNonEmpty.map(point => <dcx-gml:spatial>{ details(point) }</dcx-gml:spatial>) }
         { dm.license.withNonEmpty.map(src => <dcterms:license xsi:type={ src.scheme.nonBlankOrNull }>{ src.value.nonBlankOrEmpty }</dcterms:license>) }
-        { dm.languagesOfFiles.withNonEmpty.map(lang => <dcterms:language xsi:type ={ lang.scheme.nonBlankOrNull  }>{ lang }</dcterms:language>)}
+        { dm.languagesOfFiles.withNonEmpty.flatMap(lang => lang.value.map(value => <dcterms:language xsi:type ={ lang.scheme.nonBlankOrNull  }>{ value }</dcterms:language>)) }
       </ddm:dcmiMetadata>
     </ddm:DDM>
   }.recoverWith {

--- a/src/main/scala/nl.knaw.dans.easy.deposit/docs/DDM.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/docs/DDM.scala
@@ -76,13 +76,13 @@ object DDM extends SchemedXml with DebugEnhancedLogging {
     case e: IllegalArgumentException => Failure(InvalidDocumentException("DatasetMetadata", e))
   }
 
-  private def details(point: SpatialPoint) = {
+  private def details(point: SpatialPoint): Elem = {
     <Point xmlns="http://www.opengis.net/gml">
         <pos>{ point.pos }</pos>
     </Point>
   }
 
-  private def details(box: SpatialBox) = {
+  private def details(box: SpatialBox): Elem = {
     <boundedBy xmlns="http://www.opengis.net/gml">
         <Envelope srsName={ box.srsName }>
             <lowerCorner>{ box.lower }</lowerCorner>

--- a/src/main/scala/nl.knaw.dans.easy.deposit/docs/DDM.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/docs/DDM.scala
@@ -69,6 +69,7 @@ object DDM extends SchemedXml with DebugEnhancedLogging {
         { dm.spatialPoints.withNonEmpty.map(point => <dcx-gml:spatial srsName={ point.srsName }>{ details(point) }</dcx-gml:spatial>) }
         { dm.spatialBoxes.withNonEmpty.map(point => <dcx-gml:spatial>{ details(point) }</dcx-gml:spatial>) }
         { dm.license.withNonEmpty.map(src => <dcterms:license xsi:type={ src.scheme.nonBlankOrNull }>{ src.value.nonBlankOrEmpty }</dcterms:license>) }
+        { dm.languagesOfFiles.withNonEmpty.map(lang => <dcterms:language xsi:type ={ lang.scheme.nonBlankOrNull  }>{ lang }</dcterms:language>)}
       </ddm:dcmiMetadata>
     </ddm:DDM>
   }.recoverWith {

--- a/src/test/resources/manual-test/datasetmetadata-from-ui-all.json
+++ b/src/test/resources/manual-test/datasetmetadata-from-ui-all.json
@@ -166,7 +166,7 @@
     {
       "scheme": "dcterms:ISO639-2",
       "key": "nld",
-      "value": "Dutch"
+      "value": "nld"
     },
     {
       "value": "Flakkees"

--- a/src/test/resources/manual-test/datasetmetadata-from-ui-all.json
+++ b/src/test/resources/manual-test/datasetmetadata-from-ui-all.json
@@ -166,7 +166,7 @@
     {
       "scheme": "dcterms:ISO639-2",
       "key": "nld",
-      "value": "DUTCH"
+      "value": "Dutch"
     },
     {
       "value": "Flakkees"

--- a/src/test/resources/manual-test/datasetmetadata-from-ui-all.json
+++ b/src/test/resources/manual-test/datasetmetadata-from-ui-all.json
@@ -166,7 +166,7 @@
     {
       "scheme": "dcterms:ISO639-2",
       "key": "nld",
-      "value": "nld"
+      "value": "DUTCH"
     },
     {
       "value": "Flakkees"

--- a/src/test/resources/manual-test/datasetmetadata.json
+++ b/src/test/resources/manual-test/datasetmetadata.json
@@ -90,9 +90,9 @@
   ],
   "languagesOfFiles": [
     {
-      "scheme": "string",
-      "value": "string",
-      "key": "string"
+      "scheme": "dcterms:ISO639-2",
+      "value": "nld",
+      "key": "Dutch"
     }
   ],
   "dates": [

--- a/src/test/scala/nl.knaw.dans.easy.deposit/docs/DDMSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/docs/DDMSpec.scala
@@ -538,7 +538,7 @@ class DDMSpec extends TestSupportFixture with DdmBehavior {
         </dcx-gml:spatial>
         <dcterms:license xsi:type="dcterms:URI">http://creativecommons.org/publicdomain/zero/1.0</dcterms:license>
         <dcterms:language xsi:type="dcterms:ISO639-2">English</dcterms:language>
-        <dcterms:language xsi:type="dcterms:ISO639-2">Dutch</dcterms:language>
+        <dcterms:language xsi:type="dcterms:ISO639-2">nld</dcterms:language>
         <dcterms:language>Flakkees</dcterms:language>
         <dcterms:language>Goerees</dcterms:language>
       </ddm:dcmiMetadata>

--- a/src/test/scala/nl.knaw.dans.easy.deposit/docs/DDMSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/docs/DDMSpec.scala
@@ -537,7 +537,7 @@ class DDMSpec extends TestSupportFixture with DdmBehavior {
           </boundedBy>
         </dcx-gml:spatial>
         <dcterms:license xsi:type="dcterms:URI">http://creativecommons.org/publicdomain/zero/1.0</dcterms:license>
-        <dcterms:language xsi:type="dcterms:ISO639-2">English</dcterms:language>
+        <dcterms:language xsi:type="dcterms:ISO639-2">eng</dcterms:language>
         <dcterms:language xsi:type="dcterms:ISO639-2">nld</dcterms:language>
         <dcterms:language>Flakkees</dcterms:language>
         <dcterms:language>Goerees</dcterms:language>
@@ -556,7 +556,6 @@ class DDMSpec extends TestSupportFixture with DdmBehavior {
   private def parseTestResource(file: String) = Try {
     getManualTestResource(file)
   }.flatMap(DatasetMetadata(_))
-
 }
 
 trait DdmBehavior {

--- a/src/test/scala/nl.knaw.dans.easy.deposit/docs/DDMSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/docs/DDMSpec.scala
@@ -537,6 +537,10 @@ class DDMSpec extends TestSupportFixture with DdmBehavior {
           </boundedBy>
         </dcx-gml:spatial>
         <dcterms:license xsi:type="dcterms:URI">http://creativecommons.org/publicdomain/zero/1.0</dcterms:license>
+        <dcterms:language xsi:type="dcterms:ISO639-2">English</dcterms:language>
+        <dcterms:language xsi:type="dcterms:ISO639-2">Dutch</dcterms:language>
+        <dcterms:language>Flakkees</dcterms:language>
+        <dcterms:language>Goerees</dcterms:language>
       </ddm:dcmiMetadata>
   )
 

--- a/src/test/scala/nl.knaw.dans.easy.deposit/docs/DatasetMetadataSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/docs/DatasetMetadataSpec.scala
@@ -164,7 +164,7 @@ class DatasetMetadataSpec extends TestSupportFixture {
 
   "DatasetMetadata.*" should "only report the item in the list that are invalid" in {
     val alteredData = createCorruptMetadataJsonString(""""scheme": "string"""", """"invalid": "property"""")
-    expectErrorMessage(alteredData,"""invalid DatasetMetadata: don't recognize {"languageOfDescription":{"invalid":"property"},"audiences":{"invalid":"property"},"subjects":{"invalid":"property"},"languagesOfFiles":{"invalid":"property"},"temporalCoverages":{"invalid":"property"}}""")
+    expectErrorMessage(alteredData,"""invalid DatasetMetadata: don't recognize {"languageOfDescription":{"invalid":"property"},"audiences":{"invalid":"property"},"subjects":{"invalid":"property"},"temporalCoverages":{"invalid":"property"}}""")
   }
 
   "DatasetMetadata.spatialBoxes" should "only report spatial points of the box that are invalid" in {


### PR DESCRIPTION
Fixes EASY-2116: add language of files to DDM

#### When applied it will
*  add language of files to DDM

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### See also:
* https://github.com/DANS-KNAW/easy-ddm/pull/34