### PR TITLE
EASY-2152 : upgrade jetty with fix for cleanup of multipart on aborted upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,5 +8,3 @@ Welcome
 -------
 
 Welcome to the `easy-deposit-api` project. See the [GitHub pages](https://dans-knaw.github.io/easy-deposit-api/) for the manual and API documentation.
-
-

--- a/pom.xml
+++ b/pom.xml
@@ -79,10 +79,12 @@
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-server</artifactId>
+            <version>9.4.19.v20190610</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-servlet</artifactId>
+            <version>9.4.19.v20190610</version>
         </dependency>
         <dependency>
             <groupId>org.scalatra</groupId>

--- a/src/test/scala/nl.knaw.dans.easy.deposit/authentication/SessionSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/authentication/SessionSpec.scala
@@ -144,8 +144,8 @@ class SessionSpec extends TestSupportFixture with ServletFixture with ScalatraSu
       header("REMOTE_USER") shouldBe "foo"
       val newCookie = header("Set-Cookie")
       newCookie should startWith regex "scentry.auth.default.user=[^;].+;"
-      newCookie should include(";Path=/")
-      newCookie should include(";HttpOnly")
+      newCookie should include("; Path=/")
+      newCookie should include("; HttpOnly")
       cookieAge(newCookie) should be < 1000L
     }
   }
@@ -167,9 +167,9 @@ class SessionSpec extends TestSupportFixture with ServletFixture with ScalatraSu
     val newCookie = response.headers("Set-Cookie")
     val lastCookie = newCookie.lastOption.getOrElse("")
     lastCookie should include("scentry.auth.default.user=;") // note the empty value
-    lastCookie should include(";Path=/")
-    lastCookie should include(";Expires=")
-    lastCookie should include(";HttpOnly")
+    lastCookie should include("; Path=/")
+    lastCookie should include("; Expires=")
+    lastCookie should include("; HttpOnly")
     newCookie.size shouldBe nrOfCookies
   }
 


### PR DESCRIPTION
https://github.com/eclipse/jetty.project/issues/3683
https://github.com/eclipse/jetty.project/releases/tag/jetty-9.4.19.v20190610

Fixes EASY-2152 : upgrade jetty with fix for cleanup of multipart on aborted upload

#### When applied it will
* remove multipart files of aborted uploads
* 
* 

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

on deasy
* `watch ls -la /var/opt/dans.knaw.nl/tmp/easy-deposit-api/multipart-location/`
* upload a large file
* abort before the status bar reaches 100%
* before deploy the multipart file is not removed, after deploy it will be removed


#### Related pull requests on github
repo                       | PR                | note
-------------------------- | ----------------- | ----
easy-                      | [PR#](PRlink)     | ..
