### PR TITLE
EASY-2112 : no update of rejected deposit

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.deposit/EasyDepositApiApp.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/EasyDepositApiApp.scala
@@ -333,6 +333,7 @@ class EasyDepositApiApp(configuration: Configuration) extends DebugEnhancedLoggi
   def stageFiles(userId: String, id: UUID, destination: Path): Try[(Dispose[File], StagedFilesTarget)] = {
     val prefix = s"$userId-$id-"
     for {
+      _ <- canUpdate(userId, id)
       deposit <- DepositDir.get(draftBase, userId, id)
       dataFiles <- deposit.getDataFiles
       stagingDir <- createManagedTempDir(prefix)

--- a/src/main/scala/nl.knaw.dans.easy.deposit/docs/StateInfo.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/docs/StateInfo.scala
@@ -36,7 +36,7 @@ case class StateInfo(state: State, stateDescription: String) {
 
 object StateInfo {
   val deletableStates: Seq[State] = Seq(State.draft, State.archived, State.rejected)
-  val updatableStates: Seq[State] = Seq(State.draft, State.rejected)
+  val updatableStates: Seq[State] = Seq(State.draft)
 
   object State extends Enumeration {
     type State = Value

--- a/src/test/scala/nl.knaw.dans.easy.deposit/docs/StateInfoSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/docs/StateInfoSpec.scala
@@ -36,18 +36,20 @@ class StateInfoSpec extends TestSupportFixture {
 
   it should "fail if the state is submitted" in {
     new StateInfo(StateInfo.State.submitted, "submitted").canDelete should matchPattern {
-      case Failure(ise: IllegalDepositStateException) if ise.getMessage == s"Deposit has state SUBMITTED, can only delete deposits with one of the states: ${ StateInfo.deletableStates.mkString(", ") }" =>
+      case Failure(ise: IllegalDepositStateException) if ise.getMessage == s"Deposit has state SUBMITTED, can only delete deposits with one of the states: DRAFT, ARCHIVED, REJECTED" =>
     }
   }
 
   it should "fail if the state is in progress" in {
     new StateInfo(StateInfo.State.inProgress, "IN_PROGRESS").canDelete should matchPattern {
-      case Failure(ise: IllegalDepositStateException) if ise.getMessage == s"Deposit has state IN_PROGRESS, can only delete deposits with one of the states: ${ StateInfo.deletableStates.mkString(", ") }" =>
+      case Failure(ise: IllegalDepositStateException) if ise.getMessage == s"Deposit has state IN_PROGRESS, can only delete deposits with one of the states: DRAFT, ARCHIVED, REJECTED" =>
     }
   }
 
-  "canUpdate" should "succeed if the state is rejected" in {
-    new StateInfo(StateInfo.State.rejected, "rejected").canUpdate shouldBe a[Success[_]]
+  "canUpdate" should "fail if the state is rejected" in {
+    new StateInfo(StateInfo.State.rejected, "rejected").canUpdate should matchPattern{
+      case Failure(ise: IllegalDepositStateException) if ise.getMessage == s"Deposit has state REJECTED, can only update deposits with one of the states: DRAFT" =>
+    }
   }
 
   it should "succeed if the state is draft" in {
@@ -56,19 +58,19 @@ class StateInfoSpec extends TestSupportFixture {
 
   it should "fail if the state is submitted" in {
     new StateInfo(StateInfo.State.submitted, "submitted").canUpdate should matchPattern {
-      case Failure(ise: IllegalDepositStateException) if ise.getMessage == s"Deposit has state SUBMITTED, can only update deposits with one of the states: ${ StateInfo.updatableStates.mkString(", ") }" =>
+      case Failure(ise: IllegalDepositStateException) if ise.getMessage == s"Deposit has state SUBMITTED, can only update deposits with one of the states: DRAFT" =>
     }
   }
 
   it should "fail if the state is in progress" in {
     new StateInfo(StateInfo.State.inProgress, "IN_PROGRESS").canUpdate should matchPattern {
-      case Failure(ise: IllegalDepositStateException) if ise.getMessage == s"Deposit has state IN_PROGRESS, can only update deposits with one of the states: ${ StateInfo.updatableStates.mkString(", ") }" =>
+      case Failure(ise: IllegalDepositStateException) if ise.getMessage == s"Deposit has state IN_PROGRESS, can only update deposits with one of the states: DRAFT" =>
     }
   }
 
   it should "fail if the state is archived" in {
     new StateInfo(StateInfo.State.archived, "archived").canUpdate should matchPattern {
-      case Failure(ise: IllegalDepositStateException) if ise.getMessage == s"Deposit has state ARCHIVED, can only update deposits with one of the states: ${ StateInfo.updatableStates.mkString(", ") }" =>
+      case Failure(ise: IllegalDepositStateException) if ise.getMessage == s"Deposit has state ARCHIVED, can only update deposits with one of the states: DRAFT" =>
     }
   }
 }

--- a/src/test/scala/nl.knaw.dans.easy.deposit/servlets/IntegrationSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/servlets/IntegrationSpec.scala
@@ -176,7 +176,7 @@ class IntegrationSpec extends TestSupportFixture with ServletFixture with Scalat
       uri = s"/deposit/$uuid/file/path/to/test.txt", headers = Seq(fooBarBasicAuthHeader, ("Content-Type", "application/json")),
       body = "Lorum ipsum"
     ) {
-      body shouldBe "Deposit has state SUBMITTED, can only update deposits with one of the states: DRAFT, REJECTED"
+      body shouldBe "Deposit has state SUBMITTED, can only update deposits with one of the states: DRAFT"
       status shouldBe FORBIDDEN_403
     }
   }


### PR DESCRIPTION
Fixes api side of EASY-2112 : no update of rejected deposit

#### When applied it will
* require the client to change the state from REJECTED to DRAFT before updating a dataset
* checks if update is allowed for POST uploads

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### Related pull requests on github
repo                       | PR                | note
-------------------------- | ----------------- | ----
easy-                      | [PR#](PRlink)     | ..
