### PR TITLE
EASY-2170 : locks for submits and POST/PUT uploads; EASY-2081 : internal service error

### DIFF
--- a/debug-init-env.sh
+++ b/debug-init-env.sh
@@ -19,7 +19,6 @@ echo -n "Pre-creating log..."
 TEMPDIR=data
 touch $TEMPDIR/easy-deposit-api.log
 mkdir $TEMPDIR/drafts
-mkdir $TEMPDIR/stage
-mkdir $TEMPDIR/stage-upload
+mkdir $TEMPDIR/staged
 mkdir $TEMPDIR/easy-ingest-flow-inbox
 echo "OK"

--- a/src/main/assembly/dist/cfg/application.properties
+++ b/src/main/assembly/dist/cfg/application.properties
@@ -19,7 +19,9 @@ multipart.file-size-threshold=3145728
 #
 # Directories for managing the deposits.
 #
-# - staged:           Is used for optimistic locking of uploads (both POST and PUT) and submits.
+# - staged:           Directories have two functions:
+#                     - staging area for POST uploads and submits.
+#                     - optimistic locking of uploads (both POST and PUT) and submits.
 #                     A completed draft is copied here when the user submits it.
 #                     Multiparts of POST uploads are copied here before
 #                     running checks and moving them as payload into a bag.
@@ -31,11 +33,12 @@ multipart.file-size-threshold=3145728
 #                     of a submit request.  As moving is an atomic action this prevents further
 #                     processing of incomplete deposits.
 #
-# N.B. multipart.location, staged, drafts and  submit-to must all be located on the same partition
+# N.B. multipart.location, staged, drafts and submit-to must all be located on the same partition
 # in order to support atomic moving.
 #
 # Note that a directory in the staged folder only has temporary content, so the service should
-# clear it automatically on completion of a request.
+# clear it automatically on completion of a request. The error message of a startup failure explains
+# what to do with leftovers of a hard shutdown.
 #
 deposits.staged=/var/opt/dans.knaw.nl/tmp/easy-deposit-api/staged
 deposits.drafts=/var/opt/dans.knaw.nl/tmp/easy-deposit-api/drafts

--- a/src/main/assembly/dist/cfg/application.properties
+++ b/src/main/assembly/dist/cfg/application.properties
@@ -19,7 +19,7 @@ multipart.file-size-threshold=3145728
 #
 # Directories for managing the deposits.
 #
-# - staged:           Directory has two functions:
+# - staged:           Sub-directories have two functions:
 #                     - staging area for POST uploads and submits.
 #                     - optimistic locking of uploads (both POST and PUT) and submits.
 #                     A completed draft is copied here when the user submits a deposit.
@@ -38,7 +38,7 @@ multipart.file-size-threshold=3145728
 # in order to support atomic moving.
 #
 # Note that a directory in the staged folder only has temporary content, the service should
-# clear it automatically on completion of a request. The error message of a startup failure explains
+# remove it automatically on completion of a request. The error message of a startup failure explains
 # what to do with leftovers of a hard shutdown.
 #
 deposits.staged=/var/opt/dans.knaw.nl/tmp/easy-deposit-api/staged

--- a/src/main/assembly/dist/cfg/application.properties
+++ b/src/main/assembly/dist/cfg/application.properties
@@ -19,24 +19,26 @@ multipart.file-size-threshold=3145728
 #
 # Directories for managing the deposits.
 #
-# - stage-zips:       is used for uploads of zipped directories or complete deposits.
+# - staged:           Is used for optimistic locking of uploads (both POST and PUT) and submits.
+#                     A completed draft is copied here when the user submits it.
+#                     Multiparts of POST uploads are copied here before
+#                     running checks and moving them as payload into a bag.
+#                     A temporary directory for a PUT upload will remain empty, it only serves locking.
 # - drafts:           contains the draft deposits; single files are uploaded here directly,
-#                     unzipped directories and deposits are moved here from stage-zips.
+#                     unzipped directories and deposits are moved here from staged.
 # - stage-for-submit: the completed draft is copied here when the user submits it.
-# - submit-to:        the deposit copy in stage-for-submit is moved here on successful completion
+# - submit-to:        the deposit copy in staged is moved here on successful completion
 #                     of a submit request.  As moving is an atomic action this prevents further
 #                     processing of incomplete deposits.
 #
-# N.B. multipart.location, stage-zips and drafts must all be located on the same partition
+# N.B. multipart.location, staged, drafts and  submit-to must all be located on the same partition
 # in order to support atomic moving.
-# The same holds for the couple stage-for-submit and submit-to.
 #
-# Note that the stage-* directories only have temporary content, so the service should clear them
-# automatically on completion of a request.
+# Note that a directory in the staged folder only has temporary content, so the service should
+# clear it automatically on completion of a request.
 #
-deposits.stage-zips=/var/opt/dans.knaw.nl/tmp/easy-deposit-api/stage-zips
+deposits.staged=/var/opt/dans.knaw.nl/tmp/easy-deposit-api/staged
 deposits.drafts=/var/opt/dans.knaw.nl/tmp/easy-deposit-api/drafts
-deposits.stage-for-submit=/var/opt/dans.knaw.nl/tmp/easy-deposit-api/stage-for-submit
 deposits.submit-to=/var/opt/dans.knaw.nl/tmp/easy-ingest-flow-inbox
 
 # The group to assign to the files and directories making up the deposit, before moving it to submit-to.

--- a/src/main/assembly/dist/cfg/application.properties
+++ b/src/main/assembly/dist/cfg/application.properties
@@ -22,10 +22,11 @@ multipart.file-size-threshold=3145728
 # - staged:           Directory has two functions:
 #                     - staging area for POST uploads and submits.
 #                     - optimistic locking of uploads (both POST and PUT) and submits.
-#                     A completed draft is copied here when the user submits it.
-#                     Multiparts of POST uploads are copied here before
+#                     A completed draft is copied here when the user submits a deposit.
+#                     Multipart files of POST uploads are copied here before
 #                     running checks and moving them as payload into a bag.
-#                     A temporary directory for a PUT upload will remain empty, it only serves locking.
+#                     PUT uploads are directly streamed into a bag, so the corresponding
+#                     temporary directory will remain empty, it only serves locking.
 # - drafts:           contains the draft deposits; single files are uploaded here directly,
 #                     unzipped directories and deposits are moved here from staged.
 # - stage-for-submit: the completed draft is copied here when the user submits it.
@@ -36,7 +37,7 @@ multipart.file-size-threshold=3145728
 # N.B. multipart.location, staged, drafts and submit-to must all be located on the same partition
 # in order to support atomic moving.
 #
-# Note that a directory in the staged folder only has temporary content, so the service should
+# Note that a directory in the staged folder only has temporary content, the service should
 # clear it automatically on completion of a request. The error message of a startup failure explains
 # what to do with leftovers of a hard shutdown.
 #

--- a/src/main/assembly/dist/cfg/application.properties
+++ b/src/main/assembly/dist/cfg/application.properties
@@ -19,7 +19,7 @@ multipart.file-size-threshold=3145728
 #
 # Directories for managing the deposits.
 #
-# - staged:           Directories have two functions:
+# - staged:           Directory has two functions:
 #                     - staging area for POST uploads and submits.
 #                     - optimistic locking of uploads (both POST and PUT) and submits.
 #                     A completed draft is copied here when the user submits it.

--- a/src/main/rpm/2-post-install.sh
+++ b/src/main/rpm/2-post-install.sh
@@ -20,9 +20,8 @@
 NUMBER_OF_INSTALLATIONS=$1
 MODULE_NAME=easy-deposit-api
 INSTALL_DIR=/opt/dans.knaw.nl/$MODULE_NAME
-DEPOSITS_STAGE_ZIPS=/var/opt/dans.knaw.nl/tmp/easy-deposit-api/stage-zips
+DEPOSITS_STAGED=/var/opt/dans.knaw.nl/tmp/easy-deposit-api/staged
 DEPOSITS_DRAFTS=/var/opt/dans.knaw.nl/tmp/easy-deposit-api/drafts
-DEPOSITS_STAGE_FOR_SUBMIT=/var/opt/dans.knaw.nl/tmp/easy-deposit-api/stage-for-submit
 DEPOSITS_SUBMIT_TO=/var/opt/dans.knaw.nl/tmp/easy-ingest-flow-inbox
 PHASE="POST-INSTALL"
 
@@ -32,24 +31,17 @@ service_install_systemd_unit "$INSTALL_DIR/install/$MODULE_NAME.service" $MODULE
 service_create_log_directory $MODULE_NAME
 echo "$PHASE: DONE"
 
-if [[ ! -d ${DEPOSITS_STAGE_ZIPS} ]]; then
-  echo -n "Creating deposits stage/upload directory at ${DEPOSITS_STAGE_ZIPS}..."
-  mkdir -p ${DEPOSITS_STAGE_ZIPS}
-  chmod 755 ${DEPOSITS_STAGE_ZIPS}
+if [[ ! -d ${DEPOSITS_STAGED} ]]; then
+  echo -n "Creating deposits staged directory for uploads/submits at ${DEPOSITS_STAGED}..."
+  mkdir -p ${DEPOSITS_STAGED}
+  chmod 755 ${DEPOSITS_STAGED}
   echo "OK"
 fi
 
 if [[ ! -d ${DEPOSITS_DRAFTS} ]]; then
-  echo -n "Creating deposits draft directory at ${DEPOSITS_STAGE_FOR_SUBMIT}..."
+  echo -n "Creating deposits draft directory at ${DEPOSITS_DRAFTS}..."
   mkdir -p ${DEPOSITS_DRAFTS}
   chmod 755 ${DEPOSITS_DRAFTS}
-  echo "OK"
-fi
-
-if [[ ! -d ${DEPOSITS_STAGE_FOR_SUBMIT} ]]; then
-  echo -n "Creating deposits stage directory at ${DEPOSITS_STAGE_FOR_SUBMIT}..."
-  mkdir -p ${DEPOSITS_STAGE_FOR_SUBMIT}
-  chmod 755 ${DEPOSITS_STAGE_FOR_SUBMIT}
   echo "OK"
 fi
 

--- a/src/main/scala/nl.knaw.dans.easy.deposit/EasyDepositApiApp.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/EasyDepositApiApp.scala
@@ -364,7 +364,7 @@ class EasyDepositApiApp(configuration: Configuration) extends DebugEnhancedLoggi
 
   }
 
-  // the temporary directory is dropped on when the disposable resource is released on completion of the request,
+  // the temporary directory is dropped when the disposable resource is released on completion of the request,
   // unless the directory was moved away before to ingest-flow-inbox
   private def createManagedTempDir(prefix: String): Try[Dispose[File]] = Try {
     temporaryDirectory(prefix, Some(stagedBaseDir.createDirectories()))

--- a/src/main/scala/nl.knaw.dans.easy.deposit/EasyDepositApiApp.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/EasyDepositApiApp.scala
@@ -67,7 +67,7 @@ class EasyDepositApiApp(configuration: Configuration) extends DebugEnhancedLoggi
   private val stagedBaseDir = {
     val dir = getConfiguredDirectory("deposits.staged")
     if (dir.nonEmpty) throw LeftoversOfForcedShutdownException(dir)
-    logger.info(s"Uploads/submits are staged in $dir")
+    logger.info(s"Uploads/submits will be staged in $dir")
     dir
   }
   private val draftBase: File = getConfiguredDirectory("deposits.drafts")

--- a/src/main/scala/nl.knaw.dans.easy.deposit/EasyDepositApiApp.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/EasyDepositApiApp.scala
@@ -17,12 +17,12 @@ package nl.knaw.dans.easy.deposit
 
 import java.io.InputStream
 import java.net.{ URI, URL }
-import java.nio.file.{ FileAlreadyExistsException, Path }
+import java.nio.file.Path
 import java.util.UUID
 
 import better.files.File.temporaryDirectory
 import better.files.{ Dispose, File }
-import nl.knaw.dans.easy.deposit.Errors.{ ClientAbortedUploadException, ConfigurationException, CorruptUserException, InvalidContentTypeException, NoStagingDirException, OverwriteException, PendingUploadException }
+import nl.knaw.dans.easy.deposit.Errors.{ ClientAbortedUploadException, ConfigurationException, CorruptUserException, InvalidContentTypeException, LeftoversOfForcedShutdownException, NoStagingDirException, OverwriteException, PendingUploadException }
 import nl.knaw.dans.easy.deposit.PidRequesterComponent.PidRequester
 import nl.knaw.dans.easy.deposit.authentication.{ AuthenticationProvider, LdapAuthentication }
 import nl.knaw.dans.easy.deposit.docs.StateInfo.State
@@ -66,10 +66,8 @@ class EasyDepositApiApp(configuration: Configuration) extends DebugEnhancedLoggi
 
   private val stagedDir = {
     val dir = getConfiguredDirectory("deposits.staged")
+    if (dir.nonEmpty) throw LeftoversOfForcedShutdownException(dir)
     logger.info(s"Uploads/submits are staged in $dir")
-    if (dir.nonEmpty) throw new FileAlreadyExistsException(
-      s"Staging area [$dir] should be empty unless force shutdown during an upload/submit request."
-    )
     dir
   }
   private val draftBase: File = getConfiguredDirectory("deposits.drafts")

--- a/src/main/scala/nl.knaw.dans.easy.deposit/EasyDepositApiApp.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/EasyDepositApiApp.scala
@@ -86,7 +86,10 @@ class EasyDepositApiApp(configuration: Configuration) extends DebugEnhancedLoggi
     )
   }
 
-  private val submitter = new Submitter(stagedDir, submitBase, properties.getString("deposit.permissions.group"))
+  private val submitter = {
+    val groupName = properties.getString("deposit.permissions.group")
+    new Submitter(stagedDir, submitBase, groupName)
+  }
 
   // possible trailing slash is dropped
   private val easyHome: URL = new URL(properties.getString("easy.home").replaceAll("/?$", ""))

--- a/src/main/scala/nl.knaw.dans.easy.deposit/Errors.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/Errors.scala
@@ -111,6 +111,14 @@ object Errors extends DebugEnhancedLogging {
   case class PendingUploadException()
     extends ServletResponseException(CONFLICT_409, "Another upload is pending. Please try again later.")
 
+  case class NoStagingDirException(file: File)
+    extends ServletResponseException(INTERNAL_SERVER_ERROR_500, s"staging directory was not created: $file")
+
+  case class ClientAbortedUploadException(path: String)
+    extends ServletResponseException(OK_200, s"Client aborted upload of path $path") {
+    logger.info(getMessage)
+  }
+
   case class InvalidContentTypeException(contentType: Option[String], requirement: String)
     extends ServletResponseException(BAD_REQUEST_400, contentType
       .map(s => s"Content-Type $requirement Got: $s")

--- a/src/main/scala/nl.knaw.dans.easy.deposit/Errors.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/Errors.scala
@@ -36,9 +36,9 @@ object Errors extends DebugEnhancedLogging {
 
   case class LeftoversOfForcedShutdownException(dir: File)
     extends FileAlreadyExistsException(
-      s"Staging area [$dir] should be empty unless force shutdown during an upload/submit request." +
+      s"Staging area [$dir] should be empty unless a forced shutdown occurred during an upload/submit request." +
         " Directories containing bags are aborted submits, somehow (allow) resubmit if indeed not in fedora." +
-        " Other directories contain files of uploads not yet moved into the bag."
+        " Other directories contain files of uploads that are not yet moved into the bag."
     )
 
   abstract sealed class ServletResponseException(status: Int, httpResponseBody: String)
@@ -119,7 +119,7 @@ object Errors extends DebugEnhancedLogging {
     extends ServletResponseException(CONFLICT_409, "Another upload or submit is pending.")
 
   case class NoStagingDirException(file: File)
-    extends ServletResponseException(INTERNAL_SERVER_ERROR_500, s"staging directory was not created: $file")
+    extends ServletResponseException(INTERNAL_SERVER_ERROR_500, s"Staging directory was not created: $file")
 
   case class ClientAbortedUploadException(path: String)
     extends ServletResponseException(OK_200, s"Client aborted upload of path $path") {

--- a/src/main/scala/nl.knaw.dans.easy.deposit/Errors.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/Errors.scala
@@ -15,7 +15,7 @@
  */
 package nl.knaw.dans.easy.deposit
 
-import java.nio.file.Path
+import java.nio.file.{ FileAlreadyExistsException, Path }
 import java.util.UUID
 
 import better.files.File
@@ -33,6 +33,13 @@ import scala.util.Try
 object Errors extends DebugEnhancedLogging {
 
   case class ConfigurationException(msg: String) extends IllegalArgumentException(s"Configuration error: $msg")
+
+  case class LeftoversOfForcedShutdownException(dir: File)
+    extends FileAlreadyExistsException(
+      s"Staging area [$dir] should be empty unless force shutdown during an upload/submit request." +
+        " Directories containing bags are aborted submits, somehow (allow) resubmit if indeed not in fedora." +
+        " Other directories contain files of uploads not yet moved into the bag."
+    )
 
   abstract sealed class ServletResponseException(status: Int, httpResponseBody: String)
     extends Exception(httpResponseBody) {

--- a/src/main/scala/nl.knaw.dans.easy.deposit/Errors.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/Errors.scala
@@ -123,7 +123,7 @@ object Errors extends DebugEnhancedLogging {
 
   case class ClientAbortedUploadException(path: String)
     extends ServletResponseException(OK_200, s"Client aborted upload of path $path") {
-    logger.info(getMessage)
+    logger.info(getMessage) // logging the body explains why the request did not log new payloads
   }
 
   case class InvalidContentTypeException(contentType: Option[String], requirement: String)

--- a/src/main/scala/nl.knaw.dans.easy.deposit/Errors.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/Errors.scala
@@ -109,7 +109,7 @@ object Errors extends DebugEnhancedLogging {
     extends ServletResponseException(BAD_REQUEST_400, s"ZIP file is malformed. $msgAboutEntry")
 
   case class PendingUploadException()
-    extends ServletResponseException(CONFLICT_409, "Another upload is pending. Please try again later.")
+    extends ServletResponseException(CONFLICT_409, "Another upload or submit is pending.")
 
   case class NoStagingDirException(file: File)
     extends ServletResponseException(INTERNAL_SERVER_ERROR_500, s"staging directory was not created: $file")

--- a/src/main/scala/nl.knaw.dans.easy.deposit/StateManager.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/StateManager.scala
@@ -47,17 +47,21 @@ case class StateManager(depositDir: File, submitBase: File, easyHome: URL) exten
    *          unless more recent values might be available in SUBMITTED/UUID/deposit.properties
    */
   def getStateInfo: Try[StateInfo] = Try {
-    toDraftState(getProp(stateLabelKey, draftProps)) match {
-      case State.submitted | State.inProgress =>
-        val newState: StateInfo = getProp(stateLabelKey, submittedProps) match {
-          case "SUBMITTED" => StateInfo(State.submitted, getStateDescription(draftProps))
-          case "REJECTED" => StateInfo(State.rejected, getStateDescription(submittedProps))
-          case "FAILED" => StateInfo(State.inProgress, s"The deposit is in progress.")
-          case "IN_REVIEW" => StateInfo(State.inProgress, s"The deposit is available at $landingPage")
-          case "FEDORA_ARCHIVED" | "ARCHIVED" => StateInfo(State.archived, s"The dataset is published at $landingPage")
-          case str: String =>
+    getDraftState match {
+      case draftState @ (State.submitted | State.inProgress) =>
+        val newState: StateInfo = Try(getProp(stateLabelKey, submittedProps)) match {
+          case Success("SUBMITTED") => StateInfo(State.submitted, getStateDescription(draftProps))
+          case Success("REJECTED") => StateInfo(State.rejected, getStateDescription(submittedProps))
+          case Success("FAILED") => StateInfo(State.inProgress, s"The deposit is in progress.")
+          case Success("IN_REVIEW") => StateInfo(State.inProgress, s"The deposit is available at $landingPage")
+          case Success("FEDORA_ARCHIVED") |
+               Success("ARCHIVED") => StateInfo(State.archived, s"The dataset is published at $landingPage")
+          case Success(str: String) =>
             logger.error(InvalidPropertyException(stateLabelKey, str, submittedProps).getMessage)
             StateInfo(State.inProgress, s"The deposit is in progress.")
+          case Failure(e) =>
+            logger.error(e.getMessage, e)
+            StateInfo(draftState, getStateDescription(draftProps))
         }
         saveNewState(newState)
         newState
@@ -123,14 +127,15 @@ case class StateManager(depositDir: File, submitBase: File, easyHome: URL) exten
     draftProps.save()
   }
 
-  @throws[InvalidPropertyException](s"when $stateLabelKey has an invalid value")
-  private def toDraftState(str: String): State.Value = Try {
-    State.withName(str)
-  }.getOrElse(throw InvalidPropertyException(stateLabelKey, str, draftProps))
+  @throws[InvalidPropertyException](s"when stateLabelKey is not found in draftProps")
+  private def getDraftState: State.Value = {
+    val str = getProp(stateLabelKey, draftProps)
+    Try { State.withName(str) }
+      .getOrElse(throw InvalidPropertyException(stateLabelKey, str, draftProps))
+  }
 
-  @throws[PropertyNotFoundException](s"when $stateDescriptionKey is not found in props")
-  private def getStateDescription(props: PropertiesConfiguration): String = {
-    getProp(stateDescriptionKey, props)
+  private def getStateDescription(props: PropertiesConfiguration, default: String =""): String = {
+    Try(getProp(stateDescriptionKey, props)).getOrElse(default)
   }
 
   @throws[PropertyNotFoundException]("when key is not found in props")

--- a/src/main/scala/nl.knaw.dans.easy.deposit/Submitter.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/Submitter.scala
@@ -22,7 +22,7 @@ import java.nio.file.attribute.{ PosixFileAttributeView, UserPrincipalNotFoundEx
 import java.nio.file.spi.FileSystemProvider
 import java.util.UUID
 
-import better.files.File
+import better.files.{ Dispose, File }
 import better.files.File.{ CopyOptions, VisitOptions }
 import nl.knaw.dans.bag.ChecksumAlgorithm.ChecksumAlgorithm
 import nl.knaw.dans.bag.DansBag
@@ -68,7 +68,7 @@ class Submitter(stagingBaseDir: File,
    * @param draftDeposit the deposit object to submit
    * @return the UUID of the deposit in the submit area (easy-ingest-flow-inbox)
    */
-  def submit(draftDeposit: DepositDir, stateManager: StateManager, fullName: String): Try[UUID] = {
+  def submit(draftDeposit: DepositDir, stateManager: StateManager, fullName: String, stagedDir: File): Try[UUID] = {
     val propsFileName = "deposit.properties"
     for {
       // EASY-1464 step 3.3.4 validation
@@ -88,14 +88,13 @@ class Submitter(stagingBaseDir: File,
       _ <- sameFiles(draftBag.payloadManifests, draftBag.baseDir / "data")
       // from now on no more user errors but internal errors
       // EASY-1464 3.3.8.a create empty staged bag to take a copy of the deposit
-      stageDir = (stagingBaseDir / draftDeposit.id.toString).createDirectories()
-      stageBag <- DansV0Bag.empty(stageDir / bagDirName).map(_.withCreated())
+      stageBag <- DansV0Bag.empty(stagedDir / bagDirName).map(_.withCreated())
       // EASY-1464 3.3.6 change state and copy with the rest of the deposit properties to staged dir
       _ <- stateManager.changeState(StateInfo(State.submitted, "Deposit is ready for processing."))
       submittedId <- stateManager.getSubmittedBagId // created by changeState
       submitDir = submitToBaseDir / submittedId.toString
       _ = if (submitDir.exists) throw AlreadySubmittedException(draftDeposit.id)
-      _ = (draftBag.baseDir.parent / propsFileName).copyTo(stageDir / propsFileName)
+      _ = (draftBag.baseDir.parent / propsFileName).copyTo(stagedDir / propsFileName)
       // EASY-1464 3.3.5.b: write files to metadata
       _ = stageBag.addMetadataFile(msg, s"$depositorInfoDirectoryName/message-from-depositor.txt")
       _ <- stageBag.addMetadataFile(agreementsXml, s"$depositorInfoDirectoryName/agreements.xml")

--- a/src/main/scala/nl.knaw.dans.easy.deposit/authentication/AuthenticationSupport.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/authentication/AuthenticationSupport.scala
@@ -30,7 +30,7 @@ trait AuthenticationSupport extends ScentrySupport[AuthUser] {
   override protected def fromSession: PartialFunction[String, AuthUser] = {
     case token: String => decodeJWT(token)
       .doIfSuccess { user => scentry.store.set(encodeJWT(user)) } // refresh cookie
-      .doIfFailure { case t => logger.info(s"invalid authentication: $t") }
+      .doIfFailure { case t => logger.info(s"invalid authentication: ${ t.getMessage }") }
       .getOrElse(null)
   }
 

--- a/src/main/scala/nl.knaw.dans.easy.deposit/servlets/AbstractAuthServlet.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/servlets/AbstractAuthServlet.scala
@@ -25,7 +25,8 @@ import org.scalatra.ScalatraServlet
 
 abstract class AbstractAuthServlet(app: EasyDepositApiApp) extends ScalatraServlet
   with ServletLogger
-  with MaskedLogFormatter
+  //with MaskedLogFormatter
+  with PlainLogFormatter
   with LogResponseBodyOnError
   with DebugEnhancedLogging
   with AuthenticationSupport
@@ -35,7 +36,7 @@ abstract class AbstractAuthServlet(app: EasyDepositApiApp) extends ScalatraServl
   override protected def fromSession: PartialFunction[String, AuthUser] = {
     // prevents refreshing a cookie on logout
     case token: String => decodeJWT(token)
-      .doIfFailure { case t => logger.info(s"invalid authentication: $t") }
+      .doIfFailure { case t => logger.info(s"invalid authentication: ${ t.getMessage }") }
       .getOrElse(null)
   }
 

--- a/src/main/scala/nl.knaw.dans.easy.deposit/servlets/AbstractAuthServlet.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/servlets/AbstractAuthServlet.scala
@@ -25,8 +25,7 @@ import org.scalatra.ScalatraServlet
 
 abstract class AbstractAuthServlet(app: EasyDepositApiApp) extends ScalatraServlet
   with ServletLogger
-  //with MaskedLogFormatter
-  with PlainLogFormatter
+  with MaskedLogFormatter
   with LogResponseBodyOnError
   with DebugEnhancedLogging
   with AuthenticationSupport

--- a/src/test/resources/debug-config/application.properties
+++ b/src/test/resources/debug-config/application.properties
@@ -6,9 +6,8 @@ multipart.max-file-size=-1
 multipart.max-request-size=-1
 multipart.file-size-threshold=3145728
 
-deposits.stage-zips=data/stage-zips
+deposits.staged=data/staged
 deposits.drafts=data/drafts
-deposits.stage-for-submit=data/stage-for-submit
 deposits.submit-to=data/easy-ingest-flow-inbox
 
 deposit.permissions.group=deposits

--- a/src/test/scala/nl.knaw.dans.easy.deposit/SubmitterSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/SubmitterSpec.scala
@@ -56,7 +56,7 @@ class SubmitterSpec extends TestSupportFixture with MockFactory {
     val stateManager = depositDir.getStateManager(testDir / "submitted", easyHome)
     addDoiToDepositProperties(getBag(depositDir))
 
-    createSubmitter(unrelatedGroup).submit(depositDir, stateManager, "fullName") should matchPattern {
+    createSubmitter(unrelatedGroup).submit(depositDir, stateManager, "fullName", testDir / "staged") should matchPattern {
       case Failure(e: IOException) if e.getMessage matches
         ".*Probably the current user .* is not part of this group.*" =>
     }
@@ -81,7 +81,7 @@ class SubmitterSpec extends TestSupportFixture with MockFactory {
     val bagStoreBagID = succeedingSubmit(depositDir)
 
     // post conditions
-    (testDir / "staged").children.size shouldBe 0
+    (testDir / "staged") should not (exist)
     (bagDir / "metadata" / "dataset.json").size shouldBe mdOldSize
     // no DOI added
     val submittedBagDir = testDir / "submitted" / bagStoreBagID / bagDirName
@@ -136,7 +136,7 @@ class SubmitterSpec extends TestSupportFixture with MockFactory {
   private def succeedingSubmit(deposit: DepositDir): String = {
     val stateManager = deposit.getStateManager(testDir / "submitted", easyHome)
 
-    val triedBagStoreBagID = createSubmitter(userGroup).submit(deposit, stateManager, "fullName")
+    val triedBagStoreBagID = createSubmitter(userGroup).submit(deposit, stateManager, "fullName", testDir / "staged")
     triedBagStoreBagID shouldBe a[Success[_]]
     triedBagStoreBagID
       .map(_.toString)
@@ -154,7 +154,7 @@ class SubmitterSpec extends TestSupportFixture with MockFactory {
     // add file to manifest that does not exist
     (bag.baseDir / "manifest-sha1.txt").append("chk file")
 
-    createSubmitter(userGroup).submit(depositDir, stateManager, "fullName") should matchPattern {
+    createSubmitter(userGroup).submit(depositDir, stateManager, "fullName", testDir / "staged") should matchPattern {
       case Failure(e) if e.getMessage == s"invalid bag, missing [files, checksums]: [Set($testDir/drafts/user/${ depositDir.id }/bag/file), Set()]" =>
     }
   }
@@ -172,7 +172,7 @@ class SubmitterSpec extends TestSupportFixture with MockFactory {
     manifest.write(manifest.contentAsString.replaceAll(" +", "xxx  "))
 
     val checksum = "a57ec0c3239f30b29f1e9270581be50a70c74c04"
-    createSubmitter(userGroup).submit(depositDir, stateManager, "fullName") should matchPattern {
+    createSubmitter(userGroup).submit(depositDir, stateManager, "fullName", testDir / "staged") should matchPattern {
       case Failure(e)
         if e.getMessage == s"staged and draft bag [${ bag.baseDir.parent }] have different payload manifest elements: (Set((data/file.txt,$checksum)),Set((data/file.txt,${ checksum }xxx)))" =>
     }

--- a/src/test/scala/nl.knaw.dans.easy.deposit/SubmitterSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/SubmitterSpec.scala
@@ -81,7 +81,7 @@ class SubmitterSpec extends TestSupportFixture with MockFactory {
     val bagStoreBagID = succeedingSubmit(depositDir)
 
     // post conditions
-    (testDir / "stage-for-submit").children.size shouldBe 0
+    (testDir / "staged").children.size shouldBe 0
     (bagDir / "metadata" / "dataset.json").size shouldBe mdOldSize
     // no DOI added
     val submittedBagDir = testDir / "submitted" / bagStoreBagID / bagDirName
@@ -180,7 +180,7 @@ class SubmitterSpec extends TestSupportFixture with MockFactory {
 
   private def createSubmitter(group: String): Submitter = {
     new Submitter(
-      (testDir / "stage-for-submit").createDirectories(),
+      (testDir / "staged").createDirectories(),
       (testDir / "submitted").createDirectories(),
       group,
     )

--- a/src/test/scala/nl.knaw.dans.easy.deposit/TestSupportFixture.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/TestSupportFixture.scala
@@ -76,8 +76,7 @@ trait TestSupportFixture extends FlatSpec with Matchers with Inside with BeforeA
 
   def minimalAppConfig: Configuration = {
     new Configuration("", new PropertiesConfiguration() {
-      addProperty("deposits.stage-zips", testSubDir("stage-zips").toString())
-      addProperty("deposits.stage-for-submit", testSubDir("stage-for-submit").toString())
+      addProperty("deposits.staged", testSubDir("staged").toString())
       addProperty("deposits.drafts", testSubDir("drafts").toString())
       addProperty("deposits.submit-to", testSubDir("easy-ingest-flow-inbox").toString())
       addProperty("deposit.permissions.group", userGroup)

--- a/src/test/scala/nl.knaw.dans.easy.deposit/servlets/RichFileItemsSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/servlets/RichFileItemsSpec.scala
@@ -94,7 +94,7 @@ class RichFileItemsSpec extends TestSupportFixture with MockFactory {
     ).buffered
 
     createMultipartConfig.moveNonZips(fileItems, createStageDir) shouldBe a[Success[_]]
-    (testDir / "stage-upload").list should have size 0
+    (testDir / "staged").list should have size 0
   }
 
   it should "refuse a zip" in {
@@ -112,8 +112,8 @@ class RichFileItemsSpec extends TestSupportFixture with MockFactory {
       // that's out of scope for this unit test but is the (fall back) rationale for the "but ..."
       // of the message returned to the client
     }
-    (testDir / "stage-upload" / "some.txt").contentAsString shouldBe contentOfStagedUpload
-    (testDir / "stage-upload").list should have size 1 // the file after the zip is not processed
+    (testDir / "staged" / "some.txt").contentAsString shouldBe contentOfStagedUpload
+    (testDir / "staged").list should have size 1 // the file after the zip is not processed
   }
 
   private val multipartLocation: File = testDir / "mulitpart-location"
@@ -124,7 +124,7 @@ class RichFileItemsSpec extends TestSupportFixture with MockFactory {
   }
 
   private def createStageDir = {
-    (testDir / "stage-upload").createDirectories()
+    (testDir / "staged").createDirectories()
   }
 
   private def mockFileItem(fileName: String, contentType: String = null, content: String = "") = {

--- a/src/test/scala/nl.knaw.dans.easy.deposit/servlets/UploadSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/servlets/UploadSpec.scala
@@ -77,7 +77,7 @@ class UploadSpec extends DepositServletFixture {
       files = bodyParts
     ) {
       status shouldBe CONFLICT_409
-      body shouldBe "Another upload is pending. Please try again later."
+      body shouldBe "Another upload or submit is pending."
       val bagDir = testDir / "drafts/foo" / uuid.toString / bagDirName
       (bagDir / "data").list.size shouldBe 0
       (bagDir / "manifest-sha1.txt").lines.size shouldBe 0

--- a/src/test/scala/nl.knaw.dans.easy.deposit/servlets/UploadSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/servlets/UploadSpec.scala
@@ -57,7 +57,7 @@ class UploadSpec extends DepositServletFixture {
         file.contentAsString shouldBe (testDir / "input" / file.name).contentAsString
       )
       (bagDir / "manifest-sha1.txt").lines.size shouldBe bodyParts.size
-      (testDir / "stage-zips").list.size shouldBe 0
+      (testDir / "staged").list.size shouldBe 0
     }
   }
 
@@ -69,7 +69,7 @@ class UploadSpec extends DepositServletFixture {
       ("more", "4.txt", "Ut enim ad minim veniam"),
     ))
     val uuid = createDeposit
-    (testDir / s"stage-zips/foo-$uuid-XYZ").createDirectories() // mocks a concurrent post
+    (testDir / s"staged/foo-$uuid-XYZ").createDirectories() // mocks a concurrent post
     post(
       uri = s"/deposit/$uuid/file/path/to/dir",
       params = Iterable(),
@@ -81,7 +81,7 @@ class UploadSpec extends DepositServletFixture {
       val bagDir = testDir / "drafts/foo" / uuid.toString / bagDirName
       (bagDir / "data").list.size shouldBe 0
       (bagDir / "manifest-sha1.txt").lines.size shouldBe 0
-      (testDir / "stage-zips").list.size shouldBe 1
+      (testDir / "staged").list.size shouldBe 1
     }
   }
 


### PR DESCRIPTION
Fixes 
EASY-2170 : locks for submits and POST/PUT uploads;
EASY-2081 : internal service error

## message for squash merge
* combines both staged directories into a single one
* implements optimistic locking also for 
  * [x] PUT uploads
  * [x] submits
* fetching `StateInfo` of a submitted deposit won't cause an internal error when properties in (or pointing to) the ingest-flow-inbox are not found (not yet or no longer). The state available in the draft area will be returned and the missing property logged.

## Where should the reviewer @DANS-KNAW/easy start?

* [x] see comments on #162

#### How should this be manually tested?

Requirements
* this pull request deployed on deasy
* a small file and a large file (a few GB) to have some time to start a concurrent upload/submit
* the UUID of a draft dataset that is ready to receive uploads
* two browser windows with the deposit-ui ready for a POST upload (or submit with a large file in the bag)
* a curl command prepared for a PUT upload:
  ```
  curl -v -u user001:user001 -H 'Content-Type: text/plain' -H 'Content-Disposition': 'form-data; filename=File3.txt' -F data=@/PATH-TO/XXX.txt -X PUT "http://deasy.dans.knaw.nl/deposit-api/deposit/<UUID>/file/filepath"
  ```
  for an invalid cookie: replace the -u option with `-c 'scentry.auth.default.user=ra.bar.bera'`
* a `tail -f` for deposit api
* monitor files and their sizes:
  ```
  watch ls -la /var/opt/dans.knaw.nl/tmp/easy-deposit-api/*
  ```

Observations:
* a POST upload creates a file in `multipart-location` until the status bar reaches 100%, then a directory is created in `staged` and a log-line appears that the request is received
  * another POST upload fails with a warning to try again later
  * same for another PUT upload
* a PUT upload
  * with valid credentials and the UUID of a draft deposit immediately creates a directory in `staged`
  * with an invalid cookie the server immediately returns the `missing, invalid or expired credentials` but curl apparently keeps writing the complete file

#### Related pull requests on github
https://github.com/DANS-KNAW/easy-dtap/pull/344
