### PR TITLE
wrap URL in deposit description in <a/> tag, to be rendered in easy-deposit-ui

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.deposit/StateManager.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/StateManager.scala
@@ -53,9 +53,9 @@ case class StateManager(depositDir: File, submitBase: File, easyHome: URL) exten
           case Success("SUBMITTED") => StateInfo(State.submitted, getStateDescription(draftProps))
           case Success("REJECTED") => StateInfo(State.rejected, getStateDescription(submittedProps))
           case Success("FAILED") => StateInfo(State.inProgress, s"The deposit is in progress.")
-          case Success("IN_REVIEW") => StateInfo(State.inProgress, s"The deposit is available at $landingPage")
+          case Success("IN_REVIEW") => StateInfo(State.inProgress, s"""The deposit is available at <a href="$landingPage" target="_blank">$landingPage</a>""")
           case Success("FEDORA_ARCHIVED") |
-               Success("ARCHIVED") => StateInfo(State.archived, s"The dataset is published at $landingPage")
+               Success("ARCHIVED") => StateInfo(State.archived, s"""The dataset is published at <a href="$landingPage" target="_blank">$landingPage</a>""")
           case Success(str: String) =>
             logger.error(InvalidPropertyException(stateLabelKey, str, submittedProps).getMessage)
             StateInfo(State.inProgress, s"The deposit is in progress.")

--- a/src/test/scala/nl.knaw.dans.easy.deposit/StateManagerSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/StateManagerSpec.scala
@@ -83,7 +83,7 @@ class StateManagerSpec extends TestSupportFixture {
          |state.description = rabarbera
       """.stripMargin)
     StateManager(draftDeposit, submitBase, easyHome).getStateInfo should matchPattern {
-      case Success(StateInfo(State.inProgress, "The deposit is available at https://easy.dans.knaw.nl/ui/mydatasets")) =>
+      case Success(StateInfo(State.inProgress, """The deposit is available at <a href="https://easy.dans.knaw.nl/ui/mydatasets" target="_blank">https://easy.dans.knaw.nl/ui/mydatasets</a>""")) =>
     }
   }
 
@@ -100,7 +100,7 @@ class StateManagerSpec extends TestSupportFixture {
          |identifier.fedora = easy-dataset:1239
       """.stripMargin)
     StateManager(draftDeposit, submitBase, easyHome).getStateInfo should matchPattern {
-      case Success(StateInfo(State.inProgress, "The deposit is available at https://easy.dans.knaw.nl/ui/datasets/id/easy-dataset:1239")) =>
+      case Success(StateInfo(State.inProgress, """The deposit is available at <a href="https://easy.dans.knaw.nl/ui/datasets/id/easy-dataset:1239" target="_blank">https://easy.dans.knaw.nl/ui/datasets/id/easy-dataset:1239</a>""")) =>
     }
   }
 
@@ -116,7 +116,7 @@ class StateManagerSpec extends TestSupportFixture {
          |state.description = rabarbeara
       """.stripMargin)
     StateManager(draftDeposit, submitBase, easyHome).getStateInfo should matchPattern {
-      case Success(StateInfo(State.archived, "The dataset is published at https://easy.dans.knaw.nl/ui/mydatasets")) =>
+      case Success(StateInfo(State.archived, """The dataset is published at <a href="https://easy.dans.knaw.nl/ui/mydatasets" target="_blank">https://easy.dans.knaw.nl/ui/mydatasets</a>""")) =>
     }
   }
 


### PR DESCRIPTION
#### When applied it will
* wrap URLs in the deposit description in `<a/>` tags, so that they are clickable in `easy-deposit-ui`

@DANS-KNAW/easy for review

#### See also
* https://github.com/DANS-KNAW/easy-deposit-ui/pull/174
* https://github.com/DANS-KNAW/easy-deposit-api/pull/161/files?file-filters%5B%5D=.properties&file-filters%5B%5D=.scala#r296196986