### PR TITLE
EASY-2173: 'origin' kolom voor deposit report

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.deposit/DepositDir.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/DepositDir.scala
@@ -238,6 +238,7 @@ object DepositDir {
       addProperty("identifier.dans-doi.registered", "no")
       addProperty("identifier.dans-doi.action", "create")
       addProperty("bag-store.bag-name", bagDirName)
+      addProperty("deposit.origin", "API")
     }.save(depositDir.depositPropertiesFile.toJava)
   }
 }

--- a/src/main/scala/nl.knaw.dans.easy.deposit/StateManager.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/StateManager.scala
@@ -34,7 +34,6 @@ case class StateManager(depositDir: File, submitBase: File, easyHome: URL) exten
 
   /** created/destroyed when the state changes, needed to peek into SUBMITTED/UUID/deposit.properties */
   private val bagIdKey = "bag-store.bag-id"
-  private val depositSourceKey = "deposit.source"
 
   /** Available as side effect for properties not related to fetching or updating the state of the deposit. */
   val draftProps = new PropertiesConfiguration(
@@ -91,12 +90,10 @@ case class StateManager(depositDir: File, submitBase: File, easyHome: URL) exten
         // probably properly saved without toString but getSubmittedBagId would throw
         // ConversionException: 'bag-store.bag-id' doesn't map to a String object
         draftProps.setProperty(bagIdKey, bagStoreBagId.toString)
-        draftProps.setProperty(depositSourceKey, "API")
         saveNewStateInDraftDeposit(newStateInfo)
         Success(())
       case (State.rejected, State.draft) =>
         draftProps.clearProperty(bagIdKey)
-        draftProps.clearProperty(depositSourceKey)
         saveNewStateInDraftDeposit(newStateInfo)
         Success(())
       case (oldState, newState) =>

--- a/src/main/scala/nl.knaw.dans.easy.deposit/StateManager.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/StateManager.scala
@@ -34,6 +34,7 @@ case class StateManager(depositDir: File, submitBase: File, easyHome: URL) exten
 
   /** created/destroyed when the state changes, needed to peek into SUBMITTED/UUID/deposit.properties */
   private val bagIdKey = "bag-store.bag-id"
+  private val depositSourceKey = "deposit.source"
 
   /** Available as side effect for properties not related to fetching or updating the state of the deposit. */
   val draftProps = new PropertiesConfiguration(
@@ -90,10 +91,12 @@ case class StateManager(depositDir: File, submitBase: File, easyHome: URL) exten
         // probably properly saved without toString but getSubmittedBagId would throw
         // ConversionException: 'bag-store.bag-id' doesn't map to a String object
         draftProps.setProperty(bagIdKey, bagStoreBagId.toString)
+        draftProps.setProperty(depositSourceKey, "API")
         saveNewStateInDraftDeposit(newStateInfo)
         Success(())
       case (State.rejected, State.draft) =>
         draftProps.clearProperty(bagIdKey)
+        draftProps.clearProperty(depositSourceKey)
         saveNewStateInDraftDeposit(newStateInfo)
         Success(())
       case (oldState, newState) =>

--- a/src/test/scala/nl.knaw.dans.easy.deposit/DepositDirSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/DepositDirSpec.scala
@@ -75,6 +75,7 @@ class DepositDirSpec extends TestSupportFixture with MockFactory {
           "state.description" -> "Deposit is open for changes.",
           "identifier.dans-doi.action" -> "create",
           "bag-store.bag-name" -> bagDirName,
+          "deposit.origin" -> "API",
         )
     }
   }

--- a/src/test/scala/nl.knaw.dans.easy.deposit/servlets/UploadSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/servlets/UploadSpec.scala
@@ -349,7 +349,8 @@ class UploadSpec extends DepositServletFixture {
     ) {
       absoluteTarget.list.size shouldBe 2
       status shouldBe CONFLICT_409
-      body shouldBe s"The following file(s) already exist on the server: some/3.txt, some/2.txt"
+      val prefix = "The following file(s) already exist on the server:"
+      body should (equal(s"$prefix some/3.txt, some/2.txt".toString) or equal(s"$prefix some/2.txt, some/3.txt".toString))
     }
   }
 


### PR DESCRIPTION
Fixes EASY-2173

#### When applied it will
* add new property `deposit.source` to deposit properties
* gives this property value `API`

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### Related pull requests on github
repo                       | PR                | note
-------------------------- | ----------------- | ----
easy-manage-deposit                      | [PR#54](https://github.com/DANS-KNAW/easy-manage-deposit/pull/54)     | ..
easy-sword2                      | [PR#132](https://github.com/DANS-KNAW/easy-sword2/pull/132)     | ..
easy-split-multi-deposit                      | [PR#138](https://github.com/DANS-KNAW/easy-split-multi-deposit/pull/138)     | ..
easy-specs                     | [PR#82](https://github.com/DANS-KNAW/easy-specs/pull/82)     | ..

