### PR TITLE
EASY-2222 overide stacktrace by ingest-flow with mail-to-dans message

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.deposit/DepositDir.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/DepositDir.scala
@@ -51,7 +51,7 @@ case class DepositDir private(draftBase: File, user: String, id: UUID) extends D
    * @param submitBase the base directory with submitted deposits to extract the actual state
    * @return the `StateManager` for this deposit
    */
-  def getStateManager(submitBase: File, easyHome: URL): Try[StateManager] = Try{
+  def getStateManager(submitBase: File, easyHome: URL): Try[StateManager] = Try {
     StateManager(this, submitBase, easyHome)
   }
 
@@ -72,7 +72,7 @@ case class DepositDir private(draftBase: File, user: String, id: UUID) extends D
       stateInfo.stateDescription,
       created
     )
-  }.recoverWith {
+    }.recoverWith {
     case t: CorruptDepositException => Failure(t)
     case t => corruptDepositFailure(t)
   }

--- a/src/main/scala/nl.knaw.dans.easy.deposit/DepositDir.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/DepositDir.scala
@@ -51,7 +51,7 @@ case class DepositDir private(draftBase: File, user: String, id: UUID) extends D
    * @param submitBase the base directory with submitted deposits to extract the actual state
    * @return the `StateManager` for this deposit
    */
-  def getStateManager(submitBase: File, easyHome: URL): StateManager = {
+  def getStateManager(submitBase: File, easyHome: URL): Try[StateManager] = Try{
     StateManager(this, submitBase, easyHome)
   }
 
@@ -62,7 +62,7 @@ case class DepositDir private(draftBase: File, user: String, id: UUID) extends D
   def getDepositInfo(submitBase: File, easyHome: URL): Try[DepositInfo] = {
     for {
       title <- getDatasetTitle
-      stateManager = getStateManager(submitBase, easyHome)
+      stateManager <- getStateManager(submitBase, easyHome)
       stateInfo <- stateManager.getStateInfo
       created = new DateTime(stateManager.draftProps.getString("creation.timestamp")).withZone(UTC)
     } yield DepositInfo(

--- a/src/main/scala/nl.knaw.dans.easy.deposit/DepositDir.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/DepositDir.scala
@@ -52,7 +52,7 @@ case class DepositDir private(draftBase: File, user: String, id: UUID) extends D
    * @return the `StateManager` for this deposit
    */
   def getStateManager(submitBase: File, easyHome: URL): StateManager = {
-    StateManager(bagDir.parent, submitBase, easyHome)
+    StateManager(this, submitBase, easyHome)
   }
 
   /**

--- a/src/main/scala/nl.knaw.dans.easy.deposit/EasyDepositApiApp.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/EasyDepositApiApp.scala
@@ -149,7 +149,8 @@ class EasyDepositApiApp(configuration: Configuration) extends DebugEnhancedLoggi
   def getDepositState(user: String, id: UUID): Try[StateInfo] = {
     for {
       deposit <- getDeposit(user, id)
-      state <- deposit.getStateManager(submitBase, easyHome).getStateInfo
+      stateManager <- deposit.getStateManager(submitBase, easyHome)
+      state <- stateManager.getStateInfo
     } yield state
   }
 
@@ -184,7 +185,7 @@ class EasyDepositApiApp(configuration: Configuration) extends DebugEnhancedLoggi
 
     for {
       deposit <- getDeposit(user, id)
-      stateManager = deposit.getStateManager(submitBase, easyHome)
+      stateManager <- deposit.getStateManager(submitBase, easyHome)
       _ <- stateManager.canChangeState(newStateInfo)
       _ <- if (newStateInfo.state == State.submitted)
              submit(deposit, stateManager) // also changes the state
@@ -207,7 +208,8 @@ class EasyDepositApiApp(configuration: Configuration) extends DebugEnhancedLoggi
    */
   def deleteDeposit(user: String, id: UUID): Try[Unit] = for {
     deposit <- getDeposit(user, id)
-    state <- deposit.getStateManager(submitBase, easyHome).getStateInfo
+    stateManager <- deposit.getStateManager(submitBase, easyHome)
+    state <- stateManager.getStateInfo
     _ <- state.canDelete
     _ = deposit.bagDir.parent.delete()
   } yield ()

--- a/src/main/scala/nl.knaw.dans.easy.deposit/Errors.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/Errors.scala
@@ -65,7 +65,7 @@ object Errors extends DebugEnhancedLogging {
 
   case class CorruptDepositException(user: String, id: String, cause: Throwable)
     extends ServletResponseException(INTERNAL_SERVER_ERROR_500, s"Invalid deposit uuid $id for user $user: ${ cause.getMessage }") {
-    logger.error(cause.getMessage, cause)
+    logger.error(cause.getMessage)
   }
 
   case class CorruptUserException(msg: String)
@@ -75,7 +75,7 @@ object Errors extends DebugEnhancedLogging {
     extends ServletResponseException(INTERNAL_SERVER_ERROR_500, msg)
 
   case class PropertyNotFoundException(key: String, props: PropertiesConfiguration)
-    extends PropertyException(s"'$key' not found in ${ props.getFile }")
+    extends PropertyException(s"no value for '$key' in ${ Option(props.getFile).getOrElse("not found properties file") }")
 
   case class InvalidPropertyException(key: String, value: String, props: PropertiesConfiguration)
     extends PropertyException(s"Not expected value '$value' for '$key' in ${ props.getFile }")

--- a/src/main/scala/nl.knaw.dans.easy.deposit/StateManager.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/StateManager.scala
@@ -62,9 +62,9 @@ case class StateManager(draftDeposit: DepositDir, submitBase: File, easyHome: UR
           case _ => StateInfo(stateInDraftDeposit, mailToDansMessage)
         }
         case "FAILED" => StateInfo(stateInDraftDeposit, mailToDansMessage)
-        case "IN_REVIEW" => saveNewStateInDraftDeposit(StateInfo(State.inProgress, landingPage("deposit is available")))
+        case "IN_REVIEW" => saveNewStateInDraftDeposit(StateInfo(State.inProgress, landingPage("The deposit is available at")))
         case "FEDORA_ARCHIVED" |
-             "ARCHIVED" => saveNewStateInDraftDeposit(StateInfo(State.archived, landingPage("dataset is published")))
+             "ARCHIVED" => saveNewStateInDraftDeposit(StateInfo(State.archived, landingPage("The dataset is published at")))
         case str =>
           logger.error(InvalidPropertyException(stateLabelKey, str, submittedProps).getMessage)
           StateInfo(stateInDraftDeposit, mailToDansMessage)
@@ -145,11 +145,11 @@ case class StateManager(draftDeposit: DepositDir, submitBase: File, easyHome: UR
     s"""Something went wrong while processing this deposit. Please <a href="mailto:info@dans.knaw.nl?subject=$subject&body=$body">contact DANS</a>"""
   }
 
-  private def landingPage(how: String): String = {
+  private def landingPage(msgStart: String): String = {
     val url = getProp("identifier.fedora", submittedProps)
       .map(id => s"$easyHome/datasets/id/$id")
       .getOrElse(s"$easyHome/mydatasets") // fall back
-    s"""The $how at <a href="$url" target="_blank">$url</a>"""
+    s"""$msgStart <a href="$url" target="_blank">$url</a>"""
   }
 
   private def saveNewStateInDraftDeposit(newStateInfo: StateInfo): StateInfo = {

--- a/src/main/scala/nl.knaw.dans.easy.deposit/StateManager.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/StateManager.scala
@@ -61,7 +61,7 @@ case class StateManager(draftDeposit: DepositDir, submitBase: File, easyHome: UR
           case Success("yes") => saveNewStateInDraftDeposit(StateInfo(State.inProgress, getStateDescription(submittedProps)))
           case _ => StateInfo(stateInDraftDeposit, mailToDansMessage)
         }
-        case Success("FAILED") => StateInfo(State.inProgress, mailToDansMessage)
+        case Success("FAILED") => StateInfo(stateInDraftDeposit, mailToDansMessage)
         case Success("IN_REVIEW") => saveNewStateInDraftDeposit(StateInfo(State.inProgress, landingPage("deposit is available")))
         case Success("FEDORA_ARCHIVED") |
              Success("ARCHIVED") => saveNewStateInDraftDeposit(StateInfo(State.archived, landingPage("dataset is published")))
@@ -70,7 +70,6 @@ case class StateManager(draftDeposit: DepositDir, submitBase: File, easyHome: UR
           StateInfo(stateInDraftDeposit, mailToDansMessage)
         case Failure(e) =>
           logger.error(s"Could not find state of submitted deposit [draft = $relativeDraftDir]: ${ e.getMessage }")
-          // return as we don't want to change anything anymore when we are in such deep trouble
           StateInfo(stateInDraftDeposit, mailToDansMessage)
       }
   }

--- a/src/main/scala/nl.knaw.dans.easy.deposit/StateManager.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/StateManager.scala
@@ -124,19 +124,20 @@ case class StateManager(draftDeposit: DepositDir, submitBase: File, easyHome: UR
       case Success(Some(titles)) => titles.headOption
       case _ => None
     }).getOrElse("").trim()
-    val shortTitle = title.substring(0, Math.min(42, title.length)).replaceAll("[\r\n]+", " ")
-    val mediumTitle = title.substring(0, Math.min(1000, title.length))
+    val shortTitle = title.substring(0, Math.min(42, title.length))
+      .replaceAll("[\r\n]+", " ") // wrap a multiline title into a single line
+      .replaceAll("<.*", "") // avoid html tags in subject and body
     val ref = getSubmittedBagId.map(_.toString).getOrElse(s"DRAFT/$relativeDraftDir")
-    val subject = queryPartEncode(s"$shortTitle (reference: $ref)")
+    val subject = queryPartEncode(s"Deposit processing error: $shortTitle reference $ref")
     val body = queryPartEncode(
       s"""Dear data manager,
          |
-         |Something went wrong while processing my deposit. Could you please look into what went wrong with it?
+         |Something went wrong while processing my deposit. Could you please investigate the issue?
          |
          |It has reference:
          |   $ref
-         |and title:
-         |   $mediumTitle
+         |The title starts with:
+         |   $shortTitle
          |
          |Kind regards,
          |${ draftDeposit.user }

--- a/src/main/scala/nl.knaw.dans.easy.deposit/StateManager.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/StateManager.scala
@@ -125,16 +125,21 @@ case class StateManager(draftDeposit: DepositDir, submitBase: File, easyHome: UR
     val title: String = (draftDeposit.getDatasetMetadata.map(_.titles) match {
       case Success(Some(titles: Seq[String])) => titles.headOption
       case _ => None
-    }).getOrElse("") //.replace("<","&lt").replace(">","&gt")
+    }).getOrElse("").trim()
+    val shortTitle = title.substring(0, Math.min(42, title.length)).replaceAll("[\r\n]+", " ")
+    val mediumTitle = title.substring(0, Math.min(1000, title.length))
     val ref = getSubmittedBagId.map(_.toString).getOrElse(s"DRAFT/$relativeDraftDir")
-    val subject = queryPartEncode(s"${ title.substring(0, Math.min(42, title.length)) } (reference nr: $ref)")
+    val subject = queryPartEncode(s"${ shortTitle } (reference nr: $ref)")
     val body = queryPartEncode(
       s"""Hello
          |
          |Could you please figure out what went wrong with my deposit?
          |
-         |It has title: ${ title.substring(0, Math.min(1000, title.length)) }
-         |and reference: $ref""".stripMargin
+         |It has reference:
+         |   $ref
+         |and title:
+         |   $mediumTitle
+         |""".stripMargin
     )
     s"""Something went wrong while processing this deposit. Please <a href="mailto:info@dans.knaw.nl?subject=$subject&body=$body">contact DANS</a>"""
   }

--- a/src/main/scala/nl.knaw.dans.easy.deposit/StateManager.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/StateManager.scala
@@ -131,7 +131,8 @@ case class StateManager(draftDeposit: DepositDir, submitBase: File, easyHome: UR
     val shortTitle = title.substring(0, Math.min(42, title.length))
       .replaceAll("[\r\n]+", " ") // wrap a multiline title into a single line
       .replaceAll("<.*", "") // avoid html tags in subject and body
-    val ellipsis = if(shortTitle == title) "" else "…"
+    val ellipsis = if (shortTitle == title) ""
+                   else "…"
     val ref = getSubmittedBagId.map(_.toString).getOrElse(s"DRAFT/$relativeDraftDir")
     val subject = queryPartEncode(s"Deposit processing error: $shortTitle$ellipsis reference $ref")
     val body = queryPartEncode(

--- a/src/main/scala/nl.knaw.dans.easy.deposit/StateManager.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/StateManager.scala
@@ -119,6 +119,10 @@ case class StateManager(draftDeposit: DepositDir, submitBase: File, easyHome: UR
     UUID.fromString(draftProps.getString(bagIdKey))
   }
 
+  /**
+   * @return a message that overrides the status message of a technical problem
+   *         in easy-ingest-flow or with the preparation of its input
+   */
   private def mailToDansMessage: String = {
     val title: String = (draftDeposit.getDatasetMetadata.map(_.titles) match {
       case Success(Some(titles)) => titles.headOption

--- a/src/main/scala/nl.knaw.dans.easy.deposit/StateManager.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/StateManager.scala
@@ -131,17 +131,18 @@ case class StateManager(draftDeposit: DepositDir, submitBase: File, easyHome: UR
     val shortTitle = title.substring(0, Math.min(42, title.length))
       .replaceAll("[\r\n]+", " ") // wrap a multiline title into a single line
       .replaceAll("<.*", "") // avoid html tags in subject and body
+    val ellipsis = if(shortTitle == title) "" else "…"
     val ref = getSubmittedBagId.map(_.toString).getOrElse(s"DRAFT/$relativeDraftDir")
-    val subject = queryPartEncode(s"Deposit processing error: $shortTitle reference $ref")
+    val subject = queryPartEncode(s"Deposit processing error: $shortTitle$ellipsis reference $ref")
     val body = queryPartEncode(
       s"""Dear data manager,
          |
          |Something went wrong while processing my deposit. Could you please investigate the issue?
          |
-         |It has reference:
+         |Dataset reference:
          |   $ref
-         |The title starts with:
-         |   $shortTitle
+         |Title:
+         |   $shortTitle$ellipsis
          |
          |Kind regards,
          |${ draftDeposit.user }

--- a/src/main/scala/nl.knaw.dans.easy.deposit/StateManager.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/StateManager.scala
@@ -68,7 +68,7 @@ case class StateManager(draftDeposit: DepositDir, submitBase: File, easyHome: UR
         case str =>
           logger.error(InvalidPropertyException(stateLabelKey, str, submittedProps).getMessage)
           StateInfo(stateInDraftDeposit, mailToDansMessage)
-      }.recoverWith{case e =>
+      }.recoverWith { case e =>
         logger.error(s"Could not find state of submitted deposit [draft = $relativeDraftDir]: ${ e.getMessage }")
         Success(StateInfo(stateInDraftDeposit, mailToDansMessage))
       }
@@ -139,7 +139,7 @@ case class StateManager(draftDeposit: DepositDir, submitBase: File, easyHome: UR
          |   $mediumTitle
          |
          |Kind regards,
-         |${draftDeposit.user}
+         |${ draftDeposit.user }
          |""".stripMargin
     )
     s"""Something went wrong while processing this deposit. Please <a href="mailto:info@dans.knaw.nl?subject=$subject&body=$body">contact DANS</a>"""

--- a/src/test/scala/nl.knaw.dans.easy.deposit/EasyDepositApiAppSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/EasyDepositApiAppSpec.scala
@@ -60,7 +60,7 @@ class EasyDepositApiAppSpec extends TestSupportFixture {
           // then draft deposits
           deposit4,
           // then in-progress deposits
-          deposit5.copy(stateDescription = s"""Something went wrong while processing this deposit. Please <a href="mailto:info@dans.knaw.nl?subject=my-title%20%28reference:%20${ deposit5.id }%29&body=Dear%20data%20manager%2C%0A%0ASomething%20went%20wrong%20while%20processing%20my%20deposit.%20Could%20you%20please%20look%20into%20what%20went%20wrong%20with%20it?%0A%0AIt%20has%20reference:%0A%20%20%20${ deposit5.id }%0Aand%20title:%0A%20%20%20my-title%0A%0AKind%20regards%2C%0Auser001%0A">contact DANS</a>"""),
+          deposit5.copy(stateDescription = s"""Something went wrong while processing this deposit. Please <a href="mailto:info@dans.knaw.nl?subject=Deposit%20processing%20error:%20my-title%20reference%20${ deposit5.id }&body=Dear%20data%20manager%2C%0A%0ASomething%20went%20wrong%20while%20processing%20my%20deposit.%20Could%20you%20please%20investigate%20the%20issue?%0A%0AIt%20has%20reference:%0A%20%20%20${ deposit5.id }%0AThe%20title%20starts%20with:%0A%20%20%20my-title%0A%0AKind%20regards%2C%0Auser001%0A">contact DANS</a>""".stripMargin),
           // and finally archived deposits (newest to oldest)
           deposit6,
           deposit2,

--- a/src/test/scala/nl.knaw.dans.easy.deposit/EasyDepositApiAppSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/EasyDepositApiAppSpec.scala
@@ -60,7 +60,7 @@ class EasyDepositApiAppSpec extends TestSupportFixture {
           // then draft deposits
           deposit4,
           // then in-progress deposits
-          deposit5.copy(stateDescription = s"""Something went wrong while processing this deposit. Please <a href="mailto:info@dans.knaw.nl?subject=my-title%20%28reference%20nr:%20${deposit5.id}%29&body=Hello%0A%0ACould%20you%20please%20figure%20out%20what%20went%20wrong%20with%20my%20deposit?%0A%0AIt%20has%20title:%20my-title%0Aand%20reference:%20${deposit5.id}">contact DANS</a>"""),
+          deposit5.copy(stateDescription = s"""Something went wrong while processing this deposit. Please <a href="mailto:info@dans.knaw.nl?subject=my-title%20%28reference%20nr:%20${deposit5.id}%29&body=Hello%0A%0ACould%20you%20please%20figure%20out%20what%20went%20wrong%20with%20my%20deposit?%0A%0AIt%20has%20reference:%0A%20%20%20${deposit5.id}%0Aand%20title:%0A%20%20%20my-title%0A">contact DANS</a>"""),
           // and finally archived deposits (newest to oldest)
           deposit6,
           deposit2,

--- a/src/test/scala/nl.knaw.dans.easy.deposit/EasyDepositApiAppSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/EasyDepositApiAppSpec.scala
@@ -60,7 +60,7 @@ class EasyDepositApiAppSpec extends TestSupportFixture {
           // then draft deposits
           deposit4,
           // then in-progress deposits
-          deposit5.copy(stateDescription = "The deposit is in progress."),
+          deposit5.copy(stateDescription = s"""Something went wrong while processing this deposit. Please <a href="mailto:info@dans.knaw.nl?subject=my-title%20%28reference%20nr:%20${deposit5.id}%29&body=Hello%0A%0ACould%20you%20please%20figure%20out%20what%20went%20wrong%20with%20my%20deposit?%0A%0AIt%20has%20title:%20my-title%0Aand%20reference:%20${deposit5.id}">contact DANS</a>"""),
           // and finally archived deposits (newest to oldest)
           deposit6,
           deposit2,

--- a/src/test/scala/nl.knaw.dans.easy.deposit/EasyDepositApiAppSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/EasyDepositApiAppSpec.scala
@@ -51,7 +51,11 @@ class EasyDepositApiAppSpec extends TestSupportFixture {
     // copy from draft to submit directory: deposit5's state will be read out of the submit directory
     copyDepositToSubmitArea(deposit5.id)
 
-    inside(app.getDeposits(defaultUser)) {
+    // the state is required for the pattern match but the description is error prone and beyond the scope of the test
+    val expectedState = app.getDepositState(defaultUser,deposit5.id).getOrElse(fail())
+
+    val testResult = app.getDeposits(defaultUser)
+    inside(testResult) {
       case Success(sortedDeposits) =>
         sortedDeposits should contain inOrderOnly(
           // first rejected deposits (newest to oldest)
@@ -60,7 +64,7 @@ class EasyDepositApiAppSpec extends TestSupportFixture {
           // then draft deposits
           deposit4,
           // then in-progress deposits
-          deposit5.copy(stateDescription = s"""Something went wrong while processing this deposit. Please <a href="mailto:info@dans.knaw.nl?subject=Deposit%20processing%20error:%20my-title%20reference%20${ deposit5.id }&body=Dear%20data%20manager%2C%0A%0ASomething%20went%20wrong%20while%20processing%20my%20deposit.%20Could%20you%20please%20investigate%20the%20issue?%0A%0AIt%20has%20reference:%0A%20%20%20${ deposit5.id }%0AThe%20title%20starts%20with:%0A%20%20%20my-title%0A%0AKind%20regards%2C%0Auser001%0A">contact DANS</a>""".stripMargin),
+          deposit5.copy(state = expectedState.state, stateDescription = expectedState.stateDescription),
           // and finally archived deposits (newest to oldest)
           deposit6,
           deposit2,

--- a/src/test/scala/nl.knaw.dans.easy.deposit/EasyDepositApiAppSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/EasyDepositApiAppSpec.scala
@@ -60,7 +60,7 @@ class EasyDepositApiAppSpec extends TestSupportFixture {
           // then draft deposits
           deposit4,
           // then in-progress deposits
-          deposit5.copy(stateDescription = s"""Something went wrong while processing this deposit. Please <a href="mailto:info@dans.knaw.nl?subject=my-title%20%28reference%20nr:%20${deposit5.id}%29&body=Hello%0A%0ACould%20you%20please%20figure%20out%20what%20went%20wrong%20with%20my%20deposit?%0A%0AIt%20has%20reference:%0A%20%20%20${deposit5.id}%0Aand%20title:%0A%20%20%20my-title%0A">contact DANS</a>"""),
+          deposit5.copy(stateDescription = s"""Something went wrong while processing this deposit. Please <a href="mailto:info@dans.knaw.nl?subject=my-title%20%28reference:%20${deposit5.id}%29&body=Dear%20data%20manager%2C%0A%0ASomething%20went%20wrong%20while%20processing%20my%20deposit.%20Could%20you%20please%20look%20into%20what%20went%20wrong%20with%20it?%0A%0AIt%20has%20reference:%0A%20%20%20${deposit5.id}%0Aand%20title:%0A%20%20%20my-title%0A%0AKind%20regards%2C%0Auser001%0A">contact DANS</a>"""),
           // and finally archived deposits (newest to oldest)
           deposit6,
           deposit2,

--- a/src/test/scala/nl.knaw.dans.easy.deposit/EasyDepositApiAppSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/EasyDepositApiAppSpec.scala
@@ -60,7 +60,7 @@ class EasyDepositApiAppSpec extends TestSupportFixture {
           // then draft deposits
           deposit4,
           // then in-progress deposits
-          deposit5.copy(stateDescription = s"""Something went wrong while processing this deposit. Please <a href="mailto:info@dans.knaw.nl?subject=my-title%20%28reference:%20${deposit5.id}%29&body=Dear%20data%20manager%2C%0A%0ASomething%20went%20wrong%20while%20processing%20my%20deposit.%20Could%20you%20please%20look%20into%20what%20went%20wrong%20with%20it?%0A%0AIt%20has%20reference:%0A%20%20%20${deposit5.id}%0Aand%20title:%0A%20%20%20my-title%0A%0AKind%20regards%2C%0Auser001%0A">contact DANS</a>"""),
+          deposit5.copy(stateDescription = s"""Something went wrong while processing this deposit. Please <a href="mailto:info@dans.knaw.nl?subject=my-title%20%28reference:%20${ deposit5.id }%29&body=Dear%20data%20manager%2C%0A%0ASomething%20went%20wrong%20while%20processing%20my%20deposit.%20Could%20you%20please%20look%20into%20what%20went%20wrong%20with%20it?%0A%0AIt%20has%20reference:%0A%20%20%20${ deposit5.id }%0Aand%20title:%0A%20%20%20my-title%0A%0AKind%20regards%2C%0Auser001%0A">contact DANS</a>"""),
           // and finally archived deposits (newest to oldest)
           deposit6,
           deposit2,

--- a/src/test/scala/nl.knaw.dans.easy.deposit/StateManagerSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/StateManagerSpec.scala
@@ -36,6 +36,7 @@ class StateManagerSpec extends TestSupportFixture {
   private val easyHome: URL = new URL("https://easy.dans.knaw.nl/ui")
 
   private def submittedPropsFile: File = (submitBase / submittedUuid.toString).createDirectories() / "deposit.properties"
+
   private def draftPropsFile: File = draftDeposit.bagDir.createDirectories().parent / "deposit.properties"
 
   override def beforeEach(): Unit = {

--- a/src/test/scala/nl.knaw.dans.easy.deposit/StateManagerSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/StateManagerSpec.scala
@@ -28,10 +28,9 @@ import scala.util.{ Failure, Success }
 class StateManagerSpec extends TestSupportFixture {
 
   // need a hard coded value for a pattern match and to manually try the expected mailto href value
-  override lazy val uuid: UUID = UUID.fromString("7fa835ce-0987-4064-90ca-a7b75ce78a16")
   private val draftDeposit: DepositDir = DepositDir(testDir / "draft", "foo", uuid)
 
-  private val submittedUuid = UUID.fromString("a890ad74-872b-4f21-81a8-f3ef88b944ba")
+  private val submittedUuid = UUID.randomUUID
   private val submitBase = testDir / "submitted"
   private val easyHome: URL = new URL("https://easy.dans.knaw.nl/ui")
 
@@ -61,9 +60,12 @@ class StateManagerSpec extends TestSupportFixture {
       s"""state.label = SUBMITTED
          |state.description = The dataset is ready for processing
       """.stripMargin)
-    StateManager(draftDeposit, File("does-not-exist"), easyHome).getStateInfo should matchPattern {
-      case Success(StateInfo(State.submitted, """Something went wrong while processing this deposit. Please <a href="mailto:info@dans.knaw.nl?subject=%20%28reference:%20DRAFT/foo/7fa835ce-0987-4064-90ca-a7b75ce78a16%29&body=Dear%20data%20manager%2C%0A%0ASomething%20went%20wrong%20while%20processing%20my%20deposit.%20Could%20you%20please%20look%20into%20what%20went%20wrong%20with%20it?%0A%0AIt%20has%20reference:%0A%20%20%20DRAFT/foo/7fa835ce-0987-4064-90ca-a7b75ce78a16%0Aand%20title:%0A%20%20%20%0A%0AKind%20regards%2C%0Afoo%0A">contact DANS</a>""")) =>
+    val testResult = StateManager(draftDeposit, File("does-not-exist"), easyHome).getStateInfo
+    testResult should matchPattern {
+      case Success(StateInfo(State.submitted, _)) =>
     }
+    testResult.getOrElse(fail()).stateDescription shouldBe
+      s"""Something went wrong while processing this deposit. Please <a href="mailto:info@dans.knaw.nl?subject=Deposit%20processing%20error:%20%20reference%20DRAFT/foo/$uuid&body=Dear%20data%20manager%2C%0A%0ASomething%20went%20wrong%20while%20processing%20my%20deposit.%20Could%20you%20please%20investigate%20the%20issue?%0A%0AIt%20has%20reference:%0A%20%20%20DRAFT/foo/$uuid%0AThe%20title%20starts%20with:%0A%20%20%20%0A%0AKind%20regards%2C%0Afoo%0A">contact DANS</a>"""
   }
 
   it should "not stumble on missing ingest-flow-inbox state property for state SUBMITTED" in {
@@ -73,9 +75,12 @@ class StateManagerSpec extends TestSupportFixture {
          |state.description = The dataset is ready for processing
          |bag-store.bag-id = $submittedUuid
       """.stripMargin)
-    StateManager(draftDeposit, testDir / "does-not-exist", easyHome).getStateInfo should matchPattern {
-      case Success(StateInfo(State.submitted, """Something went wrong while processing this deposit. Please <a href="mailto:info@dans.knaw.nl?subject=%20%28reference:%20a890ad74-872b-4f21-81a8-f3ef88b944ba%29&body=Dear%20data%20manager%2C%0A%0ASomething%20went%20wrong%20while%20processing%20my%20deposit.%20Could%20you%20please%20look%20into%20what%20went%20wrong%20with%20it?%0A%0AIt%20has%20reference:%0A%20%20%20a890ad74-872b-4f21-81a8-f3ef88b944ba%0Aand%20title:%0A%20%20%20%0A%0AKind%20regards%2C%0Afoo%0A">contact DANS</a>""")) =>
+    val testResult = StateManager(draftDeposit, testDir / "does-not-exist", easyHome).getStateInfo
+    testResult should matchPattern {
+      case Success(StateInfo(State.submitted, _)) =>
     }
+    testResult.getOrElse(fail()).stateDescription shouldBe
+      s"""Something went wrong while processing this deposit. Please <a href="mailto:info@dans.knaw.nl?subject=Deposit%20processing%20error:%20%20reference%20$submittedUuid&body=Dear%20data%20manager%2C%0A%0ASomething%20went%20wrong%20while%20processing%20my%20deposit.%20Could%20you%20please%20investigate%20the%20issue?%0A%0AIt%20has%20reference:%0A%20%20%20$submittedUuid%0AThe%20title%20starts%20with:%0A%20%20%20%0A%0AKind%20regards%2C%0Afoo%0A">contact DANS</a>"""
   }
 
   it should "change SUBMITTED to IN_PROGRESS" in {
@@ -88,9 +93,12 @@ class StateManagerSpec extends TestSupportFixture {
       s"""state.label = IN_REVIEW
          |state.description = rabarbera
       """.stripMargin)
-    StateManager(draftDeposit, submitBase, easyHome).getStateInfo should matchPattern {
-      case Success(StateInfo(State.inProgress, """The deposit is available at <a href="https://easy.dans.knaw.nl/ui/mydatasets" target="_blank">https://easy.dans.knaw.nl/ui/mydatasets</a>""")) =>
+    val testResult = StateManager(draftDeposit, submitBase, easyHome).getStateInfo
+    testResult should matchPattern {
+      case Success(StateInfo(State.inProgress, _)) =>
     }
+    testResult.getOrElse(fail()).stateDescription shouldBe
+      """The deposit is available at <a href="https://easy.dans.knaw.nl/ui/mydatasets" target="_blank">https://easy.dans.knaw.nl/ui/mydatasets</a>"""
   }
 
   it should "return the fedora landing page" in {
@@ -105,9 +113,12 @@ class StateManagerSpec extends TestSupportFixture {
          |state.description = rabarbera
          |identifier.fedora = easy-dataset:1239
       """.stripMargin)
-    StateManager(draftDeposit, submitBase, easyHome).getStateInfo should matchPattern {
-      case Success(StateInfo(State.inProgress, """The deposit is available at <a href="https://easy.dans.knaw.nl/ui/datasets/id/easy-dataset:1239" target="_blank">https://easy.dans.knaw.nl/ui/datasets/id/easy-dataset:1239</a>""")) =>
+    val testResult = StateManager(draftDeposit, submitBase, easyHome).getStateInfo
+    testResult should matchPattern {
+      case Success(StateInfo(State.inProgress, _)) =>
     }
+    testResult.getOrElse(fail()).stateDescription shouldBe
+      """The deposit is available at <a href="https://easy.dans.knaw.nl/ui/datasets/id/easy-dataset:1239" target="_blank">https://easy.dans.knaw.nl/ui/datasets/id/easy-dataset:1239</a>"""
   }
 
   it should "mail the draft uuid" in {
@@ -121,9 +132,14 @@ class StateManagerSpec extends TestSupportFixture {
          |state.description = rabarbera
          |identifier.fedora = easy-dataset:1239
       """.stripMargin)
-    StateManager(draftDeposit, submitBase, easyHome).getStateInfo should matchPattern {
-      case Success(StateInfo(State.submitted, """Something went wrong while processing this deposit. Please <a href="mailto:info@dans.knaw.nl?subject=%20%28reference:%20DRAFT/foo/7fa835ce-0987-4064-90ca-a7b75ce78a16%29&body=Dear%20data%20manager%2C%0A%0ASomething%20went%20wrong%20while%20processing%20my%20deposit.%20Could%20you%20please%20look%20into%20what%20went%20wrong%20with%20it?%0A%0AIt%20has%20reference:%0A%20%20%20DRAFT/foo/7fa835ce-0987-4064-90ca-a7b75ce78a16%0Aand%20title:%0A%20%20%20%0A%0AKind%20regards%2C%0Afoo%0A">contact DANS</a>""")) =>
+    ((draftDeposit.bagDir / "metadata").createDirectories() / "dataset.json")
+      .write("""{"titles":["A test with a title longer than forty-two characters."]}""")
+    val testResult = StateManager(draftDeposit, submitBase, easyHome).getStateInfo
+    testResult should matchPattern {
+      case Success(StateInfo(State.submitted, _)) =>
     }
+    testResult.getOrElse(fail()).stateDescription shouldBe
+      s"""Something went wrong while processing this deposit. Please <a href="mailto:info@dans.knaw.nl?subject=Deposit%20processing%20error:%20A%20test%20with%20a%20title%20longer%20than%20forty-two%20%20reference%20DRAFT/foo/$uuid&body=Dear%20data%20manager%2C%0A%0ASomething%20went%20wrong%20while%20processing%20my%20deposit.%20Could%20you%20please%20investigate%20the%20issue?%0A%0AIt%20has%20reference:%0A%20%20%20DRAFT/foo/$uuid%0AThe%20title%20starts%20with:%0A%20%20%20A%20test%20with%20a%20title%20longer%20than%20forty-two%20%0A%0AKind%20regards%2C%0Afoo%0A">contact DANS</a>"""
   }
 
   it should "mail the submitted uuid" in {
@@ -139,35 +155,16 @@ class StateManagerSpec extends TestSupportFixture {
     ((draftDeposit.bagDir / "metadata").createDirectories() / "dataset.json")
       .write(
         """{"titles":["
-          | A complete ground hog <a href='mailto:info@dans.knaw.nl'>weather</a> report
-          | is a way too long title for the mail to dans message.
+          | A test with
+          | new lines and html <a href='http://user.hack.dans.knaw.nl'>link</a>.
           |
-          | Lorem ipsum dolor sit amet, consectetur adipiscing elit,
-          | sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
-          | Dolor sed viverra ipsum nunc aliquet bibendum enim.
-          | In massa tempor nec feugiat. Nunc aliquet bibendum enim facilisis gravida.
-          | Nisl nunc mi ipsum faucibus vitae aliquet nec ullamcorper.
-          | Amet luctus venenatis lectus magna fringilla.
-          | Volutpat maecenas volutpat blandit aliquam etiam erat velit scelerisque in.
-          | Egestas egestas fringilla phasellus faucibus scelerisque eleifend.
-          | Sagittis orci a scelerisque purus semper eget duis.
-          | Nulla pharetra diam sit amet nisl suscipit.
-          | Sed adipiscing diam donec adipiscing tristique risus nec feugiat in.
-          | Fusce ut placerat orci nulla. Pharetra vel turpis nunc eget lorem dolor.
-          | Tristique senectus et netus et malesuada.
-          | Etiam tempor orci eu lobortis elementum nibh tellus molestie.
-          | Neque egestas congue quisque egestas.
-          | Egestas integer eget aliquet nibh praesent tristique.
-          | Vulputate mi sit amet mauris. Sodales neque sodales ut etiam sit.
-          | Dignissim suspendisse in est ante in. Volutpat commodo sed egestas egestas.
-          | Felis donec et odio pellentesque diam. Pharetra vel turpis nunc eget lorem dolor sed viverra.
-          | Porta nibh venenatis cras sed felis eget. Aliquam ultrices sagittis orci a.
-          | Dignissim diam quis enim lobortis. Aliquet porttitor lacus luctus accumsan.
-          | Dignissim convallis aenean et tortor at risus viverra adipiscing at.
           | "]}""".stripMargin)
-    StateManager(draftDeposit, submitBase, easyHome).getStateInfo should matchPattern {
-      case Success(StateInfo(State.submitted, """Something went wrong while processing this deposit. Please <a href="mailto:info@dans.knaw.nl?subject=A%20complete%20ground%20hog%20%3Ca%20href%3D%27mailto:info%20%28reference:%20a890ad74-872b-4f21-81a8-f3ef88b944ba%29&body=Dear%20data%20manager%2C%0A%0ASomething%20went%20wrong%20while%20processing%20my%20deposit.%20Could%20you%20please%20look%20into%20what%20went%20wrong%20with%20it?%0A%0AIt%20has%20reference:%0A%20%20%20a890ad74-872b-4f21-81a8-f3ef88b944ba%0Aand%20title:%0A%20%20%20A%20complete%20ground%20hog%20%3Ca%20href%3D%27mailto:info@dans.knaw.nl%27%3Eweather%3C/a%3E%20report%0A%20is%20a%20way%20too%20long%20title%20for%20the%20mail%20to%20dans%20message.%0A%0A%20Lorem%20ipsum%20dolor%20sit%20amet%2C%20consectetur%20adipiscing%20elit%2C%0A%20sed%20do%20eiusmod%20tempor%20incididunt%20ut%20labore%20et%20dolore%20magna%20aliqua.%0A%20Dolor%20sed%20viverra%20ipsum%20nunc%20aliquet%20bibendum%20enim.%0A%20In%20massa%20tempor%20nec%20feugiat.%20Nunc%20aliquet%20bibendum%20enim%20facilisis%20gravida.%0A%20Nisl%20nunc%20mi%20ipsum%20faucibus%20vitae%20aliquet%20nec%20ullamcorper.%0A%20Amet%20luctus%20venenatis%20lectus%20magna%20fringilla.%0A%20Volutpat%20maecenas%20volutpat%20blandit%20aliquam%20etiam%20erat%20velit%20scelerisque%20in.%0A%20Egestas%20egestas%20fringilla%20phasellus%20faucibus%20scelerisque%20eleifend.%0A%20Sagittis%20orci%20a%20scelerisque%20purus%20semper%20eget%20duis.%0A%20Nulla%20pharetra%20diam%20sit%20amet%20nisl%20suscipit.%0A%20Sed%20adipiscing%20diam%20donec%20adipiscing%20tristique%20risus%20nec%20feugiat%20in.%0A%20Fusce%20ut%20placerat%20orci%20nulla.%20Pharetra%20vel%20turpis%20nunc%20eget%20lorem%20dolor.%0A%20Tristique%20senectus%20et%20netus%20et%20malesuada.%0A%20Etiam%20tempor%20orci%20eu%20lobortis%20elementum%20nibh%20tellus%20molestie.%0A%20Neque%20egesta%0A%0AKind%20regards%2C%0Afoo%0A">contact DANS</a>""")) =>
+    val testResult = StateManager(draftDeposit, submitBase, easyHome).getStateInfo
+    testResult should matchPattern {
+      case Success(StateInfo(State.submitted, _)) =>
     }
+    testResult.getOrElse(fail()).stateDescription shouldBe
+      s"""Something went wrong while processing this deposit. Please <a href="mailto:info@dans.knaw.nl?subject=Deposit%20processing%20error:%20A%20test%20with%20%20new%20lines%20and%20html%20%20reference%20$submittedUuid&body=Dear%20data%20manager%2C%0A%0ASomething%20went%20wrong%20while%20processing%20my%20deposit.%20Could%20you%20please%20investigate%20the%20issue?%0A%0AIt%20has%20reference:%0A%20%20%20$submittedUuid%0AThe%20title%20starts%20with:%0A%20%20%20A%20test%20with%20%20new%20lines%20and%20html%20%0A%0AKind%20regards%2C%0Afoo%0A">contact DANS</a>"""
   }
 
   it should "return the curators message" in {
@@ -197,9 +194,12 @@ class StateManagerSpec extends TestSupportFixture {
       s"""state.label = FEDORA_ARCHIVED
          |state.description = rabarbeara
       """.stripMargin)
-    StateManager(draftDeposit, submitBase, easyHome).getStateInfo should matchPattern {
-      case Success(StateInfo(State.archived, """The dataset is published at <a href="https://easy.dans.knaw.nl/ui/mydatasets" target="_blank">https://easy.dans.knaw.nl/ui/mydatasets</a>""")) =>
+    val testResult = StateManager(draftDeposit, submitBase, easyHome).getStateInfo
+    testResult should matchPattern {
+      case Success(StateInfo(State.archived, _)) =>
     }
+    testResult.getOrElse(fail()).stateDescription shouldBe
+      """The dataset is published at <a href="https://easy.dans.knaw.nl/ui/mydatasets" target="_blank">https://easy.dans.knaw.nl/ui/mydatasets</a>"""
   }
 
   "setStateInfo" should "result in Success when transitioning from DRAFT to SUBMITTED" in {

--- a/src/test/scala/nl.knaw.dans.easy.deposit/StateManagerSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/StateManagerSpec.scala
@@ -61,7 +61,7 @@ class StateManagerSpec extends TestSupportFixture {
          |state.description = The dataset is ready for processing
       """.stripMargin)
     StateManager(draftDeposit, File("does-not-exist"), easyHome).getStateInfo should matchPattern {
-      case Success(StateInfo(State.submitted, """Something went wrong while processing this deposit. Please <a href="mailto:info@dans.knaw.nl?subject=%20%28reference%20nr:%20DRAFT/foo/7fa835ce-0987-4064-90ca-a7b75ce78a16%29&body=Hello%0A%0ACould%20you%20please%20figure%20out%20what%20went%20wrong%20with%20my%20deposit?%0A%0AIt%20has%20reference:%0A%20%20%20DRAFT/foo/7fa835ce-0987-4064-90ca-a7b75ce78a16%0Aand%20title:%0A%20%20%20%0A">contact DANS</a>""")) =>
+      case Success(StateInfo(State.submitted, """Something went wrong while processing this deposit. Please <a href="mailto:info@dans.knaw.nl?subject=%20%28reference:%20DRAFT/foo/7fa835ce-0987-4064-90ca-a7b75ce78a16%29&body=Dear%20data%20manager%2C%0A%0ASomething%20went%20wrong%20while%20processing%20my%20deposit.%20Could%20you%20please%20look%20into%20what%20went%20wrong%20with%20it?%0A%0AIt%20has%20reference:%0A%20%20%20DRAFT/foo/7fa835ce-0987-4064-90ca-a7b75ce78a16%0Aand%20title:%0A%20%20%20%0A%0AKind%20regards%2C%0Afoo%0A">contact DANS</a>""")) =>
     }
   }
 
@@ -73,7 +73,7 @@ class StateManagerSpec extends TestSupportFixture {
          |bag-store.bag-id = $submittedUuid
       """.stripMargin)
     StateManager(draftDeposit, testDir / "does-not-exist", easyHome).getStateInfo should matchPattern {
-      case Success(StateInfo(State.submitted, """Something went wrong while processing this deposit. Please <a href="mailto:info@dans.knaw.nl?subject=%20%28reference%20nr:%20a890ad74-872b-4f21-81a8-f3ef88b944ba%29&body=Hello%0A%0ACould%20you%20please%20figure%20out%20what%20went%20wrong%20with%20my%20deposit?%0A%0AIt%20has%20reference:%0A%20%20%20a890ad74-872b-4f21-81a8-f3ef88b944ba%0Aand%20title:%0A%20%20%20%0A">contact DANS</a>""")) =>
+      case Success(StateInfo(State.submitted, """Something went wrong while processing this deposit. Please <a href="mailto:info@dans.knaw.nl?subject=%20%28reference:%20a890ad74-872b-4f21-81a8-f3ef88b944ba%29&body=Dear%20data%20manager%2C%0A%0ASomething%20went%20wrong%20while%20processing%20my%20deposit.%20Could%20you%20please%20look%20into%20what%20went%20wrong%20with%20it?%0A%0AIt%20has%20reference:%0A%20%20%20a890ad74-872b-4f21-81a8-f3ef88b944ba%0Aand%20title:%0A%20%20%20%0A%0AKind%20regards%2C%0Afoo%0A">contact DANS</a>""")) =>
     }
   }
 
@@ -121,7 +121,7 @@ class StateManagerSpec extends TestSupportFixture {
          |identifier.fedora = easy-dataset:1239
       """.stripMargin)
     StateManager(draftDeposit, submitBase, easyHome).getStateInfo should matchPattern {
-      case Success(StateInfo(State.submitted, """Something went wrong while processing this deposit. Please <a href="mailto:info@dans.knaw.nl?subject=%20%28reference%20nr:%20DRAFT/foo/7fa835ce-0987-4064-90ca-a7b75ce78a16%29&body=Hello%0A%0ACould%20you%20please%20figure%20out%20what%20went%20wrong%20with%20my%20deposit?%0A%0AIt%20has%20reference:%0A%20%20%20DRAFT/foo/7fa835ce-0987-4064-90ca-a7b75ce78a16%0Aand%20title:%0A%20%20%20%0A">contact DANS</a>""")) =>
+      case Success(StateInfo(State.submitted, """Something went wrong while processing this deposit. Please <a href="mailto:info@dans.knaw.nl?subject=%20%28reference:%20DRAFT/foo/7fa835ce-0987-4064-90ca-a7b75ce78a16%29&body=Dear%20data%20manager%2C%0A%0ASomething%20went%20wrong%20while%20processing%20my%20deposit.%20Could%20you%20please%20look%20into%20what%20went%20wrong%20with%20it?%0A%0AIt%20has%20reference:%0A%20%20%20DRAFT/foo/7fa835ce-0987-4064-90ca-a7b75ce78a16%0Aand%20title:%0A%20%20%20%0A%0AKind%20regards%2C%0Afoo%0A">contact DANS</a>""")) =>
     }
   }
 
@@ -165,7 +165,7 @@ class StateManagerSpec extends TestSupportFixture {
           | Dignissim convallis aenean et tortor at risus viverra adipiscing at.
           | "]}""".stripMargin)
     StateManager(draftDeposit, submitBase, easyHome).getStateInfo should matchPattern {
-      case Success(StateInfo(State.submitted, """Something went wrong while processing this deposit. Please <a href="mailto:info@dans.knaw.nl?subject=A%20complete%20ground%20hog%20%3Ca%20href%3D%27mailto:info%20%28reference%20nr:%20a890ad74-872b-4f21-81a8-f3ef88b944ba%29&body=Hello%0A%0ACould%20you%20please%20figure%20out%20what%20went%20wrong%20with%20my%20deposit?%0A%0AIt%20has%20reference:%0A%20%20%20a890ad74-872b-4f21-81a8-f3ef88b944ba%0Aand%20title:%0A%20%20%20A%20complete%20ground%20hog%20%3Ca%20href%3D%27mailto:info@dans.knaw.nl%27%3Eweather%3C/a%3E%20report%0A%20is%20a%20way%20too%20long%20title%20for%20the%20mail%20to%20dans%20message.%0A%0A%20Lorem%20ipsum%20dolor%20sit%20amet%2C%20consectetur%20adipiscing%20elit%2C%0A%20sed%20do%20eiusmod%20tempor%20incididunt%20ut%20labore%20et%20dolore%20magna%20aliqua.%0A%20Dolor%20sed%20viverra%20ipsum%20nunc%20aliquet%20bibendum%20enim.%0A%20In%20massa%20tempor%20nec%20feugiat.%20Nunc%20aliquet%20bibendum%20enim%20facilisis%20gravida.%0A%20Nisl%20nunc%20mi%20ipsum%20faucibus%20vitae%20aliquet%20nec%20ullamcorper.%0A%20Amet%20luctus%20venenatis%20lectus%20magna%20fringilla.%0A%20Volutpat%20maecenas%20volutpat%20blandit%20aliquam%20etiam%20erat%20velit%20scelerisque%20in.%0A%20Egestas%20egestas%20fringilla%20phasellus%20faucibus%20scelerisque%20eleifend.%0A%20Sagittis%20orci%20a%20scelerisque%20purus%20semper%20eget%20duis.%0A%20Nulla%20pharetra%20diam%20sit%20amet%20nisl%20suscipit.%0A%20Sed%20adipiscing%20diam%20donec%20adipiscing%20tristique%20risus%20nec%20feugiat%20in.%0A%20Fusce%20ut%20placerat%20orci%20nulla.%20Pharetra%20vel%20turpis%20nunc%20eget%20lorem%20dolor.%0A%20Tristique%20senectus%20et%20netus%20et%20malesuada.%0A%20Etiam%20tempor%20orci%20eu%20lobortis%20elementum%20nibh%20tellus%20molestie.%0A%20Neque%20egesta%0A">contact DANS</a>""")) =>
+      case Success(StateInfo(State.submitted, """Something went wrong while processing this deposit. Please <a href="mailto:info@dans.knaw.nl?subject=A%20complete%20ground%20hog%20%3Ca%20href%3D%27mailto:info%20%28reference:%20a890ad74-872b-4f21-81a8-f3ef88b944ba%29&body=Dear%20data%20manager%2C%0A%0ASomething%20went%20wrong%20while%20processing%20my%20deposit.%20Could%20you%20please%20look%20into%20what%20went%20wrong%20with%20it?%0A%0AIt%20has%20reference:%0A%20%20%20a890ad74-872b-4f21-81a8-f3ef88b944ba%0Aand%20title:%0A%20%20%20A%20complete%20ground%20hog%20%3Ca%20href%3D%27mailto:info@dans.knaw.nl%27%3Eweather%3C/a%3E%20report%0A%20is%20a%20way%20too%20long%20title%20for%20the%20mail%20to%20dans%20message.%0A%0A%20Lorem%20ipsum%20dolor%20sit%20amet%2C%20consectetur%20adipiscing%20elit%2C%0A%20sed%20do%20eiusmod%20tempor%20incididunt%20ut%20labore%20et%20dolore%20magna%20aliqua.%0A%20Dolor%20sed%20viverra%20ipsum%20nunc%20aliquet%20bibendum%20enim.%0A%20In%20massa%20tempor%20nec%20feugiat.%20Nunc%20aliquet%20bibendum%20enim%20facilisis%20gravida.%0A%20Nisl%20nunc%20mi%20ipsum%20faucibus%20vitae%20aliquet%20nec%20ullamcorper.%0A%20Amet%20luctus%20venenatis%20lectus%20magna%20fringilla.%0A%20Volutpat%20maecenas%20volutpat%20blandit%20aliquam%20etiam%20erat%20velit%20scelerisque%20in.%0A%20Egestas%20egestas%20fringilla%20phasellus%20faucibus%20scelerisque%20eleifend.%0A%20Sagittis%20orci%20a%20scelerisque%20purus%20semper%20eget%20duis.%0A%20Nulla%20pharetra%20diam%20sit%20amet%20nisl%20suscipit.%0A%20Sed%20adipiscing%20diam%20donec%20adipiscing%20tristique%20risus%20nec%20feugiat%20in.%0A%20Fusce%20ut%20placerat%20orci%20nulla.%20Pharetra%20vel%20turpis%20nunc%20eget%20lorem%20dolor.%0A%20Tristique%20senectus%20et%20netus%20et%20malesuada.%0A%20Etiam%20tempor%20orci%20eu%20lobortis%20elementum%20nibh%20tellus%20molestie.%0A%20Neque%20egesta%0A%0AKind%20regards%2C%0Afoo%0A">contact DANS</a>""")) =>
     }
   }
 
@@ -181,7 +181,7 @@ class StateManagerSpec extends TestSupportFixture {
          |state.description = rabarbera
       """.stripMargin)
     StateManager(draftDeposit, submitBase, easyHome).getStateInfo should matchPattern {
-      case Success(StateInfo(State.inProgress, """rabarbera""")) =>
+      case Success(StateInfo(State.rejected, """rabarbera""")) =>
     }
   }
 

--- a/src/test/scala/nl.knaw.dans.easy.deposit/StateManagerSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/StateManagerSpec.scala
@@ -109,7 +109,7 @@ class StateManagerSpec extends TestSupportFixture {
     }
   }
 
-  it should "mail the submitted uuid" in {
+  it should "mail the draft uuid" in {
     draftPropsFile.writeText(
       s"""state.label = SUBMITTED
          |state.description = The deposit is ready for processing
@@ -125,7 +125,7 @@ class StateManagerSpec extends TestSupportFixture {
     }
   }
 
-  it should "mail the draft uuid" in {
+  it should "mail the submitted uuid" in {
     draftPropsFile.writeText(
       s"""state.label = SUBMITTED
          |state.description = The deposit is ready for processing
@@ -136,9 +136,36 @@ class StateManagerSpec extends TestSupportFixture {
          |curation.performed = no
       """.stripMargin)
     ((draftDeposit.bagDir / "metadata").createDirectories() / "dataset.json")
-      .write("""{"titles":["Ground hog weather report"]}""")
+      .write(
+        """{"titles":["
+          | A complete ground hog <a href='mailto:info@dans.knaw.nl'>weather</a> report
+          | is a way too long title for the mail to dans message.
+          |
+          | Lorem ipsum dolor sit amet, consectetur adipiscing elit,
+          | sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+          | Dolor sed viverra ipsum nunc aliquet bibendum enim.
+          | In massa tempor nec feugiat. Nunc aliquet bibendum enim facilisis gravida.
+          | Nisl nunc mi ipsum faucibus vitae aliquet nec ullamcorper.
+          | Amet luctus venenatis lectus magna fringilla.
+          | Volutpat maecenas volutpat blandit aliquam etiam erat velit scelerisque in.
+          | Egestas egestas fringilla phasellus faucibus scelerisque eleifend.
+          | Sagittis orci a scelerisque purus semper eget duis.
+          | Nulla pharetra diam sit amet nisl suscipit.
+          | Sed adipiscing diam donec adipiscing tristique risus nec feugiat in.
+          | Fusce ut placerat orci nulla. Pharetra vel turpis nunc eget lorem dolor.
+          | Tristique senectus et netus et malesuada.
+          | Etiam tempor orci eu lobortis elementum nibh tellus molestie.
+          | Neque egestas congue quisque egestas.
+          | Egestas integer eget aliquet nibh praesent tristique.
+          | Vulputate mi sit amet mauris. Sodales neque sodales ut etiam sit.
+          | Dignissim suspendisse in est ante in. Volutpat commodo sed egestas egestas.
+          | Felis donec et odio pellentesque diam. Pharetra vel turpis nunc eget lorem dolor sed viverra.
+          | Porta nibh venenatis cras sed felis eget. Aliquam ultrices sagittis orci a.
+          | Dignissim diam quis enim lobortis. Aliquet porttitor lacus luctus accumsan.
+          | Dignissim convallis aenean et tortor at risus viverra adipiscing at.
+          | "]}""".stripMargin)
     StateManager(draftDeposit, submitBase, easyHome).getStateInfo should matchPattern {
-      case Success(StateInfo(State.submitted, """Something went wrong while processing this deposit. Please <a href="mailto:info@dans.knaw.nl?subject=Ground%20hog%20weather%20report%20%28reference%20nr:%20a890ad74-872b-4f21-81a8-f3ef88b944ba%29&body=Hello%0A%0ACould%20you%20please%20figure%20out%20what%20went%20wrong%20with%20my%20deposit?%0A%0AIt%20has%20title:%20Ground%20hog%20weather%20report%0Aand%20reference:%20a890ad74-872b-4f21-81a8-f3ef88b944ba">contact DANS</a>""")) =>
+      case Success(StateInfo(State.submitted, """Something went wrong while processing this deposit. Please <a href="mailto:info@dans.knaw.nl?subject=A%20complete%20ground%20hog%20%3Ca%20href%3D%27mailto:info%20%28reference%20nr:%20a890ad74-872b-4f21-81a8-f3ef88b944ba%29&body=Hello%0A%0ACould%20you%20please%20figure%20out%20what%20went%20wrong%20with%20my%20deposit?%0A%0AIt%20has%20reference:%0A%20%20%20a890ad74-872b-4f21-81a8-f3ef88b944ba%0Aand%20title:%0A%20%20%20A%20complete%20ground%20hog%20%3Ca%20href%3D%27mailto:info@dans.knaw.nl%27%3Eweather%3C/a%3E%20report%0A%20is%20a%20way%20too%20long%20title%20for%20the%20mail%20to%20dans%20message.%0A%0A%20Lorem%20ipsum%20dolor%20sit%20amet%2C%20consectetur%20adipiscing%20elit%2C%0A%20sed%20do%20eiusmod%20tempor%20incididunt%20ut%20labore%20et%20dolore%20magna%20aliqua.%0A%20Dolor%20sed%20viverra%20ipsum%20nunc%20aliquet%20bibendum%20enim.%0A%20In%20massa%20tempor%20nec%20feugiat.%20Nunc%20aliquet%20bibendum%20enim%20facilisis%20gravida.%0A%20Nisl%20nunc%20mi%20ipsum%20faucibus%20vitae%20aliquet%20nec%20ullamcorper.%0A%20Amet%20luctus%20venenatis%20lectus%20magna%20fringilla.%0A%20Volutpat%20maecenas%20volutpat%20blandit%20aliquam%20etiam%20erat%20velit%20scelerisque%20in.%0A%20Egestas%20egestas%20fringilla%20phasellus%20faucibus%20scelerisque%20eleifend.%0A%20Sagittis%20orci%20a%20scelerisque%20purus%20semper%20eget%20duis.%0A%20Nulla%20pharetra%20diam%20sit%20amet%20nisl%20suscipit.%0A%20Sed%20adipiscing%20diam%20donec%20adipiscing%20tristique%20risus%20nec%20feugiat%20in.%0A%20Fusce%20ut%20placerat%20orci%20nulla.%20Pharetra%20vel%20turpis%20nunc%20eget%20lorem%20dolor.%0A%20Tristique%20senectus%20et%20netus%20et%20malesuada.%0A%20Etiam%20tempor%20orci%20eu%20lobortis%20elementum%20nibh%20tellus%20molestie.%0A%20Neque%20egesta%0A">contact DANS</a>""")) =>
     }
   }
 

--- a/src/test/scala/nl.knaw.dans.easy.deposit/StateManagerSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/StateManagerSpec.scala
@@ -138,7 +138,7 @@ class StateManagerSpec extends TestSupportFixture {
     ((draftDeposit.bagDir / "metadata").createDirectories() / "dataset.json")
       .write("""{"titles":["Ground hog weather report"]}""")
     StateManager(draftDeposit, submitBase, easyHome).getStateInfo should matchPattern {
-      case Success(StateInfo(State.inProgress, """Something went wrong while processing this deposit. Please <a href="mailto:info@dans.knaw.nl?subject=Ground%20hog%20weather%20report%20%28reference%20nr:%20a890ad74-872b-4f21-81a8-f3ef88b944ba%29&body=Hello%0A%0ACould%20you%20please%20figure%20out%20what%20went%20wrong%20with%20my%20deposit?%0A%0AIt%20has%20title:%20Ground%20hog%20weather%20report%0Aand%20reference:%20a890ad74-872b-4f21-81a8-f3ef88b944ba">contact DANS</a>""")) =>
+      case Success(StateInfo(State.submitted, """Something went wrong while processing this deposit. Please <a href="mailto:info@dans.knaw.nl?subject=Ground%20hog%20weather%20report%20%28reference%20nr:%20a890ad74-872b-4f21-81a8-f3ef88b944ba%29&body=Hello%0A%0ACould%20you%20please%20figure%20out%20what%20went%20wrong%20with%20my%20deposit?%0A%0AIt%20has%20title:%20Ground%20hog%20weather%20report%0Aand%20reference:%20a890ad74-872b-4f21-81a8-f3ef88b944ba">contact DANS</a>""")) =>
     }
   }
 

--- a/src/test/scala/nl.knaw.dans.easy.deposit/StateManagerSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/StateManagerSpec.scala
@@ -61,7 +61,7 @@ class StateManagerSpec extends TestSupportFixture {
          |state.description = The dataset is ready for processing
       """.stripMargin)
     StateManager(draftDeposit, File("does-not-exist"), easyHome).getStateInfo should matchPattern {
-      case Success(StateInfo(State.submitted, """Something went wrong while processing this deposit. Please <a href="mailto:info@dans.knaw.nl?subject=%20%28reference%20nr:%20DRAFT/foo/7fa835ce-0987-4064-90ca-a7b75ce78a16%29&body=Hello%0A%0ACould%20you%20please%20figure%20out%20what%20went%20wrong%20with%20my%20deposit?%0A%0AIt%20has%20title:%20%0Aand%20reference:%20DRAFT/foo/7fa835ce-0987-4064-90ca-a7b75ce78a16">contact DANS</a>""")) =>
+      case Success(StateInfo(State.submitted, """Something went wrong while processing this deposit. Please <a href="mailto:info@dans.knaw.nl?subject=%20%28reference%20nr:%20DRAFT/foo/7fa835ce-0987-4064-90ca-a7b75ce78a16%29&body=Hello%0A%0ACould%20you%20please%20figure%20out%20what%20went%20wrong%20with%20my%20deposit?%0A%0AIt%20has%20reference:%0A%20%20%20DRAFT/foo/7fa835ce-0987-4064-90ca-a7b75ce78a16%0Aand%20title:%0A%20%20%20%0A">contact DANS</a>""")) =>
     }
   }
 
@@ -73,7 +73,7 @@ class StateManagerSpec extends TestSupportFixture {
          |bag-store.bag-id = $submittedUuid
       """.stripMargin)
     StateManager(draftDeposit, testDir / "does-not-exist", easyHome).getStateInfo should matchPattern {
-      case Success(StateInfo(State.submitted, """Something went wrong while processing this deposit. Please <a href="mailto:info@dans.knaw.nl?subject=%20%28reference%20nr:%20a890ad74-872b-4f21-81a8-f3ef88b944ba%29&body=Hello%0A%0ACould%20you%20please%20figure%20out%20what%20went%20wrong%20with%20my%20deposit?%0A%0AIt%20has%20title:%20%0Aand%20reference:%20a890ad74-872b-4f21-81a8-f3ef88b944ba">contact DANS</a>""")) =>
+      case Success(StateInfo(State.submitted, """Something went wrong while processing this deposit. Please <a href="mailto:info@dans.knaw.nl?subject=%20%28reference%20nr:%20a890ad74-872b-4f21-81a8-f3ef88b944ba%29&body=Hello%0A%0ACould%20you%20please%20figure%20out%20what%20went%20wrong%20with%20my%20deposit?%0A%0AIt%20has%20reference:%0A%20%20%20a890ad74-872b-4f21-81a8-f3ef88b944ba%0Aand%20title:%0A%20%20%20%0A">contact DANS</a>""")) =>
     }
   }
 
@@ -121,7 +121,7 @@ class StateManagerSpec extends TestSupportFixture {
          |identifier.fedora = easy-dataset:1239
       """.stripMargin)
     StateManager(draftDeposit, submitBase, easyHome).getStateInfo should matchPattern {
-      case Success(StateInfo(State.submitted, """Something went wrong while processing this deposit. Please <a href="mailto:info@dans.knaw.nl?subject=%20%28reference%20nr:%20DRAFT/foo/7fa835ce-0987-4064-90ca-a7b75ce78a16%29&body=Hello%0A%0ACould%20you%20please%20figure%20out%20what%20went%20wrong%20with%20my%20deposit?%0A%0AIt%20has%20title:%20%0Aand%20reference:%20DRAFT/foo/7fa835ce-0987-4064-90ca-a7b75ce78a16">contact DANS</a>""")) =>
+      case Success(StateInfo(State.submitted, """Something went wrong while processing this deposit. Please <a href="mailto:info@dans.knaw.nl?subject=%20%28reference%20nr:%20DRAFT/foo/7fa835ce-0987-4064-90ca-a7b75ce78a16%29&body=Hello%0A%0ACould%20you%20please%20figure%20out%20what%20went%20wrong%20with%20my%20deposit?%0A%0AIt%20has%20reference:%0A%20%20%20DRAFT/foo/7fa835ce-0987-4064-90ca-a7b75ce78a16%0Aand%20title:%0A%20%20%20%0A">contact DANS</a>""")) =>
     }
   }
 

--- a/src/test/scala/nl.knaw.dans.easy.deposit/StateManagerSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/StateManagerSpec.scala
@@ -63,7 +63,7 @@ class StateManagerSpec extends TestSupportFixture {
       """.stripMargin)
     checkMailtoMessage(
       testResult = StateManager(draftDeposit, File("does-not-exist"), easyHome).getStateInfo,
-      expectedURL = s"""mailto:info@dans.knaw.nl?subject=Deposit%20processing%20error:%20%20reference%20DRAFT/foo/7fa835ce-0987-4064-90ca-a7b75ce78a16&body=Dear%20data%20manager%2C%0A%0ASomething%20went%20wrong%20while%20processing%20my%20deposit.%20Could%20you%20please%20investigate%20the%20issue?%0A%0AIt%20has%20reference:%0A%20%20%20DRAFT/foo/7fa835ce-0987-4064-90ca-a7b75ce78a16%0AThe%20title%20starts%20with:%0A%20%20%20%0A%0AKind%20regards%2C%0Afoo%0A"""
+      expectedURL = s"""mailto:info@dans.knaw.nl?subject=Deposit%20processing%20error:%20%20reference%20DRAFT/foo/7fa835ce-0987-4064-90ca-a7b75ce78a16&body=Dear%20data%20manager%2C%0A%0ASomething%20went%20wrong%20while%20processing%20my%20deposit.%20Could%20you%20please%20investigate%20the%20issue?%0A%0ADataset%20reference:%0A%20%20%20DRAFT/foo/7fa835ce-0987-4064-90ca-a7b75ce78a16%0ATitle:%0A%20%20%20%0A%0AKind%20regards%2C%0Afoo%0A""".stripMargin
     )
   }
 
@@ -76,7 +76,7 @@ class StateManagerSpec extends TestSupportFixture {
       """.stripMargin)
     checkMailtoMessage(
       testResult = StateManager(draftDeposit, testDir / "does-not-exist", easyHome).getStateInfo,
-      expectedURL = s"""mailto:info@dans.knaw.nl?subject=Deposit%20processing%20error:%20%20reference%20a890ad74-872b-4f21-81a8-f3ef88b944ba&body=Dear%20data%20manager%2C%0A%0ASomething%20went%20wrong%20while%20processing%20my%20deposit.%20Could%20you%20please%20investigate%20the%20issue?%0A%0AIt%20has%20reference:%0A%20%20%20a890ad74-872b-4f21-81a8-f3ef88b944ba%0AThe%20title%20starts%20with:%0A%20%20%20%0A%0AKind%20regards%2C%0Afoo%0A"""
+      expectedURL = s"""mailto:info@dans.knaw.nl?subject=Deposit%20processing%20error:%20%20reference%20a890ad74-872b-4f21-81a8-f3ef88b944ba&body=Dear%20data%20manager%2C%0A%0ASomething%20went%20wrong%20while%20processing%20my%20deposit.%20Could%20you%20please%20investigate%20the%20issue?%0A%0ADataset%20reference:%0A%20%20%20a890ad74-872b-4f21-81a8-f3ef88b944ba%0ATitle:%0A%20%20%20%0A%0AKind%20regards%2C%0Afoo%0A""".stripMargin
     )
   }
 
@@ -133,7 +133,7 @@ class StateManagerSpec extends TestSupportFixture {
       .write("""{"titles":["A test with a title longer than forty-two characters."]}""")
     checkMailtoMessage(
       testResult = StateManager(draftDeposit, submitBase, easyHome).getStateInfo,
-      expectedURL = """mailto:info@dans.knaw.nl?subject=Deposit%20processing%20error:%20A%20test%20with%20a%20title%20longer%20than%20forty-two%20%20reference%20DRAFT/foo/7fa835ce-0987-4064-90ca-a7b75ce78a16&body=Dear%20data%20manager%2C%0A%0ASomething%20went%20wrong%20while%20processing%20my%20deposit.%20Could%20you%20please%20investigate%20the%20issue?%0A%0AIt%20has%20reference:%0A%20%20%20DRAFT/foo/7fa835ce-0987-4064-90ca-a7b75ce78a16%0AThe%20title%20starts%20with:%0A%20%20%20A%20test%20with%20a%20title%20longer%20than%20forty-two%20%0A%0AKind%20regards%2C%0Afoo%0A"""
+      expectedURL = """mailto:info@dans.knaw.nl?subject=Deposit%20processing%20error:%20A%20test%20with%20a%20title%20longer%20than%20forty-two%20%E2%80%A6%20reference%20DRAFT/foo/7fa835ce-0987-4064-90ca-a7b75ce78a16&body=Dear%20data%20manager%2C%0A%0ASomething%20went%20wrong%20while%20processing%20my%20deposit.%20Could%20you%20please%20investigate%20the%20issue?%0A%0ADataset%20reference:%0A%20%20%20DRAFT/foo/7fa835ce-0987-4064-90ca-a7b75ce78a16%0ATitle:%0A%20%20%20A%20test%20with%20a%20title%20longer%20than%20forty-two%20%E2%80%A6%0A%0AKind%20regards%2C%0Afoo%0A""".stripMargin
     )
   }
 
@@ -156,7 +156,7 @@ class StateManagerSpec extends TestSupportFixture {
           | "]}""".stripMargin)
     checkMailtoMessage(
       testResult = StateManager(draftDeposit, submitBase, easyHome).getStateInfo,
-      expectedURL = """mailto:info@dans.knaw.nl?subject=Deposit%20processing%20error:%20A%20test%20with%20%20new%20lines%20and%20html%20%20reference%20a890ad74-872b-4f21-81a8-f3ef88b944ba&body=Dear%20data%20manager%2C%0A%0ASomething%20went%20wrong%20while%20processing%20my%20deposit.%20Could%20you%20please%20investigate%20the%20issue?%0A%0AIt%20has%20reference:%0A%20%20%20a890ad74-872b-4f21-81a8-f3ef88b944ba%0AThe%20title%20starts%20with:%0A%20%20%20A%20test%20with%20%20new%20lines%20and%20html%20%0A%0AKind%20regards%2C%0Afoo%0A"""
+      expectedURL = """mailto:info@dans.knaw.nl?subject=Deposit%20processing%20error:%20A%20test%20with%20%20new%20lines%20and%20html%20%E2%80%A6%20reference%20a890ad74-872b-4f21-81a8-f3ef88b944ba&body=Dear%20data%20manager%2C%0A%0ASomething%20went%20wrong%20while%20processing%20my%20deposit.%20Could%20you%20please%20investigate%20the%20issue?%0A%0ADataset%20reference:%0A%20%20%20a890ad74-872b-4f21-81a8-f3ef88b944ba%0ATitle:%0A%20%20%20A%20test%20with%20%20new%20lines%20and%20html%20%E2%80%A6%0A%0AKind%20regards%2C%0Afoo%0A""".stripMargin
     )
   }
 

--- a/src/test/scala/nl.knaw.dans.easy.deposit/SubmitterSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/SubmitterSpec.scala
@@ -54,6 +54,7 @@ class SubmitterSpec extends TestSupportFixture with MockFactory {
   "submit" should "fail if the user is not part of the given group" in {
     val depositDir = createDeposit(datasetMetadata)
     val stateManager = depositDir.getStateManager(testDir / "submitted", easyHome)
+        .getOrRecover(e => (fail(s"could not get stateManager of test deposit $e")))
     addDoiToDepositProperties(getBag(depositDir))
 
     createSubmitter(unrelatedGroup).submit(depositDir, stateManager, "fullName", testDir / "staged") should matchPattern {
@@ -135,6 +136,7 @@ class SubmitterSpec extends TestSupportFixture with MockFactory {
 
   private def succeedingSubmit(deposit: DepositDir): String = {
     val stateManager = deposit.getStateManager(testDir / "submitted", easyHome)
+      .getOrRecover(e => (fail(s"could not get stateManager of test deposit $e")))
 
     val triedBagStoreBagID = createSubmitter(userGroup).submit(deposit, stateManager, "fullName", testDir / "staged")
     triedBagStoreBagID shouldBe a[Success[_]]
@@ -146,6 +148,7 @@ class SubmitterSpec extends TestSupportFixture with MockFactory {
   it should "report a file missing in the draft" in {
     val depositDir = createDeposit(datasetMetadata)
     val stateManager = depositDir.getStateManager(testDir / "submitted", easyHome)
+      .getOrRecover(e => (fail(s"could not get stateManager of test deposit $e")))
     val bag = getBag(depositDir)
     addDoiToDepositProperties(bag)
     bag.addPayloadFile("lorum ipsum".inputStream, Paths.get("file.txt"))
@@ -162,6 +165,7 @@ class SubmitterSpec extends TestSupportFixture with MockFactory {
   it should "report an invalid checksum" in {
     val depositDir = createDeposit(datasetMetadata)
     val stateManager = depositDir.getStateManager(testDir / "submitted", easyHome)
+      .getOrRecover(e => (fail(s"could not get stateManager of test deposit $e")))
     val bag = getBag(depositDir)
     addDoiToDepositProperties(bag)
     bag.addPayloadFile("lorum ipsum".inputStream, Paths.get("file.txt"))

--- a/src/test/scala/nl.knaw.dans.easy.deposit/SubmitterSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/SubmitterSpec.scala
@@ -54,7 +54,7 @@ class SubmitterSpec extends TestSupportFixture with MockFactory {
   "submit" should "fail if the user is not part of the given group" in {
     val depositDir = createDeposit(datasetMetadata)
     val stateManager = depositDir.getStateManager(testDir / "submitted", easyHome)
-      .getOrRecover(e => (fail(s"could not get stateManager of test deposit $e")))
+      .getOrRecover(e => fail(s"could not get stateManager of test deposit $e"))
     addDoiToDepositProperties(getBag(depositDir))
 
     createSubmitter(unrelatedGroup).submit(depositDir, stateManager, "fullName", testDir / "staged") should matchPattern {
@@ -136,7 +136,7 @@ class SubmitterSpec extends TestSupportFixture with MockFactory {
 
   private def succeedingSubmit(deposit: DepositDir): String = {
     val stateManager = deposit.getStateManager(testDir / "submitted", easyHome)
-      .getOrRecover(e => (fail(s"could not get stateManager of test deposit $e")))
+      .getOrRecover(e => fail(s"could not get stateManager of test deposit $e"))
 
     val triedBagStoreBagID = createSubmitter(userGroup).submit(deposit, stateManager, "fullName", testDir / "staged")
     triedBagStoreBagID shouldBe a[Success[_]]
@@ -148,7 +148,7 @@ class SubmitterSpec extends TestSupportFixture with MockFactory {
   it should "report a file missing in the draft" in {
     val depositDir = createDeposit(datasetMetadata)
     val stateManager = depositDir.getStateManager(testDir / "submitted", easyHome)
-      .getOrRecover(e => (fail(s"could not get stateManager of test deposit $e")))
+      .getOrRecover(e => fail(s"could not get stateManager of test deposit $e"))
     val bag = getBag(depositDir)
     addDoiToDepositProperties(bag)
     bag.addPayloadFile("lorum ipsum".inputStream, Paths.get("file.txt"))
@@ -165,7 +165,7 @@ class SubmitterSpec extends TestSupportFixture with MockFactory {
   it should "report an invalid checksum" in {
     val depositDir = createDeposit(datasetMetadata)
     val stateManager = depositDir.getStateManager(testDir / "submitted", easyHome)
-      .getOrRecover(e => (fail(s"could not get stateManager of test deposit $e")))
+      .getOrRecover(e => fail(s"could not get stateManager of test deposit $e"))
     val bag = getBag(depositDir)
     addDoiToDepositProperties(bag)
     bag.addPayloadFile("lorum ipsum".inputStream, Paths.get("file.txt"))

--- a/src/test/scala/nl.knaw.dans.easy.deposit/SubmitterSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/SubmitterSpec.scala
@@ -54,7 +54,7 @@ class SubmitterSpec extends TestSupportFixture with MockFactory {
   "submit" should "fail if the user is not part of the given group" in {
     val depositDir = createDeposit(datasetMetadata)
     val stateManager = depositDir.getStateManager(testDir / "submitted", easyHome)
-        .getOrRecover(e => (fail(s"could not get stateManager of test deposit $e")))
+      .getOrRecover(e => (fail(s"could not get stateManager of test deposit $e")))
     addDoiToDepositProperties(getBag(depositDir))
 
     createSubmitter(unrelatedGroup).submit(depositDir, stateManager, "fullName", testDir / "staged") should matchPattern {
@@ -82,7 +82,7 @@ class SubmitterSpec extends TestSupportFixture with MockFactory {
     val bagStoreBagID = succeedingSubmit(depositDir)
 
     // post conditions
-    (testDir / "staged") should not (exist)
+    (testDir / "staged") should not(exist)
     (bagDir / "metadata" / "dataset.json").size shouldBe mdOldSize
     // no DOI added
     val submittedBagDir = testDir / "submitted" / bagStoreBagID / bagDirName

--- a/src/test/scala/nl.knaw.dans.easy.deposit/docs/DDMSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/docs/DDMSpec.scala
@@ -16,7 +16,7 @@
 package nl.knaw.dans.easy.deposit.docs
 
 import javax.xml.validation.Schema
-import nl.knaw.dans.easy.deposit.Errors.{ CorruptUserException, InvalidDocumentException }
+import nl.knaw.dans.easy.deposit.Errors.InvalidDocumentException
 import nl.knaw.dans.easy.deposit.TestSupportFixture
 import nl.knaw.dans.easy.deposit.docs.dm.DateScheme.W3CDTF
 import nl.knaw.dans.easy.deposit.docs.dm._

--- a/src/test/scala/nl.knaw.dans.easy.deposit/docs/DDMSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/docs/DDMSpec.scala
@@ -16,7 +16,7 @@
 package nl.knaw.dans.easy.deposit.docs
 
 import javax.xml.validation.Schema
-import nl.knaw.dans.easy.deposit.Errors.InvalidDocumentException
+import nl.knaw.dans.easy.deposit.Errors.{ CorruptUserException, InvalidDocumentException }
 import nl.knaw.dans.easy.deposit.TestSupportFixture
 import nl.knaw.dans.easy.deposit.docs.dm.DateScheme.W3CDTF
 import nl.knaw.dans.easy.deposit.docs.dm._
@@ -66,11 +66,11 @@ class DDMSpec extends TestSupportFixture with DdmBehavior {
   )
 
   "minimal with multiple descriptions" should behave like validDatasetMetadata(
-    input = Try(new MinimalDatasetMetadata(descriptions = Some(Seq("Lorum", "ipsum")))),
+    input = Try(new MinimalDatasetMetadata(descriptions = Some(Seq("Lorum <a href='mailto:info@dans.knaw.nl'>ipsum</a>", "ipsum")))),
     subset = actualDDM => profileElements(actualDDM, "description"),
     expectedDdmContent =
       <ddm:profile>
-        <dcterms:description>Lorum</dcterms:description>
+        <dcterms:description>Lorum &lt;a href='mailto:info@dans.knaw.nl'&gt;ipsum&lt;/a&gt;</dcterms:description>
         <dcterms:description>ipsum</dcterms:description>
       </ddm:profile>
   )

--- a/src/test/scala/nl.knaw.dans.easy.deposit/servlets/UploadSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/servlets/UploadSpec.scala
@@ -349,7 +349,8 @@ class UploadSpec extends DepositServletFixture {
     ) {
       absoluteTarget.list.size shouldBe 2
       status shouldBe CONFLICT_409
-      body shouldBe s"The following file(s) already exist on the server: some/3.txt, some/2.txt"
+      val prefix = "The following file(s) already exist on the server:"
+      body should (equal(s"$prefix some/3.txt, some/2.txt".toString) or equal(s"$prefix some/3.txt, some/2.txt".toString))
     }
   }
 

--- a/src/test/scala/nl.knaw.dans.easy.deposit/servlets/UploadSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/servlets/UploadSpec.scala
@@ -350,7 +350,7 @@ class UploadSpec extends DepositServletFixture {
       absoluteTarget.list.size shouldBe 2
       status shouldBe CONFLICT_409
       val prefix = "The following file(s) already exist on the server:"
-      body should (equal(s"$prefix some/3.txt, some/2.txt".toString) or equal(s"$prefix some/3.txt, some/2.txt".toString))
+      body should (equal(s"$prefix some/3.txt, some/2.txt".toString) or equal(s"$prefix some/2.txt, some/3.txt".toString))
     }
   }
 


### PR DESCRIPTION
Fixes EASY-2222 overide stacktrace by ingest-flow with mail-to-dans message

#### When applied it will
* generate mailto-links with two variants of generated references:
  * one with the UUID found with `bag-store.bag-id` in the `deposit.properties of the draft deposit`
  * one with 'DRAFT/<user>/<UUID>' as fallback if the property (or submitted copy of the draft) was not found
* [x] fill in the title and test a long one

#### Where should the reviewer @DANS-KNAW/easy start?

The template in `StateManager.mailtoDansMssage` and when the method is called 

#### How should this be manually tested?

* [x] on deasy: 
  * `easy-dtap` and `easy-app` on ui-integration branch
  * build/deploy `easy-deposit-api` and `easy-webui`
  * shut down a service like `easy-validate-dans-bag `
  * submit a deposit (with at least one file uploaded)
  * refresh the list of deposits until ingest-flow is done
* Try the `expectedURL`-s in `StateManagerSpec`, result is shown in the screenshots. 

#### Screen shots
* The link only shows up in the notes of the deposit-ui when the mouse hovers over it
* Note that the deposit-ui does not show the user-id. The user-id does appear in the the message greeting. Users might change it and/or an automated signature gets added.
* Compare the trimmed titles in the `dataset.json` snippets with the subject line and message body.
![image](https://user-images.githubusercontent.com/10553630/62530448-cdb32c00-b840-11e9-961e-6f1fbc267aa2.png)
![image](https://user-images.githubusercontent.com/10553630/62531026-e2dc8a80-b841-11e9-9813-72733f715f86.png)

https://github.com/DANS-KNAW/easy-deposit-api/blob/9ee217567ee89d979bd26c977684637d94276e7c/src/test/scala/nl.knaw.dans.easy.deposit/StateManagerSpec.scala#L132-L133
![image](https://user-images.githubusercontent.com/10553630/62529156-64cab480-b83e-11e9-9f4e-b15b0407a77c.png)

https://github.com/DANS-KNAW/easy-deposit-api/blob/9ee217567ee89d979bd26c977684637d94276e7c/src/test/scala/nl.knaw.dans.easy.deposit/StateManagerSpec.scala#L150-L156
![image](https://user-images.githubusercontent.com/10553630/62529261-9ba0ca80-b83e-11e9-8af3-29765c2958ab.png)


