### PR TITLE
EASY-2246: fix validation error in <dcx-dai:organization>

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.deposit/docs/DDM.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/docs/DDM.scala
@@ -153,8 +153,8 @@ object DDM extends SchemedXml with DebugEnhancedLogging {
 
   private def orgDetails(organization: String, lang: String, role: Option[SchemedKeyValue]): Elem =
       <dcx-dai:organization>
-        { role.flatMap(_.key).withNonEmpty.map(key => <dcx-dai:role>{ key }</dcx-dai:role>) }
         { <dcx-dai:name xml:lang={ lang }>{ organization }</dcx-dai:name> }
+        { role.flatMap(_.key).withNonEmpty.map(key => <dcx-dai:role>{ key }</dcx-dai:role>) }
       </dcx-dai:organization>
 
   /** @param elem XML element to be adjusted */

--- a/src/test/scala/nl.knaw.dans.easy.deposit/docs/DDMSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/docs/DDMSpec.scala
@@ -468,8 +468,8 @@ class DDMSpec extends TestSupportFixture with DdmBehavior {
         </dcx-dai:contributorDetails>
         <dcx-dai:contributorDetails>
           <dcx-dai:organization>
-            <dcx-dai:role>RightsHolder</dcx-dai:role>
             <dcx-dai:name xml:lang="nld">rightsHolder1</dcx-dai:name>
+            <dcx-dai:role>RightsHolder</dcx-dai:role>
           </dcx-dai:organization>
         </dcx-dai:contributorDetails>
         <dcx-dai:contributorDetails>


### PR DESCRIPTION
Fixes EASY-2246

#### When applied it will
* swap order of fields in `<dcx-dai:organization>` to make sure the produced DDM validates according to the schema

@DANS-KNAW/easy for review