### PR TITLE
EASY-2205: Map alternative identifiers to isFormatOf

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.deposit/docs/DDM.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/docs/DDM.scala
@@ -107,18 +107,14 @@ object DDM extends SchemedXml with DebugEnhancedLogging {
       case Relation(_, None, Some(title: String)) => <label xml:lang={ lang }>{ title }</label>
       case RelatedIdentifier(Some("id-type:DOI"), Some(value), _) => <label scheme="id-type:DOI" href={ "https://doi.org/" + value }>{ value }</label>
       case RelatedIdentifier(Some("id-type:URN"), Some(value), _) => <label scheme="id-type:URN" href={ "http://persistent-identifier.nl/" + value }>{ value }</label>
-      case RelatedIdentifier(Some("id-type:URI"), Some(value), _) => <label scheme="id-type:URI" href={ value }>{ value }</label>
-      case RelatedIdentifier(Some("id-type:URL"), Some(value), _) => <label scheme="id-type:URL" href={ value }>{ value }</label>
+      case RelatedIdentifier(Some(scheme @ ("id-type:URI" | "id-type:URL")), Some(value), _) => <label scheme={ scheme } href={ value }>{ value }</label>
       case RelatedIdentifier(scheme, Some(value: String), _) => <label xsi:type={ scheme.nonBlankOrNull }>{ value }</label>
       case RelatedIdentifier(scheme, None, _) => <label xsi:type={ scheme.nonBlankOrNull }></label>
       case _ => throw new IllegalArgumentException("invalid relation " + JsonUtil.toJson(relation))
     }
   }.withLabel(relation match { // replace the namespace in case of an href=URL attribute
     case RelatedIdentifier(_, _, None) => throw new IllegalArgumentException("missing qualifier: RelatedIdentifier" + JsonUtil.toJson(relation))
-    case RelatedIdentifier(Some("id-type:URI"), _, Some(qualifier)) => qualifier.toString.replace("dcterms", "ddm")
-    case RelatedIdentifier(Some("id-type:URL"), _, Some(qualifier)) => qualifier.toString.replace("dcterms", "ddm")
-    case RelatedIdentifier(Some("id-type:URN"), _, Some(qualifier)) => qualifier.toString.replace("dcterms", "ddm")
-    case RelatedIdentifier(Some("id-type:DOI"), _, Some(qualifier)) => qualifier.toString.replace("dcterms", "ddm")
+    case RelatedIdentifier(Some("id-type:URI" | "id-type:URL" | "id-type:URN" | "id-type:DOI"), _, Some(qualifier)) => qualifier.toString.replace("dcterms", "ddm")
     case RelatedIdentifier(_, _, Some(qualifier)) => qualifier.toString
     case Relation(None, _, _) => throw new IllegalArgumentException("missing qualifier: Relation" + JsonUtil.toJson(relation))
     case Relation(Some(qualifier), Some(_), _) => qualifier.toString.replace("dcterms", "ddm")

--- a/src/main/scala/nl.knaw.dans.easy.deposit/docs/DDM.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/docs/DDM.scala
@@ -54,9 +54,9 @@ object DDM extends SchemedXml with DebugEnhancedLogging {
         { dm.accessRights.toSeq.map(src => <ddm:accessRights>{ src.toString }</ddm:accessRights>) }
       </ddm:profile>
       <ddm:dcmiMetadata>
-        { dm.allIdentifiers.map(id => <dcterms:identifier xsi:type={ id.scheme.nonBlankOrNull }>{ id.value.nonBlankOrEmpty }</dcterms:identifier>) }
+        { dm.identifiers.withNonEmpty.map(id => <dcterms:identifier xsi:type={ id.scheme.nonBlankOrNull }>{ id.value.nonBlankOrEmpty }</dcterms:identifier>) }
         { dm.alternativeTitles.withNonEmpty.map(str => <dcterms:alternative xml:lang={ lang }>{ str }</dcterms:alternative>) }
-        { dm.relations.withNonEmpty.map(details(_, lang)) }
+        { dm.allRelations.withNonEmpty.map(details(_, lang)) }
         { dm.contributors.withNonEmpty.map(author => <dcx-dai:contributorDetails>{ details(author, lang) }</dcx-dai:contributorDetails>) }
         { dm.rightsHolders.map(str => <dcterms:rightsHolder>{ str }</dcterms:rightsHolder>) }
         { dm.publishers.withNonEmpty.map(str => <dcterms:publisher xml:lang={ lang }>{ str }</dcterms:publisher>) }

--- a/src/main/scala/nl.knaw.dans.easy.deposit/docs/DDM.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/docs/DDM.scala
@@ -108,7 +108,7 @@ object DDM extends SchemedXml with DebugEnhancedLogging {
       case RelatedIdentifier(Some("id-type:DOI"), Some(value), _) => <label scheme="id-type:DOI" href={ "https://doi.org/" + value }>{ value }</label>
       case RelatedIdentifier(Some("id-type:URN"), Some(value), _) => <label scheme="id-type:URN" href={ "http://persistent-identifier.nl/" + value }>{ value }</label>
       case RelatedIdentifier(Some(scheme @ ("id-type:URI" | "id-type:URL")), Some(value), _) => <label scheme={ scheme } href={ value }>{ value }</label>
-      case RelatedIdentifier(scheme, Some(value: String), _) => <label xsi:type={ scheme.nonBlankOrNull }>{ value }</label>
+      case RelatedIdentifier(scheme, Some(value), _) => <label xsi:type={ scheme.nonBlankOrNull }>{ value }</label>
       case RelatedIdentifier(scheme, None, _) => <label xsi:type={ scheme.nonBlankOrNull }></label>
       case _ => throw new IllegalArgumentException("invalid relation " + JsonUtil.toJson(relation))
     }

--- a/src/main/scala/nl.knaw.dans.easy.deposit/docs/DatasetMetadata.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/docs/DatasetMetadata.scala
@@ -78,7 +78,8 @@ case class DatasetMetadata(identifiers: Option[Seq[SchemedValue]] = None,
     .map(_.toString)
 
   lazy val allRelations: Seq[RelationType] = relations.getOrElse(Seq()) ++
-    alternativeIdentifiers.getOrElse(Seq()).map(i => RelatedIdentifier(i.scheme, i.value, Option(RelationQualifier.isFormatOf)))
+    alternativeIdentifiers.getOrElse(Seq())
+      .map(i => RelatedIdentifier(i.scheme, i.value, Option(RelationQualifier.isFormatOf)))
 
   //// doi
   lazy val doi: Option[String] = identifiers.flatMap(_.collectFirst {

--- a/src/main/scala/nl.knaw.dans.easy.deposit/docs/DatasetMetadata.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/docs/DatasetMetadata.scala
@@ -30,7 +30,7 @@ import scala.util.{ Failure, Success, Try }
  * All params are (de)serialized by [[JsonUtil]].
  * Private params are remixed or converted for XML serialization with [[DDM]].
  */
-case class DatasetMetadata(private val identifiers: Option[Seq[SchemedValue]] = None,
+case class DatasetMetadata(identifiers: Option[Seq[SchemedValue]] = None,
                            languageOfDescription: Option[SchemedKeyValue] = None,
                            titles: Option[Seq[String]] = None,
                            alternativeTitles: Option[Seq[String]] = None,
@@ -40,7 +40,7 @@ case class DatasetMetadata(private val identifiers: Option[Seq[SchemedValue]] = 
                            audiences: Option[Seq[SchemedKeyValue]] = None,
                            subjects: Option[Seq[SchemedKeyValue]] = None,
                            private val alternativeIdentifiers: Option[Seq[SchemedValue]] = None,
-                           relations: Option[Seq[RelationType]] = None,
+                           private val relations: Option[Seq[RelationType]] = None,
                            languagesOfFiles: Option[Seq[SchemedKeyValue]] = None,
                            private val dates: Option[Seq[Date]] = None,
                            sources: Option[Seq[String]] = None,
@@ -77,7 +77,8 @@ case class DatasetMetadata(private val identifiers: Option[Seq[SchemedValue]] = 
     .withFilter(_.isRightsHolder)
     .map(_.toString)
 
-  lazy val allIdentifiers: Seq[SchemedValue] = identifiers.getOrElse(Seq()) ++ alternativeIdentifiers.getOrElse(Seq())
+  lazy val allRelations: Seq[RelationType] = relations.getOrElse(Seq()) ++
+    alternativeIdentifiers.getOrElse(Seq()).map(i => RelatedIdentifier(i.scheme, i.value, Option(RelationQualifier.isFormatOf)))
 
   //// doi
   lazy val doi: Option[String] = identifiers.flatMap(_.collectFirst {

--- a/src/test/resources/manual-test/datasetmetadata-from-ui-all.json
+++ b/src/test/resources/manual-test/datasetmetadata-from-ui-all.json
@@ -132,7 +132,6 @@
       "scheme": "id-type:DOI",
       "value": "10.5072/test-doi"
     }
-
   ],
   "relations": [
     {

--- a/src/test/resources/manual-test/datasetmetadata-from-ui-all.json
+++ b/src/test/resources/manual-test/datasetmetadata-from-ui-all.json
@@ -127,7 +127,12 @@
     {
       "scheme": "id-type:ARCHIS-ZAAK-IDENTIFICATIE",
       "value": "archis nr. 2"
+    },
+    {
+      "scheme": "id-type:DOI",
+      "value": "10.5072/test-doi"
     }
+
   ],
   "relations": [
     {

--- a/src/test/scala/nl.knaw.dans.easy.deposit/docs/DDMSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/docs/DDMSpec.scala
@@ -453,6 +453,7 @@ class DDMSpec extends TestSupportFixture with DdmBehavior {
         <dcterms:isFormatOf xsi:type="id-type:NWO-PROJECTNR">test identifier 2</dcterms:isFormatOf>
         <dcterms:isFormatOf xsi:type="id-type:ARCHIS-ZAAK-IDENTIFICATIE">archis nr. 1</dcterms:isFormatOf>
         <dcterms:isFormatOf xsi:type="id-type:ARCHIS-ZAAK-IDENTIFICATIE">archis nr. 2</dcterms:isFormatOf>
+        <ddm:isFormatOf scheme="id-type:DOI" href="https://doi.org/10.5072/test-doi">10.5072/test-doi</ddm:isFormatOf>
         <dcx-dai:contributorDetails>
           <dcx-dai:author>
             <dcx-dai:titles xml:lang="nld">Dr.</dcx-dai:titles>

--- a/src/test/scala/nl.knaw.dans.easy.deposit/docs/DDMSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/docs/DDMSpec.scala
@@ -441,10 +441,6 @@ class DDMSpec extends TestSupportFixture with DdmBehavior {
       </ddm:profile>
       <ddm:dcmiMetadata>
         <dcterms:identifier xsi:type="id-type:DOI">10.17632/DANS.6wg5xccnjd.1</dcterms:identifier>
-        <dcterms:identifier xsi:type="id-type:ISBN">test identifier 1</dcterms:identifier>
-        <dcterms:identifier xsi:type="id-type:NWO-PROJECTNR">test identifier 2</dcterms:identifier>
-        <dcterms:identifier xsi:type="id-type:ARCHIS-ZAAK-IDENTIFICATIE">archis nr. 1</dcterms:identifier>
-        <dcterms:identifier xsi:type="id-type:ARCHIS-ZAAK-IDENTIFICATIE">archis nr. 2</dcterms:identifier>
         <dcterms:alternative xml:lang="nld">alternative title 1</dcterms:alternative>
         <dcterms:alternative xml:lang="nld">alternative title2</dcterms:alternative>
         <dcterms:isReferencedBy xsi:type="id-type:ISSN">2123-34X</dcterms:isReferencedBy>
@@ -453,6 +449,10 @@ class DDMSpec extends TestSupportFixture with DdmBehavior {
         <ddm:isReplacedBy href="http://y">http://y</ddm:isReplacedBy>
         <ddm:relation href="http://z">http://z</ddm:relation>
         <dcterms:relation xml:lang="nld">title3</dcterms:relation>
+        <dcterms:isFormatOf xsi:type="id-type:ISBN">test identifier 1</dcterms:isFormatOf>
+        <dcterms:isFormatOf xsi:type="id-type:NWO-PROJECTNR">test identifier 2</dcterms:isFormatOf>
+        <dcterms:isFormatOf xsi:type="id-type:ARCHIS-ZAAK-IDENTIFICATIE">archis nr. 1</dcterms:isFormatOf>
+        <dcterms:isFormatOf xsi:type="id-type:ARCHIS-ZAAK-IDENTIFICATIE">archis nr. 2</dcterms:isFormatOf>
         <dcx-dai:contributorDetails>
           <dcx-dai:author>
             <dcx-dai:titles xml:lang="nld">Dr.</dcx-dai:titles>


### PR DESCRIPTION
Fixes EASY-2205

#### When applied it will
* Map alternative identifiers to isFormatOf instead of identifier
* Use non-versioned ddm.xsd
* Add testcases

#### Where should the reviewer @DANS-KNAW/easy start?
