### PR TITLE
EASY-2272: fix typo and fix ForbiddenUpdate description

### DIFF
--- a/docs/api/api.yml
+++ b/docs/api/api.yml
@@ -649,7 +649,7 @@ components:
 
     ForbiddenUpdate:
       description: |
-        Forbidden. The resource cannot be updated at this point. (Updating is only permitted when the deposit is in one of states: DRAFT, REJECTED.)
+        Forbidden. The resource cannot be updated at this point. (Updating is only permitted when the deposit is in state: DRAFT.)
 
     ForbiddenDelete:
       description: |
@@ -668,7 +668,7 @@ components:
     ConflictOverwritesFilesOnServer:
       description: Conflict. The following file(s) already exist on the server
 
-    ConflictConcurrentUploadsNotAllowed":
+    ConflictConcurrentUploadsNotAllowed:
       description: Conflict. Concurrent file uploads to the same deposit are not allowed.
 
     ConflictAttemptToOverwriteDirectoryWithFile:


### PR DESCRIPTION
changes the ForbiddenUpdate description to more accurately describe the resolution of https://drivenbydata.atlassian.net/browse/EASY-2112

Fixes EASY-2272

#### When applied it will
* correctly display the description of a HTTP 409 code in Swagger UI
* fix the ForbiddenUpdate description to more accurately match the current behavior

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### Related pull requests on github
repo                       | PR                | note
-------------------------- | ----------------- | ----
easy-                      | [PR#](PRlink)     | ..
