### PR TITLE
EASY-2257 : new attribute "displayName" for "UserInfo"

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.deposit/docs/UserInfo.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/docs/UserInfo.scala
@@ -24,6 +24,7 @@ case class UserInfo(userName: String,
                     firstName: Option[String] = None,
                     prefix: Option[String] = None,
                     lastName: String,
+                    displayName: String,
                    )
 object UserInfo {
   def apply(input: JsonInput): Try[UserInfo] = input.deserialize[UserInfo]
@@ -41,6 +42,7 @@ object UserInfo {
       prefix = attributes.get("dansPrefixes").map(s => s.mkString(" ")),
 
       lastName = attributes.getOrElse("sn", Seq.empty).headOption.getOrElse(""),
+      displayName = attributes.getOrElse("displayName", Seq.empty).headOption.getOrElse(""),
     )
   }
 }

--- a/src/test/scala/nl.knaw.dans.easy.deposit/servlets/HappyRoutesSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/servlets/HappyRoutesSpec.scala
@@ -93,12 +93,13 @@ class HappyRoutesSpec extends TestSupportFixture with ServletFixture with Scalat
       "cn" -> Seq("Jan"),
       "dansPrefixes" -> Seq("van", "den"),
       "sn" -> Seq("Berg"),
+      "displayName" -> Seq("Jan v.d. Berg"),
     ))
     get(
       uri = "/user",
       headers = Seq(fooBarBasicAuthHeader)
     ) {
-      body shouldBe """{"userName":"foo","firstName":"Jan","prefix":"van den","lastName":"Berg"}"""
+      body shouldBe """{"userName":"foo","firstName":"Jan","prefix":"van den","lastName":"Berg","displayName":"Jan v.d. Berg"}"""
       status shouldBe OK_200
     }
   }
@@ -107,14 +108,15 @@ class HappyRoutesSpec extends TestSupportFixture with ServletFixture with Scalat
     authMocker.expectsUserFooBar
     (mockedApp.getUser(_: String)) expects "foo" returning Success(Map(
       "uid" -> Seq("foo"),
-      "sn" -> Seq("Berg")
+      "sn" -> Seq("Berg"),
+      "displayName" -> Seq("Jan v.d. Berg"),
     ))
 
     get(
       uri = "/user",
       headers = Seq(fooBarBasicAuthHeader)
     ) {
-      body shouldBe """{"userName":"foo","lastName":"Berg"}"""
+      body shouldBe """{"userName":"foo","lastName":"Berg","displayName":"Jan v.d. Berg"}"""
       status shouldBe OK_200
     }
   }


### PR DESCRIPTION
Fixes EASY-2257 : new attribute "displayName" for "UserInfo"

#### When applied it will
* 
* 
* 

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### Related pull requests on github
https://github.com/DANS-KNAW/easy-deposit-ui/pull/186 should be merged/deployed after this
