### PR TITLE
EASY-2282: add deposit-ui form url to 'message for the datamanager' during submit

### DIFF
--- a/src/main/assembly/dist/cfg/application.properties
+++ b/src/main/assembly/dist/cfg/application.properties
@@ -93,3 +93,6 @@ auth.jwt.secret.key=changeMe
 # will be extended with "/datasets/id/easy-dataset:NNN" or "/mydatasets"
 # depending on presence of "identifier.fedora" in submitted deposit.properties
 easy.home=https://deasy.dans.knaw.nl/ui
+
+# will be extended with "/<uuid>"
+easy.deposit-ui=https://deasy.dans.knaw.nl/deposit/deposit-form

--- a/src/main/scala/nl.knaw.dans.easy.deposit/EasyDepositApiApp.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/EasyDepositApiApp.scala
@@ -88,7 +88,8 @@ class EasyDepositApiApp(configuration: Configuration) extends DebugEnhancedLoggi
 
   private val submitter = {
     val groupName = properties.getString("deposit.permissions.group")
-    new Submitter(stagedBaseDir, submitBase, groupName)
+    val depositUiURL = properties.getString("easy.deposit-ui")
+    new Submitter(stagedBaseDir, submitBase, groupName, depositUiURL)
   }
 
   // possible trailing slash is dropped

--- a/src/main/scala/nl.knaw.dans.easy.deposit/Submitter.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/Submitter.scala
@@ -36,6 +36,7 @@ import org.joda.time.DateTime
 import scala.collection.JavaConverters._
 import scala.util.control.NonFatal
 import scala.util.{ Failure, Success, Try }
+import nl.knaw.dans.lib.string._
 
 /**
  * Object that contains the logic for submitting a deposit.
@@ -46,6 +47,7 @@ import scala.util.{ Failure, Success, Try }
 class Submitter(stagingBaseDir: File,
                 submitToBaseDir: File,
                 groupName: String,
+                depositUiURL: String,
                ) extends DebugEnhancedLogging {
   private val groupPrincipal = {
     Try {
@@ -82,7 +84,11 @@ class Submitter(stagingBaseDir: File,
       _ = datasetMetadata.doi.getOrElse(throw InvalidDoiException(draftDeposit.id))
       _ <- draftDeposit.sameDOIs(datasetMetadata)
       datasetXml <- DDM(datasetMetadata)
-      msg = datasetMetadata.messageForDataManager.getOrElse("")
+      msg4DataManager = {
+        val firstPart = datasetMetadata.messageForDataManager.getOrElse("").stripLineEnd
+        val secondPart = s"The deposit can be found at $depositUiURL/${draftDeposit.id}"
+        firstPart.toOption.fold(secondPart)(_ + "\n\n" + secondPart)
+      }
       filesXml <- FilesXml(draftBag.data)
       _ <- sameFiles(draftBag.payloadManifests, draftBag.baseDir / "data")
       // from now on no more user errors but internal errors
@@ -95,7 +101,7 @@ class Submitter(stagingBaseDir: File,
       _ = if (submitDir.exists) throw AlreadySubmittedException(draftDeposit.id)
       _ = (draftBag.baseDir.parent / propsFileName).copyTo(stagedDir / propsFileName)
       // EASY-1464 3.3.5.b: write files to metadata
-      _ = stageBag.addMetadataFile(msg, s"$depositorInfoDirectoryName/message-from-depositor.txt")
+      _ = stageBag.addMetadataFile(msg4DataManager, s"$depositorInfoDirectoryName/message-from-depositor.txt")
       _ <- stageBag.addMetadataFile(agreementsXml, s"$depositorInfoDirectoryName/agreements.xml")
       _ <- stageBag.addMetadataFile(datasetXml, "dataset.xml")
       _ <- stageBag.addMetadataFile(filesXml, "files.xml")

--- a/src/test/resources/debug-config/application.properties
+++ b/src/test/resources/debug-config/application.properties
@@ -25,3 +25,4 @@ auth.jwt.hmac.algorithm=HS256
 auth.jwt.secret.key=changeMe
 
 easy.home=https://deasy.dans.knaw.nl/ui
+easy.deposit-ui=https://deasy.dans.knaw.nl/deposit/deposit-form

--- a/src/test/scala/nl.knaw.dans.easy.deposit/SubmitterSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/SubmitterSpec.scala
@@ -86,7 +86,7 @@ class SubmitterSpec extends TestSupportFixture with MockFactory {
     (bagDir / "metadata" / "dataset.json").size shouldBe mdOldSize
     // no DOI added
     val submittedBagDir = testDir / "submitted" / bagStoreBagID / bagDirName
-    (submittedBagDir / "metadata" / "depositor-info" / "message-from-depositor.txt").contentAsString shouldBe customMessage
+    (submittedBagDir / "metadata" / "depositor-info" / "message-from-depositor.txt").contentAsString shouldBe s"$customMessage\n\nThe deposit can be found at http://does.not.exist/${depositDir.id}"
     (submittedBagDir / "metadata" / "depositor-info" / "agreements.xml").lineIterator.next() shouldBe prologue
     (submittedBagDir / "metadata" / "dataset.xml").lineIterator.next() shouldBe prologue
     (submittedBagDir / "data").children.size shouldBe (bagDir / "data").children.size
@@ -107,7 +107,7 @@ class SubmitterSpec extends TestSupportFixture with MockFactory {
     val bagStoreBagId = succeedingSubmit(depositDir)
 
     (testDir / "submitted" / bagStoreBagId / bagDirName / "metadata" / "depositor-info" / "message-from-depositor.txt")
-      .contentAsString shouldBe ""
+      .contentAsString shouldBe s"The deposit can be found at http://does.not.exist/${depositDir.id}"
   }
 
   it should "overwrite a previous bag-store.bag-id at resubmit" in {
@@ -187,6 +187,7 @@ class SubmitterSpec extends TestSupportFixture with MockFactory {
       (testDir / "staged").createDirectories(),
       (testDir / "submitted").createDirectories(),
       group,
+      "http://does.not.exist",
     )
   }
 


### PR DESCRIPTION
Fixes EASY-2282

#### When applied it will
* add deposit-ui form url to 'message for the datamanager' during submit

@DANS-KNAW/easy for review

See also:
* https://github.com/DANS-KNAW/easy-dtap/pull/367