### PR TITLE
EASY-2311: email in agreements

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.deposit/EasyDepositApiApp.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/EasyDepositApiApp.scala
@@ -27,7 +27,7 @@ import nl.knaw.dans.easy.deposit.PidRequesterComponent.PidRequester
 import nl.knaw.dans.easy.deposit.authentication.{ AuthenticationProvider, LdapAuthentication }
 import nl.knaw.dans.easy.deposit.docs.StateInfo.State
 import nl.knaw.dans.easy.deposit.docs.StateInfo.State.State
-import nl.knaw.dans.easy.deposit.docs.{ DatasetMetadata, DepositInfo, StateInfo }
+import nl.knaw.dans.easy.deposit.docs.{ DatasetMetadata, DepositInfo, StateInfo, UserInfo }
 import nl.knaw.dans.easy.deposit.servlets.contentTypeZipPattern
 import nl.knaw.dans.lib.error._
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
@@ -113,7 +113,7 @@ class EasyDepositApiApp(configuration: Configuration) extends DebugEnhancedLoggi
     DepositDir.get(draftBase, user, id)
   }
 
-  def getUserProperties(user: String): Try[Map[String, Seq[String]]] = authentication.getUser(user)
+  def getUserProperties(user: String): Try[UserInfo] = authentication.getUser(user)
 
   /**
    * Creates a new, empty deposit, containing an empty bag in the user's draft area. If the user
@@ -134,7 +134,7 @@ class EasyDepositApiApp(configuration: Configuration) extends DebugEnhancedLoggi
    */
   def getDeposits(user: String): Try[Seq[DepositInfo]] = {
     implicit val timestampOrdering: Ordering[DateTime] = Ordering.fromLessThan[DateTime](_ isBefore _)
-    implicit val tupleOrdering: Ordering[(State, DateTime)] = Ordering.Tuple2[State,DateTime]
+    implicit val tupleOrdering: Ordering[(State, DateTime)] = Ordering.Tuple2[State, DateTime]
     val deposits = DepositDir.list(draftBase, user)
     for {
       infos <- deposits.map(_.getDepositInfo(submitBase, easyHome)).collectResults
@@ -360,7 +360,6 @@ class EasyDepositApiApp(configuration: Configuration) extends DebugEnhancedLoggi
       disposableStagingDir <- createManagedTempDir(prefix)
       _ <- atMostOneTempDir(prefix).doIfFailure { case _ => disposableStagingDir.get() }
     } yield disposableStagingDir
-
   }
 
   // the temporary directory is dropped when the disposable resource is released on completion of the request,

--- a/src/main/scala/nl.knaw.dans.easy.deposit/EasyDepositApiApp.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/EasyDepositApiApp.scala
@@ -113,7 +113,7 @@ class EasyDepositApiApp(configuration: Configuration) extends DebugEnhancedLoggi
     DepositDir.get(draftBase, user, id)
   }
 
-  def getUserProperties(user: String): Try[UserInfo] = authentication.getUser(user)
+  def getUserInfo(user: String): Try[UserInfo] = authentication.getUser(user)
 
   /**
    * Creates a new, empty deposit, containing an empty bag in the user's draft area. If the user
@@ -180,9 +180,9 @@ class EasyDepositApiApp(configuration: Configuration) extends DebugEnhancedLoggi
   def setDepositState(newStateInfo: StateInfo, userId: String, id: UUID): Try[Unit] = {
     def submit(deposit: DepositDir, stateManager: StateManager): Try[Unit] = {
       for {
-        userProperties <- getUserProperties(userId)
+        userInfo <- getUserInfo(userId)
         disposableStagedDir <- getStagedDir(userId, id)
-        _ <- disposableStagedDir.apply(submitter.submit(deposit, stateManager, userProperties, _))
+        _ <- disposableStagedDir.apply(submitter.submit(deposit, stateManager, userInfo, _))
       } yield ()
     }
 

--- a/src/main/scala/nl.knaw.dans.easy.deposit/Errors.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/Errors.scala
@@ -68,9 +68,6 @@ object Errors extends DebugEnhancedLogging {
     logger.error(cause.getMessage)
   }
 
-  case class CorruptUserException(msg: String)
-    extends ServletResponseException(INTERNAL_SERVER_ERROR_500, msg)
-
   class PropertyException(msg: String)
     extends ServletResponseException(INTERNAL_SERVER_ERROR_500, msg)
 

--- a/src/main/scala/nl.knaw.dans.easy.deposit/StateManager.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/StateManager.scala
@@ -149,7 +149,7 @@ case class StateManager(draftDeposit: DepositDir, submitBase: File, easyHome: UR
          |${ draftDeposit.user }
          |""".stripMargin
     )
-    s"""Something went wrong while processing this deposit. Please <a href="mailto:does.not.exist@dans.knaw.nl?subject=$subject&body=$body">contact DANS</a>"""
+    s"""Something went wrong while processing this deposit. Please <a href="mailto:info@dans.knaw.nl?subject=$subject&body=$body">contact DANS</a>"""
   }
 
   private def landingPage(msgStart: String): String = {

--- a/src/main/scala/nl.knaw.dans.easy.deposit/StateManager.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/StateManager.scala
@@ -149,7 +149,7 @@ case class StateManager(draftDeposit: DepositDir, submitBase: File, easyHome: UR
          |${ draftDeposit.user }
          |""".stripMargin
     )
-    s"""Something went wrong while processing this deposit. Please <a href="mailto:info@dans.knaw.nl?subject=$subject&body=$body">contact DANS</a>"""
+    s"""Something went wrong while processing this deposit. Please <a href="mailto:does.not.exist@dans.knaw.nl?subject=$subject&body=$body">contact DANS</a>"""
   }
 
   private def landingPage(msgStart: String): String = {

--- a/src/main/scala/nl.knaw.dans.easy.deposit/Submitter.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/Submitter.scala
@@ -28,15 +28,15 @@ import nl.knaw.dans.bag.DansBag
 import nl.knaw.dans.bag.v0.DansV0Bag
 import nl.knaw.dans.easy.deposit.Errors.{ AlreadySubmittedException, InvalidDoiException }
 import nl.knaw.dans.easy.deposit.docs.StateInfo.State
-import nl.knaw.dans.easy.deposit.docs.{ AgreementsXml, DDM, FilesXml, StateInfo }
+import nl.knaw.dans.easy.deposit.docs._
 import nl.knaw.dans.lib.error._
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
+import nl.knaw.dans.lib.string._
 import org.joda.time.DateTime
 
 import scala.collection.JavaConverters._
 import scala.util.control.NonFatal
 import scala.util.{ Failure, Success, Try }
-import nl.knaw.dans.lib.string._
 
 /**
  * Object that contains the logic for submitting a deposit.
@@ -69,7 +69,7 @@ class Submitter(stagingBaseDir: File,
    * @param draftDeposit the deposit object to submit
    * @return the UUID of the deposit in the submit area (easy-ingest-flow-inbox)
    */
-  def submit(draftDeposit: DepositDir, stateManager: StateManager, user: Map[String, Seq[String]], stagedDir: File): Try[UUID] = {
+  def submit(draftDeposit: DepositDir, stateManager: StateManager, user: UserInfo, stagedDir: File): Try[UUID] = {
     val propsFileName = "deposit.properties"
     for {
       // EASY-1464 step 3.3.4 validation
@@ -86,7 +86,7 @@ class Submitter(stagingBaseDir: File,
       datasetXml <- DDM(datasetMetadata)
       msg4DataManager = {
         val firstPart = datasetMetadata.messageForDataManager.getOrElse("").stripLineEnd
-        val secondPart = s"The deposit can be found at $depositUiURL/${draftDeposit.id}"
+        val secondPart = s"The deposit can be found at $depositUiURL/${ draftDeposit.id }"
         firstPart.toOption.fold(secondPart)(_ + "\n\n" + secondPart)
       }
       filesXml <- FilesXml(draftBag.data)

--- a/src/main/scala/nl.knaw.dans.easy.deposit/Submitter.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/Submitter.scala
@@ -69,7 +69,7 @@ class Submitter(stagingBaseDir: File,
    * @param draftDeposit the deposit object to submit
    * @return the UUID of the deposit in the submit area (easy-ingest-flow-inbox)
    */
-  def submit(draftDeposit: DepositDir, stateManager: StateManager, fullName: String, stagedDir: File): Try[UUID] = {
+  def submit(draftDeposit: DepositDir, stateManager: StateManager, user: Map[String, Seq[String]], stagedDir: File): Try[UUID] = {
     val propsFileName = "deposit.properties"
     for {
       // EASY-1464 step 3.3.4 validation
@@ -80,7 +80,7 @@ class Submitter(stagingBaseDir: File,
       // EASY-1464 3.3.5.a: generate (with some implicit validation) content for metadata files
       draftBag <- draftDeposit.getDataFiles.map(_.bag)
       datasetMetadata <- draftDeposit.getDatasetMetadata
-      agreementsXml <- AgreementsXml(draftDeposit.user, DateTime.now, datasetMetadata, fullName)
+      agreementsXml <- AgreementsXml(draftDeposit.user, DateTime.now, datasetMetadata, user)
       _ = datasetMetadata.doi.getOrElse(throw InvalidDoiException(draftDeposit.id))
       _ <- draftDeposit.sameDOIs(datasetMetadata)
       datasetXml <- DDM(datasetMetadata)

--- a/src/main/scala/nl.knaw.dans.easy.deposit/Submitter.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/Submitter.scala
@@ -80,7 +80,7 @@ class Submitter(stagingBaseDir: File,
       // EASY-1464 3.3.5.a: generate (with some implicit validation) content for metadata files
       draftBag <- draftDeposit.getDataFiles.map(_.bag)
       datasetMetadata <- draftDeposit.getDatasetMetadata
-      agreementsXml <- AgreementsXml(draftDeposit.user, DateTime.now, datasetMetadata, user)
+      agreementsXml <- AgreementsXml(DateTime.now, datasetMetadata, user)
       _ = datasetMetadata.doi.getOrElse(throw InvalidDoiException(draftDeposit.id))
       _ <- draftDeposit.sameDOIs(datasetMetadata)
       datasetXml <- DDM(datasetMetadata)

--- a/src/main/scala/nl.knaw.dans.easy.deposit/authentication/AuthenticationProvider.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/authentication/AuthenticationProvider.scala
@@ -15,10 +15,12 @@
  */
 package nl.knaw.dans.easy.deposit.authentication
 
+import nl.knaw.dans.easy.deposit.docs.UserInfo
+
 import scala.util.Try
 
 trait AuthenticationProvider {
   def authenticate(userName: String, password: String): Try[Option[AuthUser]]
 
-  def getUser(userName: String): Try[Map[String, Seq[String]]]
+  def getUser(userName: String): Try[UserInfo]
 }

--- a/src/main/scala/nl.knaw.dans.easy.deposit/authentication/LdapAuthentication.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/authentication/LdapAuthentication.scala
@@ -20,6 +20,7 @@ import java.util
 import javax.naming.directory.{ Attribute, SearchControls, SearchResult }
 import javax.naming.ldap.{ InitialLdapContext, LdapContext }
 import javax.naming.{ AuthenticationException, Context }
+import nl.knaw.dans.easy.deposit.docs.UserInfo
 import nl.knaw.dans.lib.error.TryExtensions
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
 import resource.managed
@@ -43,9 +44,9 @@ trait LdapAuthentication extends DebugEnhancedLogging {
      * @param userName name of the authenticated user
      * @return
      */
-    def getUser(userName: String): Try[Map[String, Seq[String]]] = {
+    def getUser(userName: String): Try[UserInfo] = {
       findUser(userName, adminContextProperties) match {
-        case Success(Some(props)) => Success(props)
+        case Success(Some(props)) => Success(UserInfo(props))
         case Success(None) => Failure(new Exception(s"User [$userName] not found by [$ldapAdminPrincipal] (deleted after login?)"))
         case Failure(t) => Failure(new Exception(s"Configuration error of ldap admin user: $t", t))
       }

--- a/src/main/scala/nl.knaw.dans.easy.deposit/docs/AgreementsXml.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/docs/AgreementsXml.scala
@@ -17,7 +17,7 @@ package nl.knaw.dans.easy.deposit.docs
 
 import org.joda.time.DateTime
 
-import scala.util.{ Failure, Try }
+import scala.util.Try
 import scala.xml.Elem
 
 object AgreementsXml extends SchemedXml {
@@ -25,8 +25,7 @@ object AgreementsXml extends SchemedXml {
   override val schemaLocation = "https://easy.dans.knaw.nl/schemas/bag/metadata/agreements/2019/09/agreements.xsd"
 
   def apply(dateSubmitted: DateTime, dm: DatasetMetadata, userInfo: UserInfo): Try[Elem] = {
-    if (userInfo == null) Failure(new IllegalArgumentException("no user attributes"))
-    else for {
+    for {
       _ <- dm.depositAgreementAccepted
       privacy <- dm.hasPrivacySensitiveData
     } yield

--- a/src/main/scala/nl.knaw.dans.easy.deposit/docs/AgreementsXml.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/docs/AgreementsXml.scala
@@ -30,9 +30,9 @@ object AgreementsXml extends SchemedXml {
     else for {
       _ <- dm.depositAgreementAccepted
       privacy <- dm.hasPrivacySensitiveData
-      userId <- Try(userProperties("userId").headOption.getOrElse(throw CorruptUserException(s"$userProperties has no userId")))
+      userId <- Try(userProperties("uid").headOption.getOrElse(throw CorruptUserException(s"$userProperties has no userId")))
       displayName <- Try(userProperties("displayName").headOption.getOrElse(throw CorruptUserException(s"$userProperties has no displayName")))
-      email <- Try(userProperties("email").headOption.getOrElse(throw CorruptUserException(s"$userProperties has no email")))
+      email <- Try(userProperties("mail").headOption.getOrElse(throw CorruptUserException(s"$userProperties has no email")))
     } yield
       <agreements
           xmlns={schemaNameSpace}

--- a/src/main/scala/nl.knaw.dans.easy.deposit/docs/AgreementsXml.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/docs/AgreementsXml.scala
@@ -24,8 +24,8 @@ object AgreementsXml extends SchemedXml {
   override val schemaNameSpace = "http://easy.dans.knaw.nl/schemas/bag/metadata/agreements/"
   override val schemaLocation = "https://easy.dans.knaw.nl/schemas/bag/metadata/agreements/2019/09/agreements.xsd"
 
-  def apply(dateSubmitted: DateTime, dm: DatasetMetadata, userProperties: UserInfo): Try[Elem] = {
-    if (userProperties == null) Failure(new IllegalArgumentException("no user attributes"))
+  def apply(dateSubmitted: DateTime, dm: DatasetMetadata, userInfo: UserInfo): Try[Elem] = {
+    if (userInfo == null) Failure(new IllegalArgumentException("no user attributes"))
     else for {
       _ <- dm.depositAgreementAccepted
       privacy <- dm.hasPrivacySensitiveData
@@ -36,12 +36,12 @@ object AgreementsXml extends SchemedXml {
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xsi:schemaLocation={s"$schemaNameSpace $schemaLocation"}>
         <depositAgreement>
-          <signerId easy-account={userProperties.userName} email={userProperties.email}>{userProperties.displayName}</signerId>
+          <signerId easy-account={userInfo.userName} email={userInfo.email}>{userInfo.displayName}</signerId>
           <dcterms:dateAccepted>{dateSubmitted}</dcterms:dateAccepted>
           <depositAgreementAccepted>{dm.acceptDepositAgreement}</depositAgreementAccepted>
         </depositAgreement>
         <personalDataStatement>
-          <signerId easy-account={userProperties.userName} email={userProperties.email}>{userProperties.displayName}</signerId>
+          <signerId easy-account={userInfo.userName} email={userInfo.email}>{userInfo.displayName}</signerId>
           <dateSigned>{dateSubmitted}</dateSigned>
           <containsPrivacySensitiveData>{privacy}</containsPrivacySensitiveData>
         </personalDataStatement>

--- a/src/main/scala/nl.knaw.dans.easy.deposit/docs/AgreementsXml.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/docs/AgreementsXml.scala
@@ -23,7 +23,7 @@ import scala.xml.Elem
 
 object AgreementsXml extends SchemedXml {
   override val schemaNameSpace = "http://easy.dans.knaw.nl/schemas/bag/metadata/agreements/"
-  override val schemaLocation = "https://easy.dans.knaw.nl/schemas/bag/metadata/agreements/2019/01/agreements.xsd"
+  override val schemaLocation = "https://easy.dans.knaw.nl/schemas/bag/metadata/agreements/2019/09/agreements.xsd"
 
   def apply(dateSubmitted: DateTime, dm: DatasetMetadata, userProperties: Map[String, Seq[String]]): Try[Elem] = {
     if (userProperties == null) Failure(CorruptUserException("no user attributes"))

--- a/src/main/scala/nl.knaw.dans.easy.deposit/docs/UserInfo.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/docs/UserInfo.scala
@@ -25,6 +25,7 @@ case class UserInfo(userName: String,
                     prefix: Option[String] = None,
                     lastName: String,
                     displayName: String,
+                    email: String,
                    )
 object UserInfo {
   def apply(input: JsonInput): Try[UserInfo] = input.deserialize[UserInfo]
@@ -43,6 +44,7 @@ object UserInfo {
 
       lastName = attributes.getOrElse("sn", Seq.empty).headOption.getOrElse(""),
       displayName = attributes.getOrElse("displayName", Seq.empty).headOption.getOrElse(""),
+      email = attributes.getOrElse("mail", Seq.empty).headOption.getOrElse(""),
     )
   }
 }

--- a/src/main/scala/nl.knaw.dans.easy.deposit/docs/UserInfo.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/docs/UserInfo.scala
@@ -33,27 +33,31 @@ object UserInfo extends DebugEnhancedLogging {
 
   def apply(attributes: Map[String, Seq[String]]): UserInfo = {
 
-    def getAttribute(key: String) = {
+    def getOption(key: String): Option[String] = {
       attributes
         .getOrElse(key, Seq.empty)
         .headOption
-        .getOrElse {
-          logger.warn(s"user has no attribute '$key' $attributes")
-          ""
-        }
     }
 
-    // For possible attribute keys see: https://github.com/DANS-KNAW/dans.easy-test-users/blob/master/templates
+    def getAttribute(key: String): String = {
+      getOption(key).getOrElse {
+        logger.warn(s"user has no attribute '$key' $attributes")
+        ""
+      }
+    }
+
+    // For possible attribute keys see
+    // https://github.com/DANS-KNAW/easy-app/blob/master/lib-deprecated/dans-ldap/src/main/java/nl/knaw/dans/common/ldap/management/
+    //   DANSSchema.java
+    //   EasySchema.java
+    // https://github.com/DANS-KNAW/dans.easy-test-users/blob/master/templates
     new UserInfo(
 
       // mandatory: https://github.com/DANS-KNAW/dans.easy-ldap-dir/blob/f17c391/files/easy-schema.ldif#L83-L84
       userName = getAttribute("uid"),
 
-      firstName = attributes.getOrElse("cn", Seq.empty).headOption,
-
-      // https://github.com/DANS-KNAW/easy-app/blob/b41e9e93e35f97af00c48d0515b09cc57bc5ba6c/lib-deprecated/dans-ldap/src/main/java/nl/knaw/dans/common/ldap/management/DANSSchema.java#L33-L34
-      prefix = attributes.get("dansPrefixes").map(s => s.mkString(" ")),
-
+      firstName = getOption("cn"),
+      prefix = getOption("dansPrefixes"),
       lastName = getAttribute("sn"),
       displayName = getAttribute("displayName"),
       email = getAttribute("mail"),

--- a/src/main/scala/nl.knaw.dans.easy.deposit/docs/UserInfo.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/docs/UserInfo.scala
@@ -42,6 +42,8 @@ object UserInfo extends DebugEnhancedLogging {
           ""
         }
     }
+
+    // For possible attribute keys see: https://github.com/DANS-KNAW/dans.easy-test-users/blob/master/templates
     new UserInfo(
 
       // mandatory: https://github.com/DANS-KNAW/dans.easy-ldap-dir/blob/f17c391/files/easy-schema.ldif#L83-L84

--- a/src/main/scala/nl.knaw.dans.easy.deposit/servlets/UserServlet.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/servlets/UserServlet.scala
@@ -27,7 +27,7 @@ class UserServlet(app: EasyDepositApiApp) extends ProtectedServlet(app) {
 
   get("/") {
     Try(app.getUserProperties(user.id)).flatten // no throw should slip through
-      .map(properties => Ok(toJson(UserInfo(properties))))
+      .map(userInfo => Ok(toJson(userInfo)))
       .getOrRecoverWithActionResult
   }
   put("/") {

--- a/src/main/scala/nl.knaw.dans.easy.deposit/servlets/UserServlet.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/servlets/UserServlet.scala
@@ -26,7 +26,7 @@ import scala.util.Try
 class UserServlet(app: EasyDepositApiApp) extends ProtectedServlet(app) {
 
   get("/") {
-    Try(app.getUserProperties(user.id)).flatten // no throw should slip through
+    Try(app.getUserInfo(user.id)).flatten // no throw should slip through
       .map(userInfo => Ok(toJson(userInfo)))
       .getOrRecoverWithActionResult
   }

--- a/src/main/scala/nl.knaw.dans.easy.deposit/servlets/UserServlet.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/servlets/UserServlet.scala
@@ -26,7 +26,7 @@ import scala.util.Try
 class UserServlet(app: EasyDepositApiApp) extends ProtectedServlet(app) {
 
   get("/") {
-    Try(app.getUser(user.id)).flatten // no throw should slip through
+    Try(app.getUserProperties(user.id)).flatten // no throw should slip through
       .map(properties => Ok(toJson(UserInfo(properties))))
       .getOrRecoverWithActionResult
   }

--- a/src/test/scala/nl.knaw.dans.easy.deposit/EasyDepositApiAppSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/EasyDepositApiAppSpec.scala
@@ -17,7 +17,6 @@ package nl.knaw.dans.easy.deposit
 
 import java.util.UUID
 
-import nl.knaw.dans.easy.deposit.PidRequesterComponent.PidRequester
 import nl.knaw.dans.easy.deposit.docs.DepositInfo
 import nl.knaw.dans.easy.deposit.docs.StateInfo.State
 import nl.knaw.dans.easy.deposit.docs.StateInfo.State.State

--- a/src/test/scala/nl.knaw.dans.easy.deposit/EasyDepositApiAppSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/EasyDepositApiAppSpec.scala
@@ -28,9 +28,7 @@ import org.joda.time.DateTimeZone.UTC
 import scala.util.Success
 
 class EasyDepositApiAppSpec extends TestSupportFixture {
-  private val app: EasyDepositApiApp = new EasyDepositApiApp(minimalAppConfig) {
-    override val pidRequester: PidRequester = mockPidRequester
-  }
+  private val app: EasyDepositApiApp = createTestApp
 
   private val defaultUser: String = "user001"
 
@@ -52,7 +50,7 @@ class EasyDepositApiAppSpec extends TestSupportFixture {
     copyDepositToSubmitArea(deposit5.id)
 
     // the state is required for the pattern match but the description is error prone and beyond the scope of the test
-    val expectedState = app.getDepositState(defaultUser,deposit5.id).getOrElse(fail())
+    val expectedState = app.getDepositState(defaultUser, deposit5.id).getOrElse(fail())
 
     val testResult = app.getDeposits(defaultUser)
     inside(testResult) {

--- a/src/test/scala/nl.knaw.dans.easy.deposit/StateManagerSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/StateManagerSpec.scala
@@ -61,7 +61,7 @@ class StateManagerSpec extends TestSupportFixture {
       """.stripMargin)
     StateManager(draftDeposit, submitBase, easyHome).getStateInfo shouldBe Success(StateInfo(
       State.submitted,
-      mailtoMessage(s"""mailto:does.not.exist@dans.knaw.nl?subject=Deposit%20processing%20error:%20%20reference%20DRAFT/foo/7fa835ce-0987-4064-90ca-a7b75ce78a16&body=Dear%20data%20manager%2C%0A%0ASomething%20went%20wrong%20while%20processing%20my%20deposit.%20Could%20you%20please%20investigate%20the%20issue?%0A%0ADataset%20reference:%0A%20%20%20DRAFT/foo/7fa835ce-0987-4064-90ca-a7b75ce78a16%0ATitle:%0A%20%20%20%0A%0AKind%20regards%2C%0Afoo%0A""")
+      mailtoMessage(s"""mailto:info@dans.knaw.nl?subject=Deposit%20processing%20error:%20%20reference%20DRAFT/foo/7fa835ce-0987-4064-90ca-a7b75ce78a16&body=Dear%20data%20manager%2C%0A%0ASomething%20went%20wrong%20while%20processing%20my%20deposit.%20Could%20you%20please%20investigate%20the%20issue?%0A%0ADataset%20reference:%0A%20%20%20DRAFT/foo/7fa835ce-0987-4064-90ca-a7b75ce78a16%0ATitle:%0A%20%20%20%0A%0AKind%20regards%2C%0Afoo%0A""")
     ))
   }
 
@@ -74,7 +74,7 @@ class StateManagerSpec extends TestSupportFixture {
       """.stripMargin)
     StateManager(draftDeposit, submitBase, easyHome).getStateInfo shouldBe Success(StateInfo(
       State.submitted,
-      mailtoMessage(s"""mailto:does.not.exist@dans.knaw.nl?subject=Deposit%20processing%20error:%20%20reference%20a890ad74-872b-4f21-81a8-f3ef88b944ba&body=Dear%20data%20manager%2C%0A%0ASomething%20went%20wrong%20while%20processing%20my%20deposit.%20Could%20you%20please%20investigate%20the%20issue?%0A%0ADataset%20reference:%0A%20%20%20a890ad74-872b-4f21-81a8-f3ef88b944ba%0ATitle:%0A%20%20%20%0A%0AKind%20regards%2C%0Afoo%0A""")
+      mailtoMessage(s"""mailto:info@dans.knaw.nl?subject=Deposit%20processing%20error:%20%20reference%20a890ad74-872b-4f21-81a8-f3ef88b944ba&body=Dear%20data%20manager%2C%0A%0ASomething%20went%20wrong%20while%20processing%20my%20deposit.%20Could%20you%20please%20investigate%20the%20issue?%0A%0ADataset%20reference:%0A%20%20%20a890ad74-872b-4f21-81a8-f3ef88b944ba%0ATitle:%0A%20%20%20%0A%0AKind%20regards%2C%0Afoo%0A""")
     ))
   }
 
@@ -128,7 +128,7 @@ class StateManagerSpec extends TestSupportFixture {
       .write("""{"titles":["A test with a title longer than forty-two characters."]}""")
     StateManager(draftDeposit, submitBase, easyHome).getStateInfo shouldBe Success(StateInfo(
       State.submitted,
-      mailtoMessage("""mailto:does.not.exist@dans.knaw.nl?subject=Deposit%20processing%20error:%20A%20test%20with%20a%20title%20longer%20than%20forty-two%20%E2%80%A6%20reference%20DRAFT/foo/7fa835ce-0987-4064-90ca-a7b75ce78a16&body=Dear%20data%20manager%2C%0A%0ASomething%20went%20wrong%20while%20processing%20my%20deposit.%20Could%20you%20please%20investigate%20the%20issue?%0A%0ADataset%20reference:%0A%20%20%20DRAFT/foo/7fa835ce-0987-4064-90ca-a7b75ce78a16%0ATitle:%0A%20%20%20A%20test%20with%20a%20title%20longer%20than%20forty-two%20%E2%80%A6%0A%0AKind%20regards%2C%0Afoo%0A""")
+      mailtoMessage("""mailto:info@dans.knaw.nl?subject=Deposit%20processing%20error:%20A%20test%20with%20a%20title%20longer%20than%20forty-two%20%E2%80%A6%20reference%20DRAFT/foo/7fa835ce-0987-4064-90ca-a7b75ce78a16&body=Dear%20data%20manager%2C%0A%0ASomething%20went%20wrong%20while%20processing%20my%20deposit.%20Could%20you%20please%20investigate%20the%20issue?%0A%0ADataset%20reference:%0A%20%20%20DRAFT/foo/7fa835ce-0987-4064-90ca-a7b75ce78a16%0ATitle:%0A%20%20%20A%20test%20with%20a%20title%20longer%20than%20forty-two%20%E2%80%A6%0A%0AKind%20regards%2C%0Afoo%0A""")
     ))
   }
 
@@ -151,7 +151,7 @@ class StateManagerSpec extends TestSupportFixture {
           | "]}""".stripMargin)
     StateManager(draftDeposit, submitBase, easyHome).getStateInfo shouldBe Success(StateInfo(
       State.submitted,
-      mailtoMessage("""mailto:does.not.exist@dans.knaw.nl?subject=Deposit%20processing%20error:%20A%20test%20with%20%20new%20lines%20and%20html%20%E2%80%A6%20reference%20a890ad74-872b-4f21-81a8-f3ef88b944ba&body=Dear%20data%20manager%2C%0A%0ASomething%20went%20wrong%20while%20processing%20my%20deposit.%20Could%20you%20please%20investigate%20the%20issue?%0A%0ADataset%20reference:%0A%20%20%20a890ad74-872b-4f21-81a8-f3ef88b944ba%0ATitle:%0A%20%20%20A%20test%20with%20%20new%20lines%20and%20html%20%E2%80%A6%0A%0AKind%20regards%2C%0Afoo%0A""")
+      mailtoMessage("""mailto:info@dans.knaw.nl?subject=Deposit%20processing%20error:%20A%20test%20with%20%20new%20lines%20and%20html%20%E2%80%A6%20reference%20a890ad74-872b-4f21-81a8-f3ef88b944ba&body=Dear%20data%20manager%2C%0A%0ASomething%20went%20wrong%20while%20processing%20my%20deposit.%20Could%20you%20please%20investigate%20the%20issue?%0A%0ADataset%20reference:%0A%20%20%20a890ad74-872b-4f21-81a8-f3ef88b944ba%0ATitle:%0A%20%20%20A%20test%20with%20%20new%20lines%20and%20html%20%E2%80%A6%0A%0AKind%20regards%2C%0Afoo%0A""")
     ))
   }
 

--- a/src/test/scala/nl.knaw.dans.easy.deposit/StateManagerSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/StateManagerSpec.scala
@@ -61,7 +61,7 @@ class StateManagerSpec extends TestSupportFixture {
       """.stripMargin)
     StateManager(draftDeposit, submitBase, easyHome).getStateInfo shouldBe Success(StateInfo(
       State.submitted,
-      mailtoMessage(s"""mailto:info@dans.knaw.nl?subject=Deposit%20processing%20error:%20%20reference%20DRAFT/foo/7fa835ce-0987-4064-90ca-a7b75ce78a16&body=Dear%20data%20manager%2C%0A%0ASomething%20went%20wrong%20while%20processing%20my%20deposit.%20Could%20you%20please%20investigate%20the%20issue?%0A%0ADataset%20reference:%0A%20%20%20DRAFT/foo/7fa835ce-0987-4064-90ca-a7b75ce78a16%0ATitle:%0A%20%20%20%0A%0AKind%20regards%2C%0Afoo%0A""")
+      mailtoMessage(s"""mailto:does.not.exist@dans.knaw.nl?subject=Deposit%20processing%20error:%20%20reference%20DRAFT/foo/7fa835ce-0987-4064-90ca-a7b75ce78a16&body=Dear%20data%20manager%2C%0A%0ASomething%20went%20wrong%20while%20processing%20my%20deposit.%20Could%20you%20please%20investigate%20the%20issue?%0A%0ADataset%20reference:%0A%20%20%20DRAFT/foo/7fa835ce-0987-4064-90ca-a7b75ce78a16%0ATitle:%0A%20%20%20%0A%0AKind%20regards%2C%0Afoo%0A""")
     ))
   }
 
@@ -74,7 +74,7 @@ class StateManagerSpec extends TestSupportFixture {
       """.stripMargin)
     StateManager(draftDeposit, submitBase, easyHome).getStateInfo shouldBe Success(StateInfo(
       State.submitted,
-      mailtoMessage(s"""mailto:info@dans.knaw.nl?subject=Deposit%20processing%20error:%20%20reference%20a890ad74-872b-4f21-81a8-f3ef88b944ba&body=Dear%20data%20manager%2C%0A%0ASomething%20went%20wrong%20while%20processing%20my%20deposit.%20Could%20you%20please%20investigate%20the%20issue?%0A%0ADataset%20reference:%0A%20%20%20a890ad74-872b-4f21-81a8-f3ef88b944ba%0ATitle:%0A%20%20%20%0A%0AKind%20regards%2C%0Afoo%0A""")
+      mailtoMessage(s"""mailto:does.not.exist@dans.knaw.nl?subject=Deposit%20processing%20error:%20%20reference%20a890ad74-872b-4f21-81a8-f3ef88b944ba&body=Dear%20data%20manager%2C%0A%0ASomething%20went%20wrong%20while%20processing%20my%20deposit.%20Could%20you%20please%20investigate%20the%20issue?%0A%0ADataset%20reference:%0A%20%20%20a890ad74-872b-4f21-81a8-f3ef88b944ba%0ATitle:%0A%20%20%20%0A%0AKind%20regards%2C%0Afoo%0A""")
     ))
   }
 
@@ -128,7 +128,7 @@ class StateManagerSpec extends TestSupportFixture {
       .write("""{"titles":["A test with a title longer than forty-two characters."]}""")
     StateManager(draftDeposit, submitBase, easyHome).getStateInfo shouldBe Success(StateInfo(
       State.submitted,
-      mailtoMessage("""mailto:info@dans.knaw.nl?subject=Deposit%20processing%20error:%20A%20test%20with%20a%20title%20longer%20than%20forty-two%20%E2%80%A6%20reference%20DRAFT/foo/7fa835ce-0987-4064-90ca-a7b75ce78a16&body=Dear%20data%20manager%2C%0A%0ASomething%20went%20wrong%20while%20processing%20my%20deposit.%20Could%20you%20please%20investigate%20the%20issue?%0A%0ADataset%20reference:%0A%20%20%20DRAFT/foo/7fa835ce-0987-4064-90ca-a7b75ce78a16%0ATitle:%0A%20%20%20A%20test%20with%20a%20title%20longer%20than%20forty-two%20%E2%80%A6%0A%0AKind%20regards%2C%0Afoo%0A""")
+      mailtoMessage("""mailto:does.not.exist@dans.knaw.nl?subject=Deposit%20processing%20error:%20A%20test%20with%20a%20title%20longer%20than%20forty-two%20%E2%80%A6%20reference%20DRAFT/foo/7fa835ce-0987-4064-90ca-a7b75ce78a16&body=Dear%20data%20manager%2C%0A%0ASomething%20went%20wrong%20while%20processing%20my%20deposit.%20Could%20you%20please%20investigate%20the%20issue?%0A%0ADataset%20reference:%0A%20%20%20DRAFT/foo/7fa835ce-0987-4064-90ca-a7b75ce78a16%0ATitle:%0A%20%20%20A%20test%20with%20a%20title%20longer%20than%20forty-two%20%E2%80%A6%0A%0AKind%20regards%2C%0Afoo%0A""")
     ))
   }
 
@@ -151,7 +151,7 @@ class StateManagerSpec extends TestSupportFixture {
           | "]}""".stripMargin)
     StateManager(draftDeposit, submitBase, easyHome).getStateInfo shouldBe Success(StateInfo(
       State.submitted,
-      mailtoMessage("""mailto:info@dans.knaw.nl?subject=Deposit%20processing%20error:%20A%20test%20with%20%20new%20lines%20and%20html%20%E2%80%A6%20reference%20a890ad74-872b-4f21-81a8-f3ef88b944ba&body=Dear%20data%20manager%2C%0A%0ASomething%20went%20wrong%20while%20processing%20my%20deposit.%20Could%20you%20please%20investigate%20the%20issue?%0A%0ADataset%20reference:%0A%20%20%20a890ad74-872b-4f21-81a8-f3ef88b944ba%0ATitle:%0A%20%20%20A%20test%20with%20%20new%20lines%20and%20html%20%E2%80%A6%0A%0AKind%20regards%2C%0Afoo%0A""")
+      mailtoMessage("""mailto:does.not.exist@dans.knaw.nl?subject=Deposit%20processing%20error:%20A%20test%20with%20%20new%20lines%20and%20html%20%E2%80%A6%20reference%20a890ad74-872b-4f21-81a8-f3ef88b944ba&body=Dear%20data%20manager%2C%0A%0ASomething%20went%20wrong%20while%20processing%20my%20deposit.%20Could%20you%20please%20investigate%20the%20issue?%0A%0ADataset%20reference:%0A%20%20%20a890ad74-872b-4f21-81a8-f3ef88b944ba%0ATitle:%0A%20%20%20A%20test%20with%20%20new%20lines%20and%20html%20%E2%80%A6%0A%0AKind%20regards%2C%0Afoo%0A""")
     ))
   }
 

--- a/src/test/scala/nl.knaw.dans.easy.deposit/SubmitterSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/SubmitterSpec.scala
@@ -57,7 +57,7 @@ class SubmitterSpec extends TestSupportFixture with MockFactory {
       .getOrRecover(e => fail(s"could not get stateManager of test deposit $e"))
     addDoiToDepositProperties(getBag(depositDir))
 
-    createSubmitter(unrelatedGroup).submit(depositDir, stateManager, UserInfo(userMap), testDir / "staged") should matchPattern {
+    createSubmitter(unrelatedGroup).submit(depositDir, stateManager, defaultUserInfo, testDir / "staged") should matchPattern {
       case Failure(e: IOException) if e.getMessage matches
         ".*Probably the current user .* is not part of this group.*" =>
     }
@@ -138,7 +138,7 @@ class SubmitterSpec extends TestSupportFixture with MockFactory {
     val stateManager = deposit.getStateManager(testDir / "submitted", easyHome)
       .getOrRecover(e => fail(s"could not get stateManager of test deposit $e"))
 
-    val triedBagStoreBagID = createSubmitter(userGroup).submit(deposit, stateManager, UserInfo(userMap), testDir / "staged")
+    val triedBagStoreBagID = createSubmitter(userGroup).submit(deposit, stateManager, defaultUserInfo, testDir / "staged")
     triedBagStoreBagID shouldBe a[Success[_]]
     triedBagStoreBagID
       .map(_.toString)
@@ -157,7 +157,7 @@ class SubmitterSpec extends TestSupportFixture with MockFactory {
     // add file to manifest that does not exist
     (bag.baseDir / "manifest-sha1.txt").append("chk file")
 
-    createSubmitter(userGroup).submit(depositDir, stateManager, UserInfo(userMap), testDir / "staged") should matchPattern {
+    createSubmitter(userGroup).submit(depositDir, stateManager, defaultUserInfo, testDir / "staged") should matchPattern {
       case Failure(e) if e.getMessage == s"invalid bag, missing [files, checksums]: [Set($testDir/drafts/user/${ depositDir.id }/bag/file), Set()]" =>
     }
   }
@@ -176,7 +176,7 @@ class SubmitterSpec extends TestSupportFixture with MockFactory {
     manifest.write(manifest.contentAsString.replaceAll(" +", "xxx  "))
 
     val checksum = "a57ec0c3239f30b29f1e9270581be50a70c74c04"
-    createSubmitter(userGroup).submit(depositDir, stateManager, UserInfo(userMap), testDir / "staged") should matchPattern {
+    createSubmitter(userGroup).submit(depositDir, stateManager, defaultUserInfo, testDir / "staged") should matchPattern {
       case Failure(e)
         if e.getMessage == s"staged and draft bag [${ bag.baseDir.parent }] have different payload manifest elements: (Set((data/file.txt,$checksum)),Set((data/file.txt,${ checksum }xxx)))" =>
     }

--- a/src/test/scala/nl.knaw.dans.easy.deposit/SubmitterSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/SubmitterSpec.scala
@@ -57,7 +57,7 @@ class SubmitterSpec extends TestSupportFixture with MockFactory {
       .getOrRecover(e => fail(s"could not get stateManager of test deposit $e"))
     addDoiToDepositProperties(getBag(depositDir))
 
-    createSubmitter(unrelatedGroup).submit(depositDir, stateManager, userMap, testDir / "staged") should matchPattern {
+    createSubmitter(unrelatedGroup).submit(depositDir, stateManager, UserInfo(userMap), testDir / "staged") should matchPattern {
       case Failure(e: IOException) if e.getMessage matches
         ".*Probably the current user .* is not part of this group.*" =>
     }
@@ -86,7 +86,7 @@ class SubmitterSpec extends TestSupportFixture with MockFactory {
     (bagDir / "metadata" / "dataset.json").size shouldBe mdOldSize
     // no DOI added
     val submittedBagDir = testDir / "submitted" / bagStoreBagID / bagDirName
-    (submittedBagDir / "metadata" / "depositor-info" / "message-from-depositor.txt").contentAsString shouldBe s"$customMessage\n\nThe deposit can be found at http://does.not.exist/${depositDir.id}"
+    (submittedBagDir / "metadata" / "depositor-info" / "message-from-depositor.txt").contentAsString shouldBe s"$customMessage\n\nThe deposit can be found at http://does.not.exist/${ depositDir.id }"
     (submittedBagDir / "metadata" / "depositor-info" / "agreements.xml").lineIterator.next() shouldBe prologue
     (submittedBagDir / "metadata" / "dataset.xml").lineIterator.next() shouldBe prologue
     (submittedBagDir / "data").children.size shouldBe (bagDir / "data").children.size
@@ -107,7 +107,7 @@ class SubmitterSpec extends TestSupportFixture with MockFactory {
     val bagStoreBagId = succeedingSubmit(depositDir)
 
     (testDir / "submitted" / bagStoreBagId / bagDirName / "metadata" / "depositor-info" / "message-from-depositor.txt")
-      .contentAsString shouldBe s"The deposit can be found at http://does.not.exist/${depositDir.id}"
+      .contentAsString shouldBe s"The deposit can be found at http://does.not.exist/${ depositDir.id }"
   }
 
   it should "overwrite a previous bag-store.bag-id at resubmit" in {
@@ -138,7 +138,7 @@ class SubmitterSpec extends TestSupportFixture with MockFactory {
     val stateManager = deposit.getStateManager(testDir / "submitted", easyHome)
       .getOrRecover(e => fail(s"could not get stateManager of test deposit $e"))
 
-    val triedBagStoreBagID = createSubmitter(userGroup).submit(deposit, stateManager, userMap, testDir / "staged")
+    val triedBagStoreBagID = createSubmitter(userGroup).submit(deposit, stateManager, UserInfo(userMap), testDir / "staged")
     triedBagStoreBagID shouldBe a[Success[_]]
     triedBagStoreBagID
       .map(_.toString)
@@ -157,7 +157,7 @@ class SubmitterSpec extends TestSupportFixture with MockFactory {
     // add file to manifest that does not exist
     (bag.baseDir / "manifest-sha1.txt").append("chk file")
 
-    createSubmitter(userGroup).submit(depositDir, stateManager, userMap, testDir / "staged") should matchPattern {
+    createSubmitter(userGroup).submit(depositDir, stateManager, UserInfo(userMap), testDir / "staged") should matchPattern {
       case Failure(e) if e.getMessage == s"invalid bag, missing [files, checksums]: [Set($testDir/drafts/user/${ depositDir.id }/bag/file), Set()]" =>
     }
   }
@@ -176,7 +176,7 @@ class SubmitterSpec extends TestSupportFixture with MockFactory {
     manifest.write(manifest.contentAsString.replaceAll(" +", "xxx  "))
 
     val checksum = "a57ec0c3239f30b29f1e9270581be50a70c74c04"
-    createSubmitter(userGroup).submit(depositDir, stateManager, userMap, testDir / "staged") should matchPattern {
+    createSubmitter(userGroup).submit(depositDir, stateManager, UserInfo(userMap), testDir / "staged") should matchPattern {
       case Failure(e)
         if e.getMessage == s"staged and draft bag [${ bag.baseDir.parent }] have different payload manifest elements: (Set((data/file.txt,$checksum)),Set((data/file.txt,${ checksum }xxx)))" =>
     }

--- a/src/test/scala/nl.knaw.dans.easy.deposit/SubmitterSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/SubmitterSpec.scala
@@ -57,7 +57,7 @@ class SubmitterSpec extends TestSupportFixture with MockFactory {
       .getOrRecover(e => fail(s"could not get stateManager of test deposit $e"))
     addDoiToDepositProperties(getBag(depositDir))
 
-    createSubmitter(unrelatedGroup).submit(depositDir, stateManager, "fullName", testDir / "staged") should matchPattern {
+    createSubmitter(unrelatedGroup).submit(depositDir, stateManager, userMap, testDir / "staged") should matchPattern {
       case Failure(e: IOException) if e.getMessage matches
         ".*Probably the current user .* is not part of this group.*" =>
     }
@@ -138,7 +138,7 @@ class SubmitterSpec extends TestSupportFixture with MockFactory {
     val stateManager = deposit.getStateManager(testDir / "submitted", easyHome)
       .getOrRecover(e => fail(s"could not get stateManager of test deposit $e"))
 
-    val triedBagStoreBagID = createSubmitter(userGroup).submit(deposit, stateManager, "fullName", testDir / "staged")
+    val triedBagStoreBagID = createSubmitter(userGroup).submit(deposit, stateManager, userMap, testDir / "staged")
     triedBagStoreBagID shouldBe a[Success[_]]
     triedBagStoreBagID
       .map(_.toString)
@@ -157,7 +157,7 @@ class SubmitterSpec extends TestSupportFixture with MockFactory {
     // add file to manifest that does not exist
     (bag.baseDir / "manifest-sha1.txt").append("chk file")
 
-    createSubmitter(userGroup).submit(depositDir, stateManager, "fullName", testDir / "staged") should matchPattern {
+    createSubmitter(userGroup).submit(depositDir, stateManager, userMap, testDir / "staged") should matchPattern {
       case Failure(e) if e.getMessage == s"invalid bag, missing [files, checksums]: [Set($testDir/drafts/user/${ depositDir.id }/bag/file), Set()]" =>
     }
   }
@@ -176,7 +176,7 @@ class SubmitterSpec extends TestSupportFixture with MockFactory {
     manifest.write(manifest.contentAsString.replaceAll(" +", "xxx  "))
 
     val checksum = "a57ec0c3239f30b29f1e9270581be50a70c74c04"
-    createSubmitter(userGroup).submit(depositDir, stateManager, "fullName", testDir / "staged") should matchPattern {
+    createSubmitter(userGroup).submit(depositDir, stateManager, userMap, testDir / "staged") should matchPattern {
       case Failure(e)
         if e.getMessage == s"staged and draft bag [${ bag.baseDir.parent }] have different payload manifest elements: (Set((data/file.txt,$checksum)),Set((data/file.txt,${ checksum }xxx)))" =>
     }

--- a/src/test/scala/nl.knaw.dans.easy.deposit/TestSupportFixture.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/TestSupportFixture.scala
@@ -100,7 +100,7 @@ trait TestSupportFixture extends FlatSpec with Matchers with Inside with BeforeA
     new EasyDepositApiApp(minimalAppConfig) {
       override val pidRequester: PidRequester = mockPidRequester
 
-      override def getUserProperties(user: String): Try[UserInfo] = {
+      override def getUserInfo(user: String): Try[UserInfo] = {
         Success(defaultUserInfo)
       }
     }

--- a/src/test/scala/nl.knaw.dans.easy.deposit/TestSupportFixture.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/TestSupportFixture.scala
@@ -15,20 +15,20 @@
  */
 package nl.knaw.dans.easy.deposit
 
-import java.util.{ TimeZone, UUID }
+import java.util.{TimeZone, UUID}
 
 import better.files.File
 import better.files.File._
 import nl.knaw.dans.easy.deposit.PidRequesterComponent.PidRequester
 import nl.knaw.dans.easy.deposit.authentication.TokenSupport.TokenConfig
-import nl.knaw.dans.easy.deposit.authentication.{ AuthConfig, AuthUser, AuthenticationProvider, TokenSupport }
+import nl.knaw.dans.easy.deposit.authentication.{AuthConfig, AuthUser, AuthenticationProvider, TokenSupport}
 import org.apache.commons.configuration.PropertiesConfiguration
-import org.joda.time.{ DateTime, DateTimeUtils, DateTimeZone }
+import org.joda.time.{DateTime, DateTimeUtils, DateTimeZone}
 import org.scalamock.scalatest.MockFactory
 import org.scalatest._
 import org.scalatest.enablers.Existence
 
-import scala.util.Properties
+import scala.util.{Properties, Success, Try}
 
 trait TestSupportFixture extends FlatSpec with Matchers with Inside with BeforeAndAfterEach with MockFactory {
   implicit def existenceOfFile[FILE <: better.files.File]: Existence[FILE] = _.exists
@@ -71,13 +71,14 @@ trait TestSupportFixture extends FlatSpec with Matchers with Inside with BeforeA
   }
 
   val nowYMD = "2018-03-22"
-  val now = s"${ nowYMD }T21:43:01.576"
-  val nowUTC = s"${ nowYMD }T20:43:01Z"
+  val now = s"${nowYMD}T21:43:01.576"
+  val nowUTC = s"${nowYMD}T20:43:01Z"
   /** Causes DateTime.now() to return a predefined value. */
   DateTimeUtils.setCurrentMillisFixed(new DateTime(nowUTC).getMillis)
   DateTimeZone.setDefault(DateTimeZone.forTimeZone(TimeZone.getTimeZone("Europe/Amsterdam")))
 
   trait MockedPidRequester extends PidRequester with HttpContext
+
   def mockPidRequester: PidRequester = mock[MockedPidRequester]
 
   def minimalAppConfig: Configuration = {
@@ -98,11 +99,22 @@ trait TestSupportFixture extends FlatSpec with Matchers with Inside with BeforeA
     })
   }
 
+  def createTestApp: EasyDepositApiApp = {
+    new EasyDepositApiApp(minimalAppConfig) {
+      override val pidRequester: PidRequester = mockPidRequester
+
+      override def getUserProperties(user: String): Try[Map[String, Seq[String]]] = {
+        Success(userMap)
+      }
+    }
+  }
+
   private def testSubDir(drafts: String): File = {
     (testDir / drafts)
       .delete(swallowIOExceptions = true)
       .createIfNotExists(asDirectory = true, createParents = true)
   }
+
   private class TokenSupportImpl() extends TokenSupport with AuthConfig {
 
     // required by AuthConfig but not by TokenSupport
@@ -110,6 +122,7 @@ trait TestSupportFixture extends FlatSpec with Matchers with Inside with BeforeA
 
     def getProperties: PropertiesConfiguration = new PropertiesConfiguration()
   }
+
   private val tokenSupport = new TokenSupportImpl()
 
   def jwtConfig: TokenConfig = tokenSupport.tokenConfig

--- a/src/test/scala/nl.knaw.dans.easy.deposit/TestSupportFixture.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/TestSupportFixture.scala
@@ -53,6 +53,11 @@ trait TestSupportFixture extends FlatSpec with Matchers with Inside with BeforeA
     }
   }
 
+  val userMap: Map[String, Seq[String]] = Map(
+    "displayName" -> Seq("fullName"),
+    "email" -> Seq("info@dans.knaw.nl"),
+  )
+
   def testResource(file: String): File = File(getClass.getResource(file))
 
   def getManualTestResource(file: String): String = {

--- a/src/test/scala/nl.knaw.dans.easy.deposit/TestSupportFixture.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/TestSupportFixture.scala
@@ -15,20 +15,21 @@
  */
 package nl.knaw.dans.easy.deposit
 
-import java.util.{TimeZone, UUID}
+import java.util.{ TimeZone, UUID }
 
 import better.files.File
 import better.files.File._
 import nl.knaw.dans.easy.deposit.PidRequesterComponent.PidRequester
 import nl.knaw.dans.easy.deposit.authentication.TokenSupport.TokenConfig
-import nl.knaw.dans.easy.deposit.authentication.{AuthConfig, AuthUser, AuthenticationProvider, TokenSupport}
+import nl.knaw.dans.easy.deposit.authentication.{ AuthConfig, AuthUser, AuthenticationProvider, TokenSupport }
+import nl.knaw.dans.easy.deposit.docs.UserInfo
 import org.apache.commons.configuration.PropertiesConfiguration
-import org.joda.time.{DateTime, DateTimeUtils, DateTimeZone}
+import org.joda.time.{ DateTime, DateTimeUtils, DateTimeZone }
 import org.scalamock.scalatest.MockFactory
 import org.scalatest._
 import org.scalatest.enablers.Existence
 
-import scala.util.{Properties, Success, Try}
+import scala.util.{ Properties, Success, Try }
 
 trait TestSupportFixture extends FlatSpec with Matchers with Inside with BeforeAndAfterEach with MockFactory {
   implicit def existenceOfFile[FILE <: better.files.File]: Existence[FILE] = _.exists
@@ -71,8 +72,8 @@ trait TestSupportFixture extends FlatSpec with Matchers with Inside with BeforeA
   }
 
   val nowYMD = "2018-03-22"
-  val now = s"${nowYMD}T21:43:01.576"
-  val nowUTC = s"${nowYMD}T20:43:01Z"
+  val now = s"${ nowYMD }T21:43:01.576"
+  val nowUTC = s"${ nowYMD }T20:43:01Z"
   /** Causes DateTime.now() to return a predefined value. */
   DateTimeUtils.setCurrentMillisFixed(new DateTime(nowUTC).getMillis)
   DateTimeZone.setDefault(DateTimeZone.forTimeZone(TimeZone.getTimeZone("Europe/Amsterdam")))
@@ -103,8 +104,8 @@ trait TestSupportFixture extends FlatSpec with Matchers with Inside with BeforeA
     new EasyDepositApiApp(minimalAppConfig) {
       override val pidRequester: PidRequester = mockPidRequester
 
-      override def getUserProperties(user: String): Try[Map[String, Seq[String]]] = {
-        Success(userMap)
+      override def getUserProperties(user: String): Try[UserInfo] = {
+        Success(UserInfo(userMap))
       }
     }
   }

--- a/src/test/scala/nl.knaw.dans.easy.deposit/TestSupportFixture.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/TestSupportFixture.scala
@@ -56,7 +56,7 @@ trait TestSupportFixture extends FlatSpec with Matchers with Inside with BeforeA
   val userMap: Map[String, Seq[String]] = Map(
     "uid" -> Seq("user001"),
     "displayName" -> Seq("fullName"),
-    "mail" -> Seq("info@dans.knaw.nl"),
+    "mail" -> Seq("does.not.exist@dans.knaw.nl"),
   )
 
   def testResource(file: String): File = File(getClass.getResource(file))

--- a/src/test/scala/nl.knaw.dans.easy.deposit/TestSupportFixture.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/TestSupportFixture.scala
@@ -54,7 +54,7 @@ trait TestSupportFixture extends FlatSpec with Matchers with Inside with BeforeA
     }
   }
 
-  val defaultUserInfo = UserInfo("user001", displayName = "fullName", email ="does.not.exist@dans.knaw.nl", lastName="")
+  val defaultUserInfo = UserInfo("user001", displayName = "fullName", email = "does.not.exist@dans.knaw.nl", lastName = "")
 
   def testResource(file: String): File = File(getClass.getResource(file))
 

--- a/src/test/scala/nl.knaw.dans.easy.deposit/TestSupportFixture.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/TestSupportFixture.scala
@@ -54,9 +54,9 @@ trait TestSupportFixture extends FlatSpec with Matchers with Inside with BeforeA
   }
 
   val userMap: Map[String, Seq[String]] = Map(
-    "userId" -> Seq("user001"),
+    "uid" -> Seq("user001"),
     "displayName" -> Seq("fullName"),
-    "email" -> Seq("info@dans.knaw.nl"),
+    "mail" -> Seq("info@dans.knaw.nl"),
   )
 
   def testResource(file: String): File = File(getClass.getResource(file))

--- a/src/test/scala/nl.knaw.dans.easy.deposit/TestSupportFixture.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/TestSupportFixture.scala
@@ -54,6 +54,7 @@ trait TestSupportFixture extends FlatSpec with Matchers with Inside with BeforeA
   }
 
   val userMap: Map[String, Seq[String]] = Map(
+    "userId" -> Seq("user001"),
     "displayName" -> Seq("fullName"),
     "email" -> Seq("info@dans.knaw.nl"),
   )

--- a/src/test/scala/nl.knaw.dans.easy.deposit/TestSupportFixture.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/TestSupportFixture.scala
@@ -54,11 +54,7 @@ trait TestSupportFixture extends FlatSpec with Matchers with Inside with BeforeA
     }
   }
 
-  val userMap: Map[String, Seq[String]] = Map(
-    "uid" -> Seq("user001"),
-    "displayName" -> Seq("fullName"),
-    "mail" -> Seq("does.not.exist@dans.knaw.nl"),
-  )
+  val defaultUserInfo = UserInfo("user001", displayName = "fullName", email ="does.not.exist@dans.knaw.nl", lastName="")
 
   def testResource(file: String): File = File(getClass.getResource(file))
 
@@ -105,7 +101,7 @@ trait TestSupportFixture extends FlatSpec with Matchers with Inside with BeforeA
       override val pidRequester: PidRequester = mockPidRequester
 
       override def getUserProperties(user: String): Try[UserInfo] = {
-        Success(UserInfo(userMap))
+        Success(defaultUserInfo)
       }
     }
   }

--- a/src/test/scala/nl.knaw.dans.easy.deposit/authentication/LdapAuthenticationSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/authentication/LdapAuthenticationSpec.scala
@@ -110,7 +110,7 @@ class LdapAuthenticationSpec extends TestSupportFixture with MockFactory {
     })
     inside(authentication.getUser("someone")) {
       case Success(user) => // just sampling the result
-        user.prefix shouldBe Some("van den")
+        user.prefix.value shouldBe "van den"
     }
   }
 }

--- a/src/test/scala/nl.knaw.dans.easy.deposit/authentication/LdapAuthenticationSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/authentication/LdapAuthenticationSpec.scala
@@ -100,7 +100,9 @@ class LdapAuthenticationSpec extends TestSupportFixture with MockFactory {
     wire(new LdapMocker).authenticate("someone", " ") shouldBe Success(None)
   }
 
-  "getUser(user)" should "concatenate multiple prefixes" in {
+  "getUser(user)" should "ignore a second prefix" in {
+    // schema defines attribute as single-value
+    // https://github.com/DANS-KNAW/easy-app/blob/b8e64ead3b74e5d453ef895a083847b21fc225c4/lib-deprecated/dans-ldap/src/main/java/nl/knaw/dans/common/ldap/management/DANSSchema.java#L33-L37
     wire(new LdapMocker {
       expectLdapAttributes(new BasicAttributes() {
         put("uid", "foo")
@@ -110,7 +112,7 @@ class LdapAuthenticationSpec extends TestSupportFixture with MockFactory {
       })
     }).getUser("someone")
     .getOrRecover(e => fail(e))
-    .prefix shouldBe Some("van den")
+    .prefix shouldBe Some("van")
   }
 
   // TODO for now set 'trace' at https://github.com/DANS-KNAW/easy-deposit-api/blob/f1b9924/src/test/resources/logback.xml#L15

--- a/src/test/scala/nl.knaw.dans.easy.deposit/authentication/LdapAuthenticationSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/authentication/LdapAuthenticationSpec.scala
@@ -22,9 +22,9 @@ import javax.naming.directory.BasicAttributes
 import javax.naming.ldap.LdapContext
 import nl.knaw.dans.easy.deposit.TestSupportFixture
 import nl.knaw.dans.easy.deposit.authentication.AuthUser.UserState
+import nl.knaw.dans.lib.error._
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.exceptions.TestFailedException
-import nl.knaw.dans.lib.error._
 
 import scala.util.{ Failure, Success }
 
@@ -111,12 +111,12 @@ class LdapAuthenticationSpec extends TestSupportFixture with MockFactory {
         put("sn", "Berg")
       })
     }).getUser("someone")
-    .getOrRecover(e => fail(e))
-    .prefix shouldBe Some("van")
+      .getOrRecover(e => fail(e))
+      .prefix shouldBe Some("van")
   }
 
-  // TODO for now set 'trace' at https://github.com/DANS-KNAW/easy-deposit-api/blob/f1b9924/src/test/resources/logback.xml#L15
-  //  figure out how to intercept and assert the logging
+  // TODO figure out how to intercept and assert the logging
+  //  for now test manually with 'trace':  https://github.com/DANS-KNAW/easy-deposit-api/blob/f1b9924/src/test/resources/logback.xml#L15
   it should "log a user without an email" in {
     wire(new LdapMocker {
       expectLdapAttributes(new BasicAttributes() {

--- a/src/test/scala/nl.knaw.dans.easy.deposit/authentication/LdapAuthenticationSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/authentication/LdapAuthenticationSpec.scala
@@ -96,7 +96,6 @@ class LdapAuthenticationSpec extends TestSupportFixture with MockFactory {
   }
 
   it should "not access ldap with a blank password" in pendingUntilFixed {
-
     wire(new LdapMocker).authenticate("someone", " ") shouldBe Success(None)
   }
 
@@ -111,7 +110,7 @@ class LdapAuthenticationSpec extends TestSupportFixture with MockFactory {
     })
     inside(authentication.getUser("someone")) {
       case Success(user) => // just sampling the result
-        user("dansPrefixes").toArray shouldBe Array("van", "den")
+        user.prefix shouldBe Array("van", "den")
     }
   }
 }

--- a/src/test/scala/nl.knaw.dans.easy.deposit/authentication/LdapAuthenticationSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/authentication/LdapAuthenticationSpec.scala
@@ -110,7 +110,7 @@ class LdapAuthenticationSpec extends TestSupportFixture with MockFactory {
     })
     inside(authentication.getUser("someone")) {
       case Success(user) => // just sampling the result
-        user.prefix shouldBe Array("van", "den")
+        user.prefix shouldBe Some("van den")
     }
   }
 }

--- a/src/test/scala/nl.knaw.dans.easy.deposit/authentication/SessionSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/authentication/SessionSpec.scala
@@ -15,10 +15,9 @@
  */
 package nl.knaw.dans.easy.deposit.authentication
 
-import nl.knaw.dans.easy.deposit.PidRequesterComponent.PidRequester
 import nl.knaw.dans.easy.deposit._
 import nl.knaw.dans.easy.deposit.authentication.AuthUser.UserState
-import nl.knaw.dans.easy.deposit.servlets.{AuthServlet, ProtectedServlet, ServletFixture, UndoMasking}
+import nl.knaw.dans.easy.deposit.servlets.{ AuthServlet, ProtectedServlet, ServletFixture, UndoMasking }
 import org.eclipse.jetty.http.HttpStatus._
 import org.joda.time.DateTime
 import org.joda.time.format.DateTimeFormat
@@ -41,7 +40,7 @@ class SessionSpec extends TestSupportFixture with ServletFixture with ScalatraSu
 
     get("/") {
       contentType = "text/plain"
-      Ok(s"$user ${new DateTime()}: EASY Deposit API Service running")
+      Ok(s"$user ${ new DateTime() }: EASY Deposit API Service running")
     }
   }
 
@@ -78,7 +77,7 @@ class SessionSpec extends TestSupportFixture with ServletFixture with ScalatraSu
 
     get(
       uri = "/deposit",
-      headers = Seq(("Cookie", s"${Scentry.scentryAuthKey}=$jwtCookie"))
+      headers = Seq(("Cookie", s"${ Scentry.scentryAuthKey }=$jwtCookie"))
     ) {
       status shouldBe OK_200
       Option(header("REMOTE_USER")) shouldBe None
@@ -93,7 +92,7 @@ class SessionSpec extends TestSupportFixture with ServletFixture with ScalatraSu
 
     get(
       uri = "/deposit",
-      headers = Seq(("Cookie", s"${Scentry.scentryAuthKey}=$jwtCookie"))
+      headers = Seq(("Cookie", s"${ Scentry.scentryAuthKey }=$jwtCookie"))
     ) {
       status shouldBe UNAUTHORIZED_401
       header("Content-Type").toLowerCase shouldBe "text/plain;charset=utf-8"
@@ -107,7 +106,7 @@ class SessionSpec extends TestSupportFixture with ServletFixture with ScalatraSu
 
     post(
       uri = "/auth/logout",
-      headers = Seq(("Cookie", s"${Scentry.scentryAuthKey}=$jwtCookie"))
+      headers = Seq(("Cookie", s"${ Scentry.scentryAuthKey }=$jwtCookie"))
     ) {
       status shouldBe NO_CONTENT_204
       header("Content-Type").toLowerCase shouldBe "text/html;charset=utf-8"

--- a/src/test/scala/nl.knaw.dans.easy.deposit/authentication/SessionSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/authentication/SessionSpec.scala
@@ -18,7 +18,7 @@ package nl.knaw.dans.easy.deposit.authentication
 import nl.knaw.dans.easy.deposit.PidRequesterComponent.PidRequester
 import nl.knaw.dans.easy.deposit._
 import nl.knaw.dans.easy.deposit.authentication.AuthUser.UserState
-import nl.knaw.dans.easy.deposit.servlets.{ AuthServlet, ProtectedServlet, ServletFixture, UndoMasking }
+import nl.knaw.dans.easy.deposit.servlets.{AuthServlet, ProtectedServlet, ServletFixture, UndoMasking}
 import org.eclipse.jetty.http.HttpStatus._
 import org.joda.time.DateTime
 import org.joda.time.format.DateTimeFormat
@@ -28,9 +28,7 @@ import org.scalatra.test.scalatest.ScalatraSuite
 
 class SessionSpec extends TestSupportFixture with ServletFixture with ScalatraSuite {
 
-  private val app: EasyDepositApiApp = new EasyDepositApiApp(minimalAppConfig) {
-    override val pidRequester: PidRequester = mockPidRequester
-  }
+  private val app: EasyDepositApiApp = createTestApp
   private val authMocker = new AuthenticationMocker() {
     override val mockedAuthenticationProvider: AuthenticationProvider = mock[AuthenticationProvider]
   }
@@ -43,7 +41,7 @@ class SessionSpec extends TestSupportFixture with ServletFixture with ScalatraSu
 
     get("/") {
       contentType = "text/plain"
-      Ok(s"$user ${ new DateTime() }: EASY Deposit API Service running")
+      Ok(s"$user ${new DateTime()}: EASY Deposit API Service running")
     }
   }
 
@@ -80,7 +78,7 @@ class SessionSpec extends TestSupportFixture with ServletFixture with ScalatraSu
 
     get(
       uri = "/deposit",
-      headers = Seq(("Cookie", s"${ Scentry.scentryAuthKey }=$jwtCookie"))
+      headers = Seq(("Cookie", s"${Scentry.scentryAuthKey}=$jwtCookie"))
     ) {
       status shouldBe OK_200
       Option(header("REMOTE_USER")) shouldBe None
@@ -95,7 +93,7 @@ class SessionSpec extends TestSupportFixture with ServletFixture with ScalatraSu
 
     get(
       uri = "/deposit",
-      headers = Seq(("Cookie", s"${ Scentry.scentryAuthKey }=$jwtCookie"))
+      headers = Seq(("Cookie", s"${Scentry.scentryAuthKey}=$jwtCookie"))
     ) {
       status shouldBe UNAUTHORIZED_401
       header("Content-Type").toLowerCase shouldBe "text/plain;charset=utf-8"
@@ -109,7 +107,7 @@ class SessionSpec extends TestSupportFixture with ServletFixture with ScalatraSu
 
     post(
       uri = "/auth/logout",
-      headers = Seq(("Cookie", s"${ Scentry.scentryAuthKey }=$jwtCookie"))
+      headers = Seq(("Cookie", s"${Scentry.scentryAuthKey}=$jwtCookie"))
     ) {
       status shouldBe NO_CONTENT_204
       header("Content-Type").toLowerCase shouldBe "text/html;charset=utf-8"

--- a/src/test/scala/nl.knaw.dans.easy.deposit/docs/AgreementsSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/docs/AgreementsSpec.scala
@@ -22,6 +22,7 @@ import nl.knaw.dans.easy.deposit.docs.dm.PrivacySensitiveDataPresent
 import org.joda.time.DateTime
 
 import scala.util.{ Failure, Success, Try }
+import scala.xml.Elem
 
 class AgreementsSpec extends TestSupportFixture {
 
@@ -55,8 +56,7 @@ class AgreementsSpec extends TestSupportFixture {
   private lazy val triedSchema: Try[Schema] = AgreementsXml.loadSchema
 
   "schema validation" should "succeed with an empty full name" in {
-    assume(triedSchema.isAvailable)
-    AgreementsXml(
+    validate(AgreementsXml(
       "user",
       DateTime.now,
       DatasetMetadata().copy(
@@ -67,12 +67,11 @@ class AgreementsSpec extends TestSupportFixture {
         "displayName" -> Seq(""),
         "email" -> Seq(""),
       )
-    ).flatMap(triedSchema.validate) shouldBe a[Success[_]]
+    ))
   }
 
   it should "fail without an emal property for the user" in {
-    assume(triedSchema.isAvailable)
-    AgreementsXml(
+    validate(AgreementsXml(
       "user",
       DateTime.now,
       DatasetMetadata().copy(
@@ -82,12 +81,11 @@ class AgreementsSpec extends TestSupportFixture {
       Seq(
         "displayName" -> Seq(""),
       ).toMap
-    ).flatMap(triedSchema.validate) shouldBe a[Success[_]]
+    ))
   }
 
   it should "succeed without a user" in {
-    assume(triedSchema.isAvailable)
-    AgreementsXml(
+    validate(AgreementsXml(
       null, // the attribute is omitted from <signerId easy-account={userId}>{fullname}</signerId>
       null, // the schema is happy with <dateSigned></dateSigned>
       DatasetMetadata().copy(
@@ -95,6 +93,12 @@ class AgreementsSpec extends TestSupportFixture {
         privacySensitiveDataPresent = PrivacySensitiveDataPresent.no
       ),
       null, // the schema is happy with <signerId></signerId>
-    ).flatMap(triedSchema.validate) shouldBe a[Success[_]]
+    ))
+  }
+
+  private def validate(triedXML: Try[Elem]) = {
+    triedXML shouldBe a[Success[_]]
+    assume(triedSchema.isAvailable)
+    triedXML.flatMap(triedSchema.validate) shouldBe a[Success[_]]
   }
 }

--- a/src/test/scala/nl.knaw.dans.easy.deposit/docs/AgreementsSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/docs/AgreementsSpec.scala
@@ -33,7 +33,7 @@ class AgreementsSpec extends TestSupportFixture {
         acceptDepositAgreement = false,
         privacySensitiveDataPresent = PrivacySensitiveDataPresent.no
       ),
-      ""
+      userMap
     ) should matchPattern {
       case Failure(e: InvalidDocumentException) if e.getMessage == "invalid DatasetMetadata: Please set AcceptDepositAgreement" =>
     }
@@ -46,7 +46,7 @@ class AgreementsSpec extends TestSupportFixture {
         acceptDepositAgreement = true,
         privacySensitiveDataPresent = PrivacySensitiveDataPresent.unspecified
       ),
-      ""
+      userMap
     ) should matchPattern {
       case Failure(e: InvalidDocumentException) if e.getMessage == "invalid DatasetMetadata: Please set PrivacySensitiveDataPresent" =>
     }
@@ -63,11 +63,29 @@ class AgreementsSpec extends TestSupportFixture {
         acceptDepositAgreement = true,
         privacySensitiveDataPresent = PrivacySensitiveDataPresent.no
       ),
-      ""
+      Map(
+        "displayName" -> Seq(""),
+        "email" -> Seq(""),
+      )
     ).flatMap(triedSchema.validate) shouldBe a[Success[_]]
   }
 
-  it should "succeed without fullname" in {
+  it should "fail without an emal property for the user" in {
+    assume(triedSchema.isAvailable)
+    AgreementsXml(
+      "user",
+      DateTime.now,
+      DatasetMetadata().copy(
+        acceptDepositAgreement = true,
+        privacySensitiveDataPresent = PrivacySensitiveDataPresent.no
+      ),
+      Seq(
+        "displayName" -> Seq(""),
+      ).toMap
+    ).flatMap(triedSchema.validate) shouldBe a[Success[_]]
+  }
+
+  it should "succeed without a user" in {
     assume(triedSchema.isAvailable)
     AgreementsXml(
       null, // the attribute is omitted from <signerId easy-account={userId}>{fullname}</signerId>

--- a/src/test/scala/nl.knaw.dans.easy.deposit/docs/AgreementsSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/docs/AgreementsSpec.scala
@@ -48,7 +48,7 @@ class AgreementsSpec extends TestSupportFixture {
       acceptDepositAgreement = true,
       privacySensitiveDataPresent = PrivacySensitiveDataPresent.no
     ), Seq(
-      "userId" -> Seq(""),
+      "uid" -> Seq(""),
       "displayName" -> Seq(""),
     ).toMap) shouldBe Failure(CorruptUserException("key not found: email"))
   }
@@ -65,8 +65,8 @@ class AgreementsSpec extends TestSupportFixture {
       acceptDepositAgreement = true,
       privacySensitiveDataPresent = PrivacySensitiveDataPresent.no
     ), Seq(
-      "userId" -> Seq(""),
-      "email" -> Seq(""),
+      "uid" -> Seq(""),
+      "mail" -> Seq(""),
     ).toMap) shouldBe Failure(CorruptUserException("key not found: displayName"))
   }
 
@@ -75,9 +75,9 @@ class AgreementsSpec extends TestSupportFixture {
       acceptDepositAgreement = true,
       privacySensitiveDataPresent = PrivacySensitiveDataPresent.no
     ), Map(
-      "userId" -> Seq(""),
+      "uid" -> Seq(""),
       "displayName" -> Seq(""),
-      "email" -> Seq(""),
+      "mail" -> Seq(""),
     ))
     triedXML shouldBe a[Success[_]]
     val triedSchema: Try[Schema] = AgreementsXml.loadSchema

--- a/src/test/scala/nl.knaw.dans.easy.deposit/docs/AgreementsSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/docs/AgreementsSpec.scala
@@ -60,7 +60,7 @@ class AgreementsSpec extends TestSupportFixture {
       ),
       userInfo = null,
     ) should matchPattern {
-      case Failure(e: IllegalArgumentException) if e.getMessage == "no user attributes" =>
+      case Failure(e: NullPointerException) =>
     }
   }
 

--- a/src/test/scala/nl.knaw.dans.easy.deposit/docs/AgreementsSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/docs/AgreementsSpec.scala
@@ -50,7 +50,7 @@ class AgreementsSpec extends TestSupportFixture {
     ), Seq(
       "uid" -> Seq(""),
       "displayName" -> Seq(""),
-    ).toMap) shouldBe Failure(CorruptUserException("key not found: email"))
+    ).toMap) shouldBe Failure(CorruptUserException("key not found: mail"))
   }
 
   it should "fail without user properties" in {

--- a/src/test/scala/nl.knaw.dans.easy.deposit/docs/AgreementsSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/docs/AgreementsSpec.scala
@@ -32,7 +32,7 @@ class AgreementsSpec extends TestSupportFixture {
         acceptDepositAgreement = false,
         privacySensitiveDataPresent = PrivacySensitiveDataPresent.no
       ),
-      userProperties = UserInfo(userMap),
+      userProperties = defaultUserInfo,
     ) should matchPattern {
       case Failure(e: InvalidDocumentException) if e.getMessage == "invalid DatasetMetadata: Please set AcceptDepositAgreement" =>
     }
@@ -45,35 +45,10 @@ class AgreementsSpec extends TestSupportFixture {
         acceptDepositAgreement = true,
         privacySensitiveDataPresent = PrivacySensitiveDataPresent.unspecified
       ),
-      userProperties = UserInfo(userMap),
+      userProperties = defaultUserInfo,
     ) should matchPattern {
       case Failure(e: InvalidDocumentException) if e.getMessage == "invalid DatasetMetadata: Please set PrivacySensitiveDataPresent" =>
     }
-  }
-
-  it should "log a user without an email" in {
-    // TODO for now set 'trace' at https://github.com/DANS-KNAW/easy-deposit-api/blob/f1b9924/src/test/resources/logback.xml#L15
-    AgreementsXml(
-      dateSubmitted = DateTime.now,
-      dm = DatasetMetadata().copy(
-        acceptDepositAgreement = true,
-        privacySensitiveDataPresent = PrivacySensitiveDataPresent.no
-      ),
-      userProperties = UserInfo(Seq("uid" -> Seq(""), "displayName" -> Seq(""),
-      ).toMap),
-    ) shouldBe a[Success[_]]
-  }
-
-  it should "log a user without a display name" in {
-    // TODO for now set 'trace' at https://github.com/DANS-KNAW/easy-deposit-api/blob/f1b9924/src/test/resources/logback.xml#L15
-    AgreementsXml(
-      dateSubmitted = DateTime.now,
-      dm = DatasetMetadata().copy(
-        acceptDepositAgreement = true,
-        privacySensitiveDataPresent = PrivacySensitiveDataPresent.no
-      ),
-      userProperties = UserInfo(Seq("uid" -> Seq(""), "mail" -> Seq("")).toMap),
-    ) shouldBe a[Success[_]]
   }
 
   it should "fail without user properties" in {

--- a/src/test/scala/nl.knaw.dans.easy.deposit/docs/AgreementsSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/docs/AgreementsSpec.scala
@@ -32,7 +32,7 @@ class AgreementsSpec extends TestSupportFixture {
         acceptDepositAgreement = false,
         privacySensitiveDataPresent = PrivacySensitiveDataPresent.no
       ),
-      userProperties = defaultUserInfo,
+      userInfo = defaultUserInfo,
     ) should matchPattern {
       case Failure(e: InvalidDocumentException) if e.getMessage == "invalid DatasetMetadata: Please set AcceptDepositAgreement" =>
     }
@@ -45,7 +45,7 @@ class AgreementsSpec extends TestSupportFixture {
         acceptDepositAgreement = true,
         privacySensitiveDataPresent = PrivacySensitiveDataPresent.unspecified
       ),
-      userProperties = defaultUserInfo,
+      userInfo = defaultUserInfo,
     ) should matchPattern {
       case Failure(e: InvalidDocumentException) if e.getMessage == "invalid DatasetMetadata: Please set PrivacySensitiveDataPresent" =>
     }
@@ -58,7 +58,7 @@ class AgreementsSpec extends TestSupportFixture {
         acceptDepositAgreement = true,
         privacySensitiveDataPresent = PrivacySensitiveDataPresent.no
       ),
-      userProperties = null,
+      userInfo = null,
     ) should matchPattern {
       case Failure(e: IllegalArgumentException) if e.getMessage == "no user attributes" =>
     }
@@ -71,7 +71,7 @@ class AgreementsSpec extends TestSupportFixture {
         acceptDepositAgreement = true,
         privacySensitiveDataPresent = PrivacySensitiveDataPresent.no
       ),
-      userProperties = UserInfo(Map[String, Seq[String]]()),
+      userInfo = UserInfo(Map[String, Seq[String]]()),
     )
     triedXML shouldBe a[Success[_]]
     val triedSchema: Try[Schema] = AgreementsXml.loadSchema

--- a/src/test/scala/nl.knaw.dans.easy.deposit/docs/DDMSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/docs/DDMSpec.scala
@@ -591,7 +591,7 @@ trait DdmBehavior {
 
       assume(triedSchema.isAvailable)
       val result = triedSchema.validate(ddm)
-      if (result.isFailure) // show the relevant XML section to trouble shoot a broken test
+      if (result.isFailure) // show the relevant XML section to troubleshoot a broken test
         println(prettyPrinter.format(subset(triedDDM.getOrRecover(e => fail(e)))))
       result shouldBe a[Success[_]]
     }

--- a/src/test/scala/nl.knaw.dans.easy.deposit/docs/DDMSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/docs/DDMSpec.scala
@@ -66,11 +66,11 @@ class DDMSpec extends TestSupportFixture with DdmBehavior {
   )
 
   "minimal with multiple descriptions" should behave like validDatasetMetadata(
-    input = Try(new MinimalDatasetMetadata(descriptions = Some(Seq("Lorum <a href='mailto:info@dans.knaw.nl'>ipsum</a>", "ipsum")))),
+    input = Try(new MinimalDatasetMetadata(descriptions = Some(Seq("Lorum <a href='mailto:does.not.exist@dans.knaw.nl'>ipsum</a>", "ipsum")))),
     subset = actualDDM => profileElements(actualDDM, "description"),
     expectedDdmContent =
       <ddm:profile>
-        <dcterms:description>Lorum &lt;a href='mailto:info@dans.knaw.nl'&gt;ipsum&lt;/a&gt;</dcterms:description>
+        <dcterms:description>Lorum &lt;a href='mailto:does.not.exist@dans.knaw.nl'&gt;ipsum&lt;/a&gt;</dcterms:description>
         <dcterms:description>ipsum</dcterms:description>
       </ddm:profile>
   )

--- a/src/test/scala/nl.knaw.dans.easy.deposit/docs/DDMSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/docs/DDMSpec.scala
@@ -591,7 +591,7 @@ trait DdmBehavior {
 
       assume(triedSchema.isAvailable)
       val result = triedSchema.validate(ddm)
-      if (result.isFailure) // trouble shoot broken tests
+      if (result.isFailure) // show the relevant XML section to trouble shoot a broken test
         println(prettyPrinter.format(subset(triedDDM.getOrRecover(e => fail(e)))))
       result shouldBe a[Success[_]]
     }

--- a/src/test/scala/nl.knaw.dans.easy.deposit/docs/package.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/docs/package.scala
@@ -28,7 +28,7 @@ import scala.util.{ Failure, Try }
 import scala.xml.{ Elem, PrettyPrinter, SAXParseException }
 
 package object docs extends DebugEnhancedLogging {
-  // pretty provides friendly trouble shooting for complex XML's
+  // pretty provides friendly troubleshooting for complex XML's
   val prettyPrinter: PrettyPrinter = new scala.xml.PrettyPrinter(1024, 2)
 
   implicit class triedSchemaExtension(val triedSchema: Try[Schema]) extends AnyVal {

--- a/src/test/scala/nl.knaw.dans.easy.deposit/servlets/DepositServletFixture.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/servlets/DepositServletFixture.scala
@@ -32,8 +32,8 @@ trait DepositServletFixture extends TestSupportFixture with ServletFixture with 
   private val app: EasyDepositApiApp = new EasyDepositApiApp(minimalAppConfig) {
     override val pidRequester: PidRequester = mockPidRequester
 
-    override def getUser(user: String): Try[Map[String, Seq[String]]] = {
-      Success(Map(("displayName", Seq("F. Bar"))))
+    override def getUserProperties(user: String): Try[Map[String, Seq[String]]] = {
+      Success(userMap)
     }
   }
   private val depositServlet = new DepositServlet(app) with UndoMasking {

--- a/src/test/scala/nl.knaw.dans.easy.deposit/servlets/DepositServletFixture.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/servlets/DepositServletFixture.scala
@@ -16,26 +16,20 @@
 package nl.knaw.dans.easy.deposit.servlets
 
 import nl.knaw.dans.easy.deposit.PidRequesterComponent.PidType.PidType
-import nl.knaw.dans.easy.deposit.PidRequesterComponent.{ PidRequester, PidType }
-import nl.knaw.dans.easy.deposit.authentication.{ AuthenticationMocker, AuthenticationProvider }
+import nl.knaw.dans.easy.deposit.PidRequesterComponent.{PidRequester, PidType}
+import nl.knaw.dans.easy.deposit.authentication.{AuthenticationMocker, AuthenticationProvider}
 import nl.knaw.dans.easy.deposit.docs.DepositInfo
-import nl.knaw.dans.easy.deposit.{ EasyDepositApiApp, TestSupportFixture }
+import nl.knaw.dans.easy.deposit.{EasyDepositApiApp, TestSupportFixture}
 import nl.knaw.dans.lib.error._
 import org.eclipse.jetty.http.HttpStatus._
 import org.scalamock.handlers.CallHandler1
 import org.scalamock.scalatest.MockFactory
 import org.scalatra.test.scalatest.ScalatraSuite
 
-import scala.util.{ Success, Try }
+import scala.util.{Success, Try}
 
 trait DepositServletFixture extends TestSupportFixture with ServletFixture with ScalatraSuite with MockFactory {
-  private val app: EasyDepositApiApp = new EasyDepositApiApp(minimalAppConfig) {
-    override val pidRequester: PidRequester = mockPidRequester
-
-    override def getUserProperties(user: String): Try[Map[String, Seq[String]]] = {
-      Success(userMap)
-    }
-  }
+  private val app: EasyDepositApiApp = createTestApp
   private val depositServlet = new DepositServlet(app) with UndoMasking {
     override def getAuthenticationProvider: AuthenticationProvider = {
       new AuthenticationMocker() {

--- a/src/test/scala/nl.knaw.dans.easy.deposit/servlets/DepositServletFixture.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/servlets/DepositServletFixture.scala
@@ -15,18 +15,18 @@
  */
 package nl.knaw.dans.easy.deposit.servlets
 
+import nl.knaw.dans.easy.deposit.PidRequesterComponent.PidType
 import nl.knaw.dans.easy.deposit.PidRequesterComponent.PidType.PidType
-import nl.knaw.dans.easy.deposit.PidRequesterComponent.{PidRequester, PidType}
-import nl.knaw.dans.easy.deposit.authentication.{AuthenticationMocker, AuthenticationProvider}
+import nl.knaw.dans.easy.deposit.authentication.{ AuthenticationMocker, AuthenticationProvider }
 import nl.knaw.dans.easy.deposit.docs.DepositInfo
-import nl.knaw.dans.easy.deposit.{EasyDepositApiApp, TestSupportFixture}
+import nl.knaw.dans.easy.deposit.{ EasyDepositApiApp, TestSupportFixture }
 import nl.knaw.dans.lib.error._
 import org.eclipse.jetty.http.HttpStatus._
 import org.scalamock.handlers.CallHandler1
 import org.scalamock.scalatest.MockFactory
 import org.scalatra.test.scalatest.ScalatraSuite
 
-import scala.util.{Success, Try}
+import scala.util.{ Success, Try }
 
 trait DepositServletFixture extends TestSupportFixture with ServletFixture with ScalatraSuite with MockFactory {
   private val app: EasyDepositApiApp = createTestApp

--- a/src/test/scala/nl.knaw.dans.easy.deposit/servlets/HappyRoutesSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/servlets/HappyRoutesSpec.scala
@@ -88,7 +88,7 @@ class HappyRoutesSpec extends TestSupportFixture with ServletFixture with Scalat
 
   "get /user" should "return a user with something for all attributes" in {
     authMocker.expectsUserFooBar
-    (mockedApp.getUser(_: String)) expects "foo" returning Success(Map(
+    (mockedApp.getUserProperties(_: String)) expects "foo" returning Success(Map(
       "uid" -> Seq("foo"),
       "cn" -> Seq("Jan"),
       "dansPrefixes" -> Seq("van", "den"),
@@ -106,7 +106,7 @@ class HappyRoutesSpec extends TestSupportFixture with ServletFixture with Scalat
 
   it should "return a user with minimal attributes" in {
     authMocker.expectsUserFooBar
-    (mockedApp.getUser(_: String)) expects "foo" returning Success(Map(
+    (mockedApp.getUserProperties(_: String)) expects "foo" returning Success(Map(
       "uid" -> Seq("foo"),
       "sn" -> Seq("Berg"),
       "displayName" -> Seq("Jan v.d. Berg"),

--- a/src/test/scala/nl.knaw.dans.easy.deposit/servlets/HappyRoutesSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/servlets/HappyRoutesSpec.scala
@@ -88,7 +88,7 @@ class HappyRoutesSpec extends TestSupportFixture with ServletFixture with Scalat
 
   "get /user" should "return a user with something for all attributes" in {
     authMocker.expectsUserFooBar
-    (mockedApp.getUserProperties(_: String)) expects "foo" returning
+    (mockedApp.getUserInfo(_: String)) expects "foo" returning
       Success(UserInfo("foo", displayName = "Jan v.d. Berg", email ="", firstName = Some("Jan"), prefix = Some("van den"), lastName="Berg"))
     get(
       uri = "/user",
@@ -101,7 +101,7 @@ class HappyRoutesSpec extends TestSupportFixture with ServletFixture with Scalat
 
   it should "return a user with minimal attributes" in {
     authMocker.expectsUserFooBar
-    (mockedApp.getUserProperties(_: String)) expects "foo" returning
+    (mockedApp.getUserInfo(_: String)) expects "foo" returning
       Success(UserInfo("foo", displayName = "", email ="", lastName=""))
 
     get(

--- a/src/test/scala/nl.knaw.dans.easy.deposit/servlets/HappyRoutesSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/servlets/HappyRoutesSpec.scala
@@ -89,7 +89,7 @@ class HappyRoutesSpec extends TestSupportFixture with ServletFixture with Scalat
   "get /user" should "return a user with something for all attributes" in {
     authMocker.expectsUserFooBar
     (mockedApp.getUserInfo(_: String)) expects "foo" returning
-      Success(UserInfo("foo", displayName = "Jan v.d. Berg", email ="", firstName = Some("Jan"), prefix = Some("van den"), lastName="Berg"))
+      Success(UserInfo("foo", displayName = "Jan v.d. Berg", email = "", firstName = Some("Jan"), prefix = Some("van den"), lastName = "Berg"))
     get(
       uri = "/user",
       headers = Seq(fooBarBasicAuthHeader)
@@ -102,7 +102,7 @@ class HappyRoutesSpec extends TestSupportFixture with ServletFixture with Scalat
   it should "return a user with minimal attributes" in {
     authMocker.expectsUserFooBar
     (mockedApp.getUserInfo(_: String)) expects "foo" returning
-      Success(UserInfo("foo", displayName = "", email ="", lastName=""))
+      Success(UserInfo("foo", displayName = "", email = "", lastName = ""))
 
     get(
       uri = "/user",

--- a/src/test/scala/nl.knaw.dans.easy.deposit/servlets/HappyRoutesSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/servlets/HappyRoutesSpec.scala
@@ -88,35 +88,35 @@ class HappyRoutesSpec extends TestSupportFixture with ServletFixture with Scalat
 
   "get /user" should "return a user with something for all attributes" in {
     authMocker.expectsUserFooBar
-    (mockedApp.getUserProperties(_: String)) expects "foo" returning Success(Map(
+    (mockedApp.getUserProperties(_: String)) expects "foo" returning Success(UserInfo(Map(
       "uid" -> Seq("foo"),
       "cn" -> Seq("Jan"),
       "dansPrefixes" -> Seq("van", "den"),
       "sn" -> Seq("Berg"),
       "displayName" -> Seq("Jan v.d. Berg"),
-    ))
+    )))
     get(
       uri = "/user",
       headers = Seq(fooBarBasicAuthHeader)
     ) {
-      body shouldBe """{"userName":"foo","firstName":"Jan","prefix":"van den","lastName":"Berg","displayName":"Jan v.d. Berg"}"""
+      body shouldBe """{"userName":"foo","firstName":"Jan","prefix":"van den","lastName":"Berg","displayName":"Jan v.d. Berg","email":""}"""
       status shouldBe OK_200
     }
   }
 
   it should "return a user with minimal attributes" in {
     authMocker.expectsUserFooBar
-    (mockedApp.getUserProperties(_: String)) expects "foo" returning Success(Map(
+    (mockedApp.getUserProperties(_: String)) expects "foo" returning Success(UserInfo(Map(
       "uid" -> Seq("foo"),
       "sn" -> Seq("Berg"),
       "displayName" -> Seq("Jan v.d. Berg"),
-    ))
+    )))
 
     get(
       uri = "/user",
       headers = Seq(fooBarBasicAuthHeader)
     ) {
-      body shouldBe """{"userName":"foo","lastName":"Berg","displayName":"Jan v.d. Berg"}"""
+      body shouldBe """{"userName":"foo","lastName":"Berg","displayName":"Jan v.d. Berg","email":""}"""
       status shouldBe OK_200
     }
   }

--- a/src/test/scala/nl.knaw.dans.easy.deposit/servlets/HappyRoutesSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/servlets/HappyRoutesSpec.scala
@@ -88,13 +88,8 @@ class HappyRoutesSpec extends TestSupportFixture with ServletFixture with Scalat
 
   "get /user" should "return a user with something for all attributes" in {
     authMocker.expectsUserFooBar
-    (mockedApp.getUserProperties(_: String)) expects "foo" returning Success(UserInfo(Map(
-      "uid" -> Seq("foo"),
-      "cn" -> Seq("Jan"),
-      "dansPrefixes" -> Seq("van", "den"),
-      "sn" -> Seq("Berg"),
-      "displayName" -> Seq("Jan v.d. Berg"),
-    )))
+    (mockedApp.getUserProperties(_: String)) expects "foo" returning
+      Success(UserInfo("foo", displayName = "Jan v.d. Berg", email ="", firstName = Some("Jan"), prefix = Some("van den"), lastName="Berg"))
     get(
       uri = "/user",
       headers = Seq(fooBarBasicAuthHeader)
@@ -106,17 +101,14 @@ class HappyRoutesSpec extends TestSupportFixture with ServletFixture with Scalat
 
   it should "return a user with minimal attributes" in {
     authMocker.expectsUserFooBar
-    (mockedApp.getUserProperties(_: String)) expects "foo" returning Success(UserInfo(Map(
-      "uid" -> Seq("foo"),
-      "sn" -> Seq("Berg"),
-      "displayName" -> Seq("Jan v.d. Berg"),
-    )))
+    (mockedApp.getUserProperties(_: String)) expects "foo" returning
+      Success(UserInfo("foo", displayName = "", email ="", lastName=""))
 
     get(
       uri = "/user",
       headers = Seq(fooBarBasicAuthHeader)
     ) {
-      body shouldBe """{"userName":"foo","lastName":"Berg","displayName":"Jan v.d. Berg","email":""}"""
+      body shouldBe """{"userName":"foo","lastName":"","displayName":"","email":""}"""
       status shouldBe OK_200
     }
   }

--- a/src/test/scala/nl.knaw.dans.easy.deposit/servlets/IntegrationSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/servlets/IntegrationSpec.scala
@@ -43,8 +43,11 @@ class IntegrationSpec extends TestSupportFixture with ServletFixture with Scalat
   private val app: EasyDepositApiApp = new EasyDepositApiApp(minimalAppConfig) {
     override val pidRequester: PidRequester = mockPidRequester
 
-    override def getUser(user: String): Try[Map[String, Seq[String]]] = {
-      Success(Map(("displayName", Seq("F. Bar"))))
+    override def getUserProperties(user: String): Try[Map[String, Seq[String]]] = {
+      Success(Map(
+        "displayName"-> Seq("F. Bar"),
+        "email"-> Seq("info@dans.knaw.nl"),
+      ))
     }
   }
   mountServlets(app, authMocker.mockedAuthenticationProvider)

--- a/src/test/scala/nl.knaw.dans.easy.deposit/servlets/IntegrationSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/servlets/IntegrationSpec.scala
@@ -20,14 +20,14 @@ import java.util.UUID
 import nl.knaw.dans.easy.deposit.PidRequesterComponent.PidRequester
 import nl.knaw.dans.easy.deposit.PidRequesterComponent.PidType.PidType
 import nl.knaw.dans.easy.deposit._
-import nl.knaw.dans.easy.deposit.authentication.{ AuthenticationMocker, AuthenticationProvider }
+import nl.knaw.dans.easy.deposit.authentication.{AuthenticationMocker, AuthenticationProvider}
 import nl.knaw.dans.easy.deposit.docs._
 import nl.knaw.dans.lib.error._
 import org.apache.commons.configuration.PropertiesConfiguration
 import org.eclipse.jetty.http.HttpStatus._
 import org.scalatra.test.scalatest.ScalatraSuite
 
-import scala.util.{ Success, Try }
+import scala.util.{Success, Try}
 
 class IntegrationSpec extends TestSupportFixture with ServletFixture with ScalatraSuite {
 
@@ -40,19 +40,15 @@ class IntegrationSpec extends TestSupportFixture with ServletFixture with Scalat
     clearTestDir()
   }
 
-  private val app: EasyDepositApiApp = new EasyDepositApiApp(minimalAppConfig) {
-    override val pidRequester: PidRequester = mockPidRequester
-
-    override def getUserProperties(user: String): Try[Map[String, Seq[String]]] = {
-      Success(userMap)
-    }
-  }
+  private val app: EasyDepositApiApp = createTestApp
   mountServlets(app, authMocker.mockedAuthenticationProvider)
 
   "scenario: /deposit/:uuid/metadata life cycle" should "return default dataset metadata" in {
     // create dataset
     authMocker.expectsUserFooBar
-    val responseBody = post(uri = s"/deposit", headers = Seq(fooBarBasicAuthHeader)) { body }
+    val responseBody = post(uri = s"/deposit", headers = Seq(fooBarBasicAuthHeader)) {
+      body
+    }
     val uuid = DepositInfo(responseBody).map(_.id.toString).getOrRecover(e => fail(e.toString, e))
     val metadataURI = s"/deposit/$uuid/metadata"
 
@@ -88,7 +84,9 @@ class IntegrationSpec extends TestSupportFixture with ServletFixture with Scalat
       post(
         uri = s"/deposit",
         headers = Seq(fooBarBasicAuthHeader)
-      ) { new String(bodyBytes) }
+      ) {
+        new String(bodyBytes)
+      }
     }
     responseBodies.foreach(_ should endWith("""Z"}"""))
 
@@ -107,7 +105,9 @@ class IntegrationSpec extends TestSupportFixture with ServletFixture with Scalat
   "scenario: POST /deposit; PUT /deposit/:uuid/file/...; GET /deposit/$uuid/file/..." should "return single FileInfo object respective an array of objects" in {
     // create dataset
     authMocker.expectsUserFooBar
-    val responseBody = post(uri = s"/deposit", headers = Seq(fooBarBasicAuthHeader)) { body }
+    val responseBody = post(uri = s"/deposit", headers = Seq(fooBarBasicAuthHeader)) {
+      body
+    }
     val uuid = DepositInfo(responseBody).map(_.id.toString).getOrRecover(e => fail(e.toString, e))
 
     // upload files in a folder (more variations in UploadSpec)
@@ -184,7 +184,9 @@ class IntegrationSpec extends TestSupportFixture with ServletFixture with Scalat
   "scenario: POST /deposit; twice GET /deposit/:uuid/doi" should "return 200" in {
     // create dataset
     authMocker.expectsUserFooBar
-    val responseBody = post(uri = s"/deposit", headers = Seq(fooBarBasicAuthHeader)) { body }
+    val responseBody = post(uri = s"/deposit", headers = Seq(fooBarBasicAuthHeader)) {
+      body
+    }
     val uuid = DepositInfo(responseBody).map(_.id.toString).getOrRecover(e => fail(e.toString, e))
 
     // expect a new doi once
@@ -252,7 +254,9 @@ class IntegrationSpec extends TestSupportFixture with ServletFixture with Scalat
 
     // create dataset
     authMocker.expectsUserFooBar
-    val responseBody = post(uri = s"/deposit", headers = Seq(fooBarBasicAuthHeader)) { body }
+    val responseBody = post(uri = s"/deposit", headers = Seq(fooBarBasicAuthHeader)) {
+      body
+    }
 
     val uuid = DepositInfo(responseBody).map(_.id.toString).getOrRecover(e => fail(e.toString, e))
     // upload dataset metadata
@@ -297,7 +301,9 @@ class IntegrationSpec extends TestSupportFixture with ServletFixture with Scalat
   "scenario: POST /deposit; hack state to ARCHIVED; SUBMIT" should "reject state transition" in {
     // create dataset
     authMocker.expectsUserFooBar
-    val responseBody = post(uri = s"/deposit", headers = Seq(fooBarBasicAuthHeader)) { body }
+    val responseBody = post(uri = s"/deposit", headers = Seq(fooBarBasicAuthHeader)) {
+      body
+    }
     val uuid = DepositInfo(responseBody).map(_.id.toString).getOrRecover(e => fail(e.toString, e))
 
     // hack state
@@ -331,7 +337,9 @@ class IntegrationSpec extends TestSupportFixture with ServletFixture with Scalat
 
     // create dataset
     authMocker.expectsUserFooBar
-    val responseBody = post(uri = s"/deposit", headers = Seq(fooBarBasicAuthHeader)) { body }
+    val responseBody = post(uri = s"/deposit", headers = Seq(fooBarBasicAuthHeader)) {
+      body
+    }
     val uuid = DepositInfo(responseBody).map(_.id.toString).getOrRecover(e => fail(e.toString, e))
     val depositDir = testDir / "drafts" / "foo" / uuid.toString
 

--- a/src/test/scala/nl.knaw.dans.easy.deposit/servlets/IntegrationSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/servlets/IntegrationSpec.scala
@@ -44,10 +44,7 @@ class IntegrationSpec extends TestSupportFixture with ServletFixture with Scalat
     override val pidRequester: PidRequester = mockPidRequester
 
     override def getUserProperties(user: String): Try[Map[String, Seq[String]]] = {
-      Success(Map(
-        "displayName"-> Seq("F. Bar"),
-        "email"-> Seq("info@dans.knaw.nl"),
-      ))
+      Success(userMap)
     }
   }
   mountServlets(app, authMocker.mockedAuthenticationProvider)

--- a/src/test/scala/nl.knaw.dans.easy.deposit/servlets/IntegrationSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/servlets/IntegrationSpec.scala
@@ -17,17 +17,16 @@ package nl.knaw.dans.easy.deposit.servlets
 
 import java.util.UUID
 
-import nl.knaw.dans.easy.deposit.PidRequesterComponent.PidRequester
 import nl.knaw.dans.easy.deposit.PidRequesterComponent.PidType.PidType
 import nl.knaw.dans.easy.deposit._
-import nl.knaw.dans.easy.deposit.authentication.{AuthenticationMocker, AuthenticationProvider}
+import nl.knaw.dans.easy.deposit.authentication.{ AuthenticationMocker, AuthenticationProvider }
 import nl.knaw.dans.easy.deposit.docs._
 import nl.knaw.dans.lib.error._
 import org.apache.commons.configuration.PropertiesConfiguration
 import org.eclipse.jetty.http.HttpStatus._
 import org.scalatra.test.scalatest.ScalatraSuite
 
-import scala.util.{Success, Try}
+import scala.util.Success
 
 class IntegrationSpec extends TestSupportFixture with ServletFixture with ScalatraSuite {
 

--- a/src/test/scala/nl.knaw.dans.easy.deposit/servlets/IntegrationSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/servlets/IntegrationSpec.scala
@@ -170,6 +170,8 @@ class IntegrationSpec extends TestSupportFixture with ServletFixture with Scalat
 
   "scenario: POST /deposit; PUT /deposit/:uuid/state; PUT /deposit/$uuid/file/..." should "return forbidden cannot update SUBMITTED deposit" in {
     val uuid: String = setupSubmittedDeposit
+    submittedAgreementsHasEmail(uuid)
+
     authMocker.expectsUserFooBar
     put(
       uri = s"/deposit/$uuid/file/path/to/test.txt", headers = Seq(fooBarBasicAuthHeader, ("Content-Type", "application/json")),
@@ -178,6 +180,13 @@ class IntegrationSpec extends TestSupportFixture with ServletFixture with Scalat
       body shouldBe "Deposit has state SUBMITTED, can only update deposits with one of the states: DRAFT"
       status shouldBe FORBIDDEN_403
     }
+  }
+
+  private def submittedAgreementsHasEmail(uuid: String) = {
+    // might be overkill with respect to AgreementsSpec
+    val submittedUUID = new PropertiesConfiguration((testDir / "drafts" / "foo" / uuid / "deposit.properties").toJava).getString("bag-store.bag-id")
+    (testDir / "easy-ingest-flow-inbox" / submittedUUID / "bag" / "metadata" / "depositor-info" / "agreements.xml").contentAsString should
+      include("""<signerId easy-account="user001" email="does.not.exist@dans.knaw.nl">fullName</signerId>""")
   }
 
   "scenario: POST /deposit; twice GET /deposit/:uuid/doi" should "return 200" in {

--- a/src/test/scala/nl.knaw.dans.easy.deposit/servlets/IntegrationSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/servlets/IntegrationSpec.scala
@@ -84,7 +84,7 @@ class IntegrationSpec extends TestSupportFixture with ServletFixture with Scalat
         uri = s"/deposit",
         headers = Seq(fooBarBasicAuthHeader)
       ) {
-        new String(bodyBytes)
+        body
       }
     }
     responseBodies.foreach(_ should endWith("""Z"}"""))

--- a/src/test/scala/nl.knaw.dans.easy.deposit/servlets/UndoMasking.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/servlets/UndoMasking.scala
@@ -21,7 +21,7 @@ import org.scalatra.ScalatraBase
 trait UndoMasking extends MaskedLogFormatter {
   this: ScalatraBase =>
 
-  // to trouble shoot unit tests set the log level to trace in test/resource/logback.xml
+  // to troubleshoot unit tests set the log level to trace in test/resource/logback.xml
   // move the change to another change list in git to prevent an accidental commit
 
   override protected def formatRemoteAddress(remoteAddress: String): String = remoteAddress

--- a/src/test/scala/nl.knaw.dans.easy.deposit/servlets/UploadSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/servlets/UploadSpec.scala
@@ -379,7 +379,7 @@ class UploadSpec extends DepositServletFixture with Inspectors {
       uri = "/deposit",
       headers = Seq(fooBarBasicAuthHeader)
     ) {
-      new String(bodyBytes)
+      body
     }
     DepositInfo(responseBody)
       .map(_.id)


### PR DESCRIPTION
Fixes EASY-

#### When applied it will
* 

#### Before merge
* [x] merge https://github.com/DANS-KNAW/easy-schema/pull/76
* [x] release/deploy `easy-schema`

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?
Build/deploy on deasy together with  ingest-flow and DANS-KNAW/easy-stage-dataset#145
* [x] submit a deposit, examine emd (as either depositor or datamander)

#### Related pull requests on github
* requires https://github.com/DANS-KNAW/easy-schema/pull/76
  for one of the unit tests and ingest-flow of a manual submit
* required by https://github.com/DANS-KNAW/easy-stage-dataset/pull/145