### PR TITLE
EASY-2312, EASY-2323: format ISO dates as yyyy-MM-dd dates in DDM

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.deposit/docs/DatasetMetadata.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/docs/DatasetMetadata.scala
@@ -69,7 +69,10 @@ case class DatasetMetadata(identifiers: Option[Seq[SchemedValue]] = None,
                                                  else Failure(missingValue("AcceptDepositAgreement"))
 
   // not lazy so not allowed duplicates throw exceptions when parsing json, like other unknown fields
-  val (datesCreated, datesAvailable, otherDates) = dates.separate
+  val (datesCreated, datesAvailable, otherDates) = dates
+    .getOrElse(Seq.empty)
+    .map(_.toDayLevel)
+    .separate
 
   private lazy val authors: Seq[Author] = (contributors.toSeq ++ creators.toSeq).flatten
   // duplicates for plain strings in dcterms (which has no place for IDs as contributors/creators do)

--- a/src/main/scala/nl.knaw.dans.easy.deposit/docs/dm/Date.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/docs/dm/Date.scala
@@ -54,7 +54,7 @@ case class Date(
    */
   def toDayLevel: Date = {
     lazy val hasW3CDTFScheme = scheme contains DateScheme.W3CDTF.toString
-    lazy val hasValidValue = value.exists(_ matches "^[0-9]{4}-[0-9]{2}-[0-9]{2}(.*)$")
+    lazy val hasValidValue = value.exists(_ matches "^[0-9]{4}-[0-9]{1,2}-[0-9]{1,2}(.*)$")
 
     if (hasW3CDTFScheme && hasValidValue)
       copy(value = value.map(DateTime.parse(_).toString(ISODateTimeFormat.date())))

--- a/src/main/scala/nl.knaw.dans.easy.deposit/docs/dm/Date.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/docs/dm/Date.scala
@@ -42,7 +42,26 @@ case class Date(
                  scheme: Option[String],
                  value: Option[String],
                  qualifier: Option[DateQualifier],
-               )
+               ) {
+
+  /**
+   * If the scheme is present and is equal to DateScheme.W3CDTF and
+   * if the value is present and starts with a yyyy-MM-dd formatted date
+   * converts this Date with date-and-time value to just day level.
+   * Else, keep the value as is
+   *
+   * @return the day level representation of this Date
+   */
+  def toDayLevel: Date = {
+    lazy val hasW3CDTFScheme = scheme contains DateScheme.W3CDTF.toString
+    lazy val hasValidValue = value.exists(_ matches "^[0-9]{4}-[0-9]{2}-[0-9]{2}(.*)$")
+
+    if (hasW3CDTFScheme && hasValidValue)
+      copy(value = value.map(DateTime.parse(_).toString(ISODateTimeFormat.date())))
+    else
+      this
+  }
+}
 
 object Date {
   private def dateSubmitted: Date = Date(
@@ -51,14 +70,13 @@ object Date {
     Some(DateQualifier.dateSubmitted)
   )
 
-  implicit class DatesExtension(val dates: Option[Seq[Date]]) extends AnyVal {
+  implicit class DatesExtension(val dates: Seq[Date]) extends AnyVal {
     /**
      * @return (dateCreated, dateAvailable, plainDates)
      */
     private[docs] def separate = {
-      dates.getOrElse(Seq.empty)
-        .foldLeft((Option.empty[Date], Option.empty[Date], Seq(dateSubmitted))) {
-          // @formatter:off
+      dates.foldLeft((Option.empty[Date], Option.empty[Date], Seq(dateSubmitted))) {
+        // @formatter:off
           case ((_,           _,             _     ),      Date(_, _, Some(q@DateQualifier.dateSubmitted))) => invalidQualifier(q)
           case ((None,        dateAvailable, others), date@Date(_, _, Some(  DateQualifier.created))      ) => (Some(date),  dateAvailable, others)
           case ((Some(dc),    _,             _     ), date@Date(_, _, Some(  DateQualifier.created))      ) => duplicateDates(Seq(dc, date))
@@ -66,7 +84,7 @@ object Date {
           case ((_,           Some(da),      _     ), date@Date(_, _, Some(  DateQualifier.available))    ) => duplicateDates(Seq(da, date))
           case ((dateCreated, dateAvailable, others), date@Date(_, _, _)                                  ) => (dateCreated, dateAvailable, others :+ date)
           // @formatter:on
-        }
+      }
     }
 
     private def duplicateDates(dates: Seq[Date]) = {

--- a/src/main/scala/nl.knaw.dans.easy.deposit/docs/dm/Date.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/docs/dm/Date.scala
@@ -77,13 +77,13 @@ object Date {
     private[docs] def separate = {
       dates.foldLeft((Option.empty[Date], Option.empty[Date], Seq(dateSubmitted))) {
         // @formatter:off
-          case ((_,           _,             _     ),      Date(_, _, Some(q@DateQualifier.dateSubmitted))) => invalidQualifier(q)
-          case ((None,        dateAvailable, others), date@Date(_, _, Some(  DateQualifier.created))      ) => (Some(date),  dateAvailable, others)
-          case ((Some(dc),    _,             _     ), date@Date(_, _, Some(  DateQualifier.created))      ) => duplicateDates(Seq(dc, date))
-          case ((dateCreated, None,          others), date@Date(_, _, Some(  DateQualifier.available))    ) => (dateCreated, Some(date),    others)
-          case ((_,           Some(da),      _     ), date@Date(_, _, Some(  DateQualifier.available))    ) => duplicateDates(Seq(da, date))
-          case ((dateCreated, dateAvailable, others), date@Date(_, _, _)                                  ) => (dateCreated, dateAvailable, others :+ date)
-          // @formatter:on
+        case ((_,           _,             _     ),      Date(_, _, Some(q@DateQualifier.dateSubmitted))) => invalidQualifier(q)
+        case ((None,        dateAvailable, others), date@Date(_, _, Some(  DateQualifier.created))      ) => (Some(date),  dateAvailable, others)
+        case ((Some(dc),    _,             _     ), date@Date(_, _, Some(  DateQualifier.created))      ) => duplicateDates(Seq(dc, date))
+        case ((dateCreated, None,          others), date@Date(_, _, Some(  DateQualifier.available))    ) => (dateCreated, Some(date),    others)
+        case ((_,           Some(da),      _     ), date@Date(_, _, Some(  DateQualifier.available))    ) => duplicateDates(Seq(da, date))
+        case ((dateCreated, dateAvailable, others), date@Date(_, _, _)                                  ) => (dateCreated, dateAvailable, others :+ date)
+        // @formatter:on
       }
     }
 

--- a/src/test/scala/nl.knaw.dans.easy.deposit/docs/DDMSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/docs/DDMSpec.scala
@@ -44,8 +44,8 @@ class DDMSpec extends TestSupportFixture with DdmBehavior {
             <dcx-dai:surname>Foo</dcx-dai:surname>
           </dcx-dai:author>
         </dcx-dai:creatorDetails>
-        <ddm:created>2018</ddm:created>
-        <ddm:available>2018</ddm:available>
+        <ddm:created>2018-05-29</ddm:created>
+        <ddm:available>2018-07-30</ddm:available>
         <ddm:audience>D35200</ddm:audience>
         <ddm:accessRights>OPEN_ACCESS</ddm:accessRights>
       </ddm:profile>
@@ -261,8 +261,8 @@ class DDMSpec extends TestSupportFixture with DdmBehavior {
           <dcterms:valid>Groundhog day</dcterms:valid>
           <dcterms:valid xsi:type="dcterms:W3CDTF">2018</dcterms:valid>
           <dcterms:valid xsi:type="dcterms:W3CDTF">2018-12</dcterms:valid>
-          <dcterms:valid xsi:type="dcterms:W3CDTF">2018-12-09T08:15:30-05:00</dcterms:valid>
-          <dcterms:valid xsi:type="dcterms:W3CDTF">2018-12-09T13:15:30Z</dcterms:valid>
+          <dcterms:valid xsi:type="dcterms:W3CDTF">2018-12-09</dcterms:valid>
+          <dcterms:valid xsi:type="dcterms:W3CDTF">2018-12-09</dcterms:valid>
         </ddm:dcmiMetadata>
     )
   }

--- a/src/test/scala/nl.knaw.dans.easy.deposit/docs/DatasetMetadataSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/docs/DatasetMetadataSpec.scala
@@ -101,6 +101,21 @@ class DatasetMetadataSpec extends TestSupportFixture with OptionValues {
     }
   }
 
+  it should "accept single digit dates" in {
+    val s: JsonInput =
+      """{"dates":[{"qualifier":"dcterms:date","scheme":"dcterms:W3CDTF","value":"2019-3-9T15:08:34+01:00"}]}"""
+
+    inside(DatasetMetadata(s)) {
+      case Success(dm) =>
+        dm.datesCreated shouldBe empty
+        dm.datesAvailable shouldBe empty
+        dm.otherDates should contain only(
+          Date(scheme = Some("dcterms:W3CDTF"), qualifier = Some(DateQualifier.date), value = Some("2019-03-09")),
+          Date(scheme = Some("dcterms:W3CDTF"), qualifier = Some(DateQualifier.dateSubmitted), value = Some(nowYMD)),
+        )
+    }
+  }
+
   "DatasetMetadata.relations" should "accept complete relations" in {
     val s: JsonInput =
       """{

--- a/src/test/scala/nl.knaw.dans.easy.deposit/docs/MinimalDatasetMetadata.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/docs/MinimalDatasetMetadata.scala
@@ -44,7 +44,7 @@ class MinimalDatasetMetadata(
                               relations: Option[Seq[RelationType]] = None,
                               languagesOfFiles: Option[Seq[SchemedKeyValue]] = None,
                               dates: Option[Seq[Date]] = Some(Seq(
-                                Date(scheme = Some(W3CDTF.toString), value = Some("2018-05-29T19:35:00.000+02:00"), Some(DateQualifier.created)),
+                                Date(scheme = Some(W3CDTF.toString), value = Some("2018-5-29T19:35:00.000+02:00"), Some(DateQualifier.created)),
                                 Date(scheme = Some(W3CDTF.toString), value = Some("2018-07-30T16:00:00.000+02:00"), Some(DateQualifier.available))
                               )),
                               sources: Option[Seq[String]] = None,

--- a/src/test/scala/nl.knaw.dans.easy.deposit/docs/MinimalDatasetMetadata.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/docs/MinimalDatasetMetadata.scala
@@ -44,8 +44,8 @@ class MinimalDatasetMetadata(
                               relations: Option[Seq[RelationType]] = None,
                               languagesOfFiles: Option[Seq[SchemedKeyValue]] = None,
                               dates: Option[Seq[Date]] = Some(Seq(
-                                Date(scheme = Some(W3CDTF.toString), value = Some("2018"), Some(DateQualifier.created)),
-                                Date(scheme = Some(W3CDTF.toString), value = Some("2018"), Some(DateQualifier.available))
+                                Date(scheme = Some(W3CDTF.toString), value = Some("2018-05-29T19:35:00.000+02:00"), Some(DateQualifier.created)),
+                                Date(scheme = Some(W3CDTF.toString), value = Some("2018-07-30T16:00:00.000+02:00"), Some(DateQualifier.available))
                               )),
                               sources: Option[Seq[String]] = None,
                               instructionsForReuse: Option[Seq[String]] = None,


### PR DESCRIPTION
Fixes EASY-2312 and EASY-2323

#### When applied it will
* format the ISO dates (e.g. the ones filled by the date pickers in `easy-deposit-ui`) as `yyyy-MM-dd` when writing the DDM.

Explanation:
* `easy-deposit-ui` uses date pickers to select ISO dates; when sent to `easy-deposit-api` these get marked with `scheme: "dcterms:W3CDTF"` and collected together with non-ISO dates (who do not get marked with that scheme).
* `easy-deposit-api` (as per this PR) finds those marked dates and converts any and all ISO date-time formatted values into the format `yyyy-MM-dd` when writing the DDM for `metadata/dataset.xml` during the submit phase.
* `easy-ingest-flow` picks up the deposit and hands off the creation of the EMD to `easy-stage-dataset`, which in turn calls `easy-ddm`, which uses `easy-emd`. The latter implements a date parser which automatically selects the proper date formatting. When `yyyy-MM-dd` is used, the string is ISO-formatted and `eas:format="DAY"` is added.
    * Note: no information (in terms of timestamps) is lost between the conversions from `easy-deposit-ui`'s date pickers to EMD; the date pickers already strip off the time part, so when `easy-emd` is adding that back in, it's the same `T00:00:00.000Z`.

@DANS-KNAW/easy for review