### PR TITLE
NO JIRA. Make timeouts for agreement-generator connection configurable

### DIFF
--- a/src/main/assembly/dist/cfg/application.properties
+++ b/src/main/assembly/dist/cfg/application.properties
@@ -120,3 +120,5 @@ mail.template=opt/dans.knaw.nl/easy-deposit-api/cfg/template
 file.limit=500
 
 agreement-generator.url=http://localhost:20210/agreement
+agreement-generator.connection-timeout-ms=3000
+agreement-generator.read-timeout-ms=60000

--- a/src/main/scala/nl.knaw.dans.easy.deposit/AgreementGenerator.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/AgreementGenerator.scala
@@ -29,12 +29,12 @@ import scalaj.http.BaseHttp
 import scala.io.Source
 import scala.util.{ Failure, Success, Try }
 
-case class AgreementGenerator(http: BaseHttp, url: URL) extends DebugEnhancedLogging {
+case class AgreementGenerator(http: BaseHttp, url: URL, connectionTimeoutMs: Int = 2000, readTimeoutMs: Int = 30000) extends DebugEnhancedLogging {
 
   def generate(agreementData: AgreementData, id: UUID): Try[Array[Byte]] = {
     val json = toJson(agreementData)
     logger.info(s"calling easy-deposit-agreement-generator for $id with body: $json")
-    Try(http(url.toString).postData(json).header("content-type", "application/json").exec {
+    Try(http(url.toString).timeout(connectionTimeoutMs, readTimeoutMs).postData(json).header("content-type", "application/json").exec {
       case (OK_200, _, is) =>
         return Success(readAll(is))
       case (_, _, is) =>

--- a/src/main/scala/nl.knaw.dans.easy.deposit/EasyDepositApiApp.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/EasyDepositApiApp.scala
@@ -102,7 +102,9 @@ class EasyDepositApiApp(configuration: Configuration) extends DebugEnhancedLoggi
       )
       override val agreementGenerator: AgreementGenerator = AgreementGenerator (
         new BaseHttp(userAgent = s"easy-deposit-agreement-creator/${ configuration.version }"),
-        new URL(properties.getString("agreement-generator.url", "http://localhost"))
+        new URL(properties.getString("agreement-generator.url", "http://localhost")),
+        connectionTimeoutMs = properties.getInt("agreement-generator.connection-timeout-ms"),
+        readTimeoutMs = properties.getInt("agreement-generator.read-timeout-ms")
       )
     }
   }

--- a/src/test/resources/debug-config/application.properties
+++ b/src/test/resources/debug-config/application.properties
@@ -34,4 +34,6 @@ mail.bounceAddress=develloper@dans.knaw.nl
 mail.bccs=
 mail.template=home/template
 file.limit=500
-agreement-generator.url=https://deasy.dans.knaw.nl:20210/agreement`
+agreement-generator.url=https://deasy.dans.knaw.nl:20210/agreement
+agreement-generator.connection-timeout-ms=3000
+agreement-generator.read-timeout-ms=60000

--- a/src/test/scala/nl.knaw.dans.easy.deposit/TestSupportFixture.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/TestSupportFixture.scala
@@ -118,6 +118,8 @@ trait TestSupportFixture extends FlatSpec with Matchers with Inside with BeforeA
       addProperty("mail.template", "src/main/assembly/dist/cfg/template")
       addProperty("file.limit", "500")
       addProperty("agreement-generator.url", "http://agreementGeneratorDoesNotExist.dans.knaw.nl")
+      addProperty("agreement-generator.connection-timeout-ms", "3000")
+      addProperty("agreement-generator.read-timeout-ms", "60000")
     })
   }
 


### PR DESCRIPTION
NO JIRA.

#### When applied it will
* Make it possible to configure the connection-timeout and the read-timeout of the connection to `easy-deposit-agreement-generator`.

#### Where should the reviewer @DANS-KNAW/easy start?

