### PR TITLE
EASY-2473: configurable agreement attachment: html or pdf

### DIFF
--- a/src/main/assembly/dist/cfg/application.properties
+++ b/src/main/assembly/dist/cfg/application.properties
@@ -120,3 +120,4 @@ mail.template=opt/dans.knaw.nl/easy-deposit-api/cfg/template
 file.limit=500
 
 agreement-generator.url=http://localhost:20210/agreement
+agreement-generator.accept=text/html

--- a/src/main/scala/nl.knaw.dans.easy.deposit/EasyDepositApiApp.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/EasyDepositApiApp.scala
@@ -100,9 +100,10 @@ class EasyDepositApiApp(configuration: Configuration) extends DebugEnhancedLoggi
         templateDir = File(properties.getString("mail.template", "")),
         myDatasets = new URL(properties.getString("easy.my_datasets"))
       )
-      override val agreementGenerator: AgreementGenerator = AgreementGenerator (
+      override val agreementGenerator: AgreementGenerator = AgreementGenerator(
         new BaseHttp(userAgent = s"easy-deposit-agreement-creator/${ configuration.version }"),
-        new URL(properties.getString("agreement-generator.url", "http://localhost"))
+        new URL(properties.getString("agreement-generator.url", "http://localhost")),
+        properties.getString("agreement-generator.accept", "application/pdf"),
       )
     }
   }

--- a/src/test/resources/debug-config/application.properties
+++ b/src/test/resources/debug-config/application.properties
@@ -34,4 +34,5 @@ mail.bounceAddress=develloper@dans.knaw.nl
 mail.bccs=
 mail.template=home/template
 file.limit=500
-agreement-generator.url=https://deasy.dans.knaw.nl:20210/agreement`
+agreement-generator.url=https://deasy.dans.knaw.nl:20210/agreement
+agreement-generator.accept=text/html

--- a/src/test/scala/nl.knaw.dans.easy.deposit/AgreementGeneratorSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/AgreementGeneratorSpec.scala
@@ -41,7 +41,7 @@ class AgreementGeneratorSpec extends TestSupportFixture with BeforeAndAfterAll {
   private val server = new MockWebServer
   private val test_server = "/generate/"
 
-  private val generator = AgreementGenerator(Http, server.url(test_server).url())
+  private val generator = AgreementGenerator(Http, server.url(test_server).url(),"text/html")
 
   override protected def afterAll(): Unit = {
     server.shutdown()
@@ -74,7 +74,7 @@ class AgreementGeneratorSpec extends TestSupportFixture with BeforeAndAfterAll {
     val uuid = UUID.randomUUID()
     generator.generate(data, uuid) should matchPattern {
       case Failure(GeneratorError(msg, HttpResponse("some error message", 400, _)))
-        if msg ==(s"Could not generate agreement for dataset $uuid") =>
+        if msg == s"Could not generate agreement for dataset $uuid" =>
     }
   }
 }

--- a/src/test/scala/nl.knaw.dans.easy.deposit/DebugConfigSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/DebugConfigSpec.scala
@@ -25,8 +25,8 @@ class DebugConfigSpec extends TestSupportFixture {
   private val distConfigDir = currentWorkingDirectory / "src" / "main" / "assembly" / "dist" / "cfg"
   private val debugConfigDir = testResource("/debug-config")
 
-  "debug-config" should "contain the same files as src/main/assembly/dist/cfg" in pendingUntilFixed {
-    debugConfigDir.list.map(_.name).toSet shouldBe distConfigDir.list.map(_.name).toSet
+  "debug-config" should "contain the same files as src/main/assembly/dist/cfg" in {
+    debugConfigDir.list.map(_.name).toSet shouldBe distConfigDir.list.withFilter(!_.toString().contains("/template")).map(_.name).toSet
   }
 
   it should "contain an application.properties with the same keys as the one in src/main/assembly/dist/cfg" in {

--- a/src/test/scala/nl.knaw.dans.easy.deposit/TestSupportFixture.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/TestSupportFixture.scala
@@ -134,14 +134,13 @@ trait TestSupportFixture extends FlatSpec with Matchers with Inside with BeforeA
         val depositUiURL = properties.getString("easy.deposit-ui")
         createSubmitterWithStubs(stagedBaseDir, submitBase, groupName, depositUiURL)
       }
-
     }
   }
 
-  def createSubmitterWithStubs(stagedBaseDir: File, submitBase: File,groupName: String, depositUiURL: String): Submitter = {
+  def createSubmitterWithStubs(stagedBaseDir: File, submitBase: File, groupName: String, depositUiURL: String): Submitter = {
     new Submitter(stagedBaseDir, submitBase, groupName, depositUiURL) {
       // stubs
-      override val agreementGenerator: AgreementGenerator = new AgreementGenerator(Http, new URL("http://does.not.exist")) {
+      override val agreementGenerator: AgreementGenerator = new AgreementGenerator(Http, new URL("http://does.not.exist"), "text/html") {
         override def generate(agreementData: AgreementData, id: UUID): Try[Array[Byte]] = {
           Success("mocked pdf".getBytes)
         }


### PR DESCRIPTION
Fixes EASY-2473: configurable agreement attachment: html or pdf

#### When applied it will
* 
* 
* 

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

* build and deploy together with generator.
* submit a new deposit
* when pdf is configured the KNAW delivers the message in the inbox
  when html is configured the message is marked as spam

#### Related pull requests on github
* depends on https://github.com/DANS-KNAW/easy-deposit-agreement-generator/pull/6
* most likely conflicts with #191
* possibly dtap should implement all the new entries in `application.properties`
