### PR TITLE
sort deposits on state, then date.created (newest to oldest)

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.deposit/EasyDepositApiApp.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/EasyDepositApiApp.scala
@@ -154,6 +154,7 @@ class EasyDepositApiApp(configuration: Configuration) extends DebugEnhancedLoggi
   def getDeposits(user: String): Try[Seq[DepositInfo]] = {
     trace(user)
     implicit val timestampOrdering: Ordering[DateTime] = Ordering.fromLessThan[DateTime](_ isBefore _).reverse
+    implicit val tupleOrdering: Ordering[(State, DateTime)] = Ordering.Tuple2[State, DateTime]
     for {
       infos <- DepositDir.list(draftBase, user).map(_.getDepositInfo(submitBase, easyHome)).collectResults
       sortedInfos = infos.sortBy(deposit => (deposit.state, deposit.date))

--- a/src/main/scala/nl.knaw.dans.easy.deposit/EasyDepositApiApp.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/EasyDepositApiApp.scala
@@ -154,10 +154,8 @@ class EasyDepositApiApp(configuration: Configuration) extends DebugEnhancedLoggi
   def getDeposits(user: String): Try[Seq[DepositInfo]] = {
     trace(user)
     implicit val timestampOrdering: Ordering[DateTime] = Ordering.fromLessThan[DateTime](_ isBefore _).reverse
-    implicit val tupleOrdering: Ordering[(State, DateTime)] = Ordering.Tuple2[State, DateTime]
-    val deposits = DepositDir.list(draftBase, user)
     for {
-      infos <- deposits.map(_.getDepositInfo(submitBase, easyHome)).collectResults
+      infos <- DepositDir.list(draftBase, user).map(_.getDepositInfo(submitBase, easyHome)).collectResults
       sortedInfos = infos.sortBy(deposit => (deposit.state, deposit.date))
     } yield sortedInfos
   }

--- a/src/main/scala/nl.knaw.dans.easy.deposit/EasyDepositApiApp.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/EasyDepositApiApp.scala
@@ -153,7 +153,7 @@ class EasyDepositApiApp(configuration: Configuration) extends DebugEnhancedLoggi
    */
   def getDeposits(user: String): Try[Seq[DepositInfo]] = {
     trace(user)
-    implicit val timestampOrdering: Ordering[DateTime] = Ordering.fromLessThan[DateTime](_ isBefore _)
+    implicit val timestampOrdering: Ordering[DateTime] = Ordering.fromLessThan[DateTime](_ isBefore _).reverse
     implicit val tupleOrdering: Ordering[(State, DateTime)] = Ordering.Tuple2[State, DateTime]
     val deposits = DepositDir.list(draftBase, user)
     for {

--- a/src/test/scala/nl.knaw.dans.easy.deposit/EasyDepositApiAppSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/EasyDepositApiAppSpec.scala
@@ -56,15 +56,15 @@ class EasyDepositApiAppSpec extends TestSupportFixture {
       case Success(sortedDeposits) =>
         sortedDeposits should contain inOrderOnly(
           // first rejected deposits (newest to oldest)
-          deposit3,
           deposit1,
+          deposit3,
           // then draft deposits
           deposit4,
           // then in-progress deposits
           deposit5.copy(state = expectedState.state, stateDescription = expectedState.stateDescription),
           // and finally archived deposits (newest to oldest)
-          deposit6,
           deposit2,
+          deposit6,
         )
 
         sortedDeposits should not contain deposit7


### PR DESCRIPTION
~Fixes EASY-~

#### When applied it will
* sort deposits on state, then date.created (newest to oldest) (previously it was 'oldest to newest')

@DANS-KNAW/easy for review