### PR TITLE
EASY-2494 confirmation email explains other attachments

### DIFF
--- a/src/main/assembly/dist/cfg/application.properties
+++ b/src/main/assembly/dist/cfg/application.properties
@@ -120,6 +120,7 @@ mail.template=/opt/dans.knaw.nl/easy-deposit-api/cfg/template
 
 # maximum number of lines alias files in (currently unzipped) attached files.txt
 # arbitrary assumption of an average 2000 chars per files -> attachment of 20MB
+# these large number of files are usually submitted via other channels
 attached-file-list.limit=10000
 
 agreement-generator.url=http://localhost:20210/agreement

--- a/src/main/assembly/dist/cfg/application.properties
+++ b/src/main/assembly/dist/cfg/application.properties
@@ -120,7 +120,7 @@ mail.template=/opt/dans.knaw.nl/easy-deposit-api/cfg/template
 
 # maximum number of lines alias files in (currently unzipped) attached files.txt
 # arbitrary assumption of an average 2000 chars per files -> attachment of 20MB
-# these large number of files are usually submitted via other channels
+# these large numbers of files are usually submitted via other channels
 attached-file-list.limit=10000
 
 agreement-generator.url=http://localhost:20210/agreement

--- a/src/main/assembly/dist/cfg/template/depositConfirmation.html
+++ b/src/main/assembly/dist/cfg/template/depositConfirmation.html
@@ -27,5 +27,9 @@ Within a few working days, DANS staff will make your data available to the publi
     <h4>Metadata</h4>
     <p>Also attached is the metadata provided by you, in XML format.</p>
 #end
+#if ($msg4Datamanager)
+    <h4>Your message for the data manager</h4>
+    <p>$msg4Datamanager</p>
+#end
 </body>
 </html>

--- a/src/main/assembly/dist/cfg/template/depositConfirmation.html
+++ b/src/main/assembly/dist/cfg/template/depositConfirmation.html
@@ -16,7 +16,7 @@ Within a few working days, DANS staff will make your data available to the publi
 <p>Note: This link will not yet work until the day after your dataset becomes available to the public.</p>
 <h4>Deposit agreement</h4>
 <p>Attached is a copy of the deposit agreement with the terms and conditions which were agreed with DANS when you deposited the data.</p>
-#if ($hasFilesXml)
+#if ($hasFileListAttached)
     <h4>Other attachments</h4>
     <p>Also attached are:</p>
     <ul>

--- a/src/main/assembly/dist/cfg/template/depositConfirmation.html
+++ b/src/main/assembly/dist/cfg/template/depositConfirmation.html
@@ -16,5 +16,11 @@ Within a few working days, DANS staff will make your data available to the publi
 <p>Note: This link will not yet work until the day after your dataset becomes available to the public.</p>
 <h4>Deposit agreement</h4>
 <p>Attached is a copy of the deposit agreement with the terms and conditions which were agreed with DANS when you deposited the data.</p>
+<h4>Other attachments</h4>
+<p>Also attached are:</p>
+<ul>
+    <li>the metadata provided by you, in XML format;</li>
+    <li>the list of uploaded files and their SHA-1 checksums.</li>
+</ul>
 </body>
 </html>

--- a/src/main/assembly/dist/cfg/template/depositConfirmation.html
+++ b/src/main/assembly/dist/cfg/template/depositConfirmation.html
@@ -16,11 +16,16 @@ Within a few working days, DANS staff will make your data available to the publi
 <p>Note: This link will not yet work until the day after your dataset becomes available to the public.</p>
 <h4>Deposit agreement</h4>
 <p>Attached is a copy of the deposit agreement with the terms and conditions which were agreed with DANS when you deposited the data.</p>
-<h4>Other attachments</h4>
-<p>Also attached are:</p>
-<ul>
-    <li>the metadata provided by you, in XML format;</li>
-    <li>the list of uploaded files and their SHA-1 checksums.</li>
-</ul>
+#if ($hasFilesXml)
+    <h4>Other attachments</h4>
+    <p>Also attached are:</p>
+    <ul>
+        <li>the metadata provided by you, in XML format;</li>
+        <li>the list of uploaded files and their SHA-1 checksums.</li>
+    </ul>
+#else
+    <h4>Metadata</h4>
+    <p>Also attached is the metadata provided by you, in XML format.</p>
+#end
 </body>
 </html>

--- a/src/main/assembly/dist/cfg/template/depositConfirmation.txt
+++ b/src/main/assembly/dist/cfg/template/depositConfirmation.txt
@@ -20,3 +20,9 @@ Note: This link will not work until the day after your dataset becomes available
 
 DEPOSIT AGREEMENT
 Attached is a copy of the deposit agreement with the terms and conditions which you agreed upon when you deposited the data.
+
+OTHER ATTACHMENTS
+
+Also attached are:
+- the metadata provided by you, in XML format;
+- the list of uploaded files and their SHA-1 checksums.

--- a/src/main/assembly/dist/cfg/template/depositConfirmation.txt
+++ b/src/main/assembly/dist/cfg/template/depositConfirmation.txt
@@ -21,7 +21,7 @@ Note: This link will not work until the day after your dataset becomes available
 DEPOSIT AGREEMENT
 Attached is a copy of the deposit agreement with the terms and conditions which you agreed upon when you deposited the data.
 
-#if ($hasFilesXml)
+#if ($hasFileListAttached)
 OTHER ATTACHMENTS
 
 Also attached are:

--- a/src/main/assembly/dist/cfg/template/depositConfirmation.txt
+++ b/src/main/assembly/dist/cfg/template/depositConfirmation.txt
@@ -21,8 +21,13 @@ Note: This link will not work until the day after your dataset becomes available
 DEPOSIT AGREEMENT
 Attached is a copy of the deposit agreement with the terms and conditions which you agreed upon when you deposited the data.
 
+#if ($hasFilesXml)
 OTHER ATTACHMENTS
 
 Also attached are:
 - the metadata provided by you, in XML format;
 - the list of uploaded files and their SHA-1 checksums.
+#else
+METADATA
+Also attached is the metadata provided by you, in XML format.
+#end

--- a/src/main/assembly/dist/cfg/template/depositConfirmation.txt
+++ b/src/main/assembly/dist/cfg/template/depositConfirmation.txt
@@ -29,5 +29,12 @@ Also attached are:
 - the list of uploaded files and their SHA-1 checksums.
 #else
 METADATA
+
 Also attached is the metadata provided by you, in XML format.
+#end
+#if ($msg4Datamanager)
+
+YOUR MESSAGE FOR THE DATA MANAGER
+
+$msg4Datamanager
 #end

--- a/src/main/scala/nl.knaw.dans.easy.deposit/Mailer.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/Mailer.scala
@@ -59,13 +59,15 @@ case class Mailer(smtpHost: String,
   }
 
   /** @return messageID */
-  def buildMessage(data: AgreementData, attachments: Map[String, DataSource], depositId: UUID): Try[MultiPartEmail] = Try {
+  def buildMessage(data: AgreementData, attachments: Map[String, DataSource], depositId: UUID, msg4Datamanager: String): Try[MultiPartEmail] = Try {
     val context = new VelocityContext {
       put("displayName", data.depositor.name)
       put("datasetTitle", data.title)
       put("myDatasetsUrl", myDatasets.toString)
       put("doi", data.doi)
       put("hasFileListAttached", hasFileList(attachments))
+      if (msg4Datamanager.trim.nonEmpty)
+        put("msg4Datamanager", msg4Datamanager)
     }
     logger.info(s"[$depositId] email placeholder values: ${ context.getKeys.map(key => s"$key=${ context.get(key.toString) }").mkString(", ") }")
     val email = new HtmlEmail()

--- a/src/main/scala/nl.knaw.dans.easy.deposit/Mailer.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/Mailer.scala
@@ -65,7 +65,7 @@ case class Mailer(smtpHost: String,
       put("datasetTitle", data.title)
       put("myDatasetsUrl", myDatasets.toString)
       put("doi", data.doi)
-      put("hasFilesXml", nrOf(attachments) > 1)
+      put("hasFilesXml", nrOf(attachments) > 2)
     }
     logger.info(s"[$depositId] email placeholder values: ${ context.getKeys.map(key => s"$key=${ context.get(key.toString) }").mkString(", ") }")
     val email = new HtmlEmail()
@@ -87,14 +87,11 @@ case class Mailer(smtpHost: String,
 }
 object Mailer extends DebugEnhancedLogging {
 
-
-  private def nrOf(attachments: Map[String, DataSource]) = {
-    attachments
-      .map { case (_, content) => notEmpty(content) }
-      .size
+  private def nrOf(attachments: Map[String, DataSource]): Int = {
+    attachments.count{ case (_, content) => notEmpty(content) }
   }
 
-  private def notEmpty(content: DataSource) = {
+  private def notEmpty(content: DataSource): Boolean = {
     content.getInputStream.available() > 0
   }
 

--- a/src/main/scala/nl.knaw.dans.easy.deposit/Mailer.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/Mailer.scala
@@ -22,7 +22,7 @@ import java.util.{ Properties, UUID }
 import better.files.File
 import javax.activation.DataSource
 import javax.mail.util.ByteArrayDataSource
-import nl.knaw.dans.easy.deposit.Mailer.{ notEmpty, nrOf }
+import nl.knaw.dans.easy.deposit.Mailer.{ notEmpty, hasFileList }
 import nl.knaw.dans.easy.deposit.docs.AgreementData
 import nl.knaw.dans.lib.error._
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
@@ -65,7 +65,7 @@ case class Mailer(smtpHost: String,
       put("datasetTitle", data.title)
       put("myDatasetsUrl", myDatasets.toString)
       put("doi", data.doi)
-      put("hasFilesXml", nrOf(attachments) > 2)
+      put("hasFileListAttached", hasFileList(attachments))
     }
     logger.info(s"[$depositId] email placeholder values: ${ context.getKeys.map(key => s"$key=${ context.get(key.toString) }").mkString(", ") }")
     val email = new HtmlEmail()
@@ -87,8 +87,8 @@ case class Mailer(smtpHost: String,
 }
 object Mailer extends DebugEnhancedLogging {
 
-  private def nrOf(attachments: Map[String, DataSource]): Int = {
-    attachments.count{ case (_, content) => notEmpty(content) }
+  private def hasFileList(attachments: Map[String, DataSource]): Boolean = {
+    attachments.exists { case (name, content) => name.startsWith("files.") && notEmpty(content) }
   }
 
   private def notEmpty(content: DataSource): Boolean = {

--- a/src/test/scala/nl.knaw.dans.easy.deposit/MailerSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/MailerSpec.scala
@@ -42,16 +42,18 @@ class MailerSpec extends TestSupportFixture {
   )
 
   private val url = new URL("http:/localhost")
+  private val validTemplateDir: File = File("src/main/assembly/dist/cfg/template")
+  private val invalidTemplateDir: File = File("does/not/exist")
   "buildMessage" should "succeed" in {
     val from = "does.not.exist@dans.knaw.nl"
-    Mailer(smtpHost = "localhost", fromAddress = from, bounceAddress = from, bccs = Seq.empty, templateDir = File("src/main/assembly/dist/cfg/template"), url)
-      .buildMessage(data, attachments, UUID.randomUUID()) shouldBe a[Success[_]]
+    Mailer(smtpHost = "localhost", fromAddress = from, bounceAddress = from, bccs = Seq.empty, validTemplateDir, url)
+      .buildMessage(data, attachments, UUID.randomUUID(), msg4Datamanager = "") shouldBe a[Success[_]]
   }
 
-  "buildMessage" should "report invalid address" in {
+  it should "report invalid address" in {
     val from = "dans.knaw.nl"
-    Mailer(smtpHost = "localhost", fromAddress = from, bounceAddress = from, bccs = Seq.empty, templateDir = File("src/main/assembly/dist/cfg/template"), url)
-      .buildMessage(data, attachments, UUID.randomUUID()) should matchPattern {
+    Mailer(smtpHost = "localhost", fromAddress = from, bounceAddress = from, bccs = Seq.empty, validTemplateDir, url)
+      .buildMessage(data, attachments, UUID.randomUUID(), msg4Datamanager = "") should matchPattern {
       case Failure(e) if e.getMessage.matches(".*Missing final '@domain'.*dans.knaw.nl.*") =>
     }
   }
@@ -59,7 +61,7 @@ class MailerSpec extends TestSupportFixture {
   "constructor" should "report missing templates" in {
     val from = "does.not.exist@dans.knaw.nl"
     the[ResourceNotFoundException] thrownBy
-      Mailer(smtpHost = "localhost", fromAddress = from, bounceAddress = from, bccs = Seq.empty, templateDir = File("does/not/exist"), url) should
+      Mailer(smtpHost = "localhost", fromAddress = from, bounceAddress = from, bccs = Seq.empty, invalidTemplateDir, url) should
       have message "Unable to find resource 'depositConfirmation.html'"
   }
 }

--- a/src/test/scala/nl.knaw.dans.easy.deposit/TestSupportFixture.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/TestSupportFixture.scala
@@ -160,7 +160,7 @@ trait TestSupportFixture extends FlatSpec with Matchers with Inside with BeforeA
         templateDir = File("src/main/assembly/dist/cfg/template"),
         myDatasets = new URL("http://does.not.exist")
       ) {
-        override def buildMessage(data: AgreementData, attachments: Map[String, DataSource], depositId: UUID): Try[MultiPartEmail] = {
+        override def buildMessage(data: AgreementData, attachments: Map[String, DataSource], depositId: UUID, msg: String): Try[MultiPartEmail] = {
           Success(new MultiPartEmail) // only cause causes the following logging:
           // ERROR could not send deposit confirmation message
           //java.lang.IllegalArgumentException: MimeMessage has not been created yet


### PR DESCRIPTION
Fixes EASY-2494 confirmation email explains other attachments

#### When applied it will
* 
* 
* 

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

build/deploy on deasy:
* [x] submit a deposit with less than 10000 files
* [x] submit a deposit with more than 10000 files
The latter lacks the `files.xml` and thus has other text

## < 10000 files and message for data manager
![image](https://user-images.githubusercontent.com/10553630/71891185-557dc900-3146-11ea-92c2-c2401e1faff8.png)


## > 10000 files
![image](https://user-images.githubusercontent.com/10553630/71879738-13955880-312f-11ea-8010-2507284e8b39.png)


#### Related pull requests on github
repo                       | PR                | note
-------------------------- | ----------------- | ----
easy-                      | [PR#](PRlink)     | ..
