### PR TITLE
EASY-2500: restore user data that is exposed through the servlet

### DIFF
--- a/docs/api/api.yml
+++ b/docs/api/api.yml
@@ -700,23 +700,22 @@ components:
         firstName: "First"
         prefix: "van"
         lastName: "Namen"
-        groups: [ "group001", "group002"]
+        displayName: "First van Namen"
       properties:
         username:
           type: "string"
         firstName:
           type: "string"
-          description: "(optional)"
+          description: "Initials of the user"
         prefix:
           type: "string"
           description: "insertions, called 'tussenvoegsels' in Dutch"
         lastName:
           type: "string"
-        groups:
-          type: array
-          items:
-            type: string
-          description: "string array with group-names this user belongs to"
+          description: "Surname of the user"
+        displayName:
+          type: "string"
+          description: "Full name of the user used for displaying"
 
     Doi:
       type: object

--- a/src/main/scala/nl.knaw.dans.easy.deposit/docs/AgreementUser.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/docs/AgreementUser.scala
@@ -31,7 +31,7 @@ case class AgreementUser(name: String,
                          email: String,
                    )
 object AgreementUser extends DebugEnhancedLogging {
-  def apply(input: JsonInput): Try[UserInfo] = input.deserialize[UserInfo]
+  def apply(input: JsonInput): Try[AgreementUser] = input.deserialize[AgreementUser]
 
   def apply(data: UserData): AgreementUser = {
     new AgreementUser(

--- a/src/main/scala/nl.knaw.dans.easy.deposit/docs/UserData.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/docs/UserData.scala
@@ -63,7 +63,7 @@ object UserData extends DebugEnhancedLogging {
       id = getAttribute("uid"),
 
       name = getAttribute("displayName"),
-      firstName = getOption("cn"),
+      firstName = getOption("initials"),
       prefix = getOption("dansPrefixes"),
       lastName = getAttribute("sn"),
       address = getAttribute("postalAddress"),

--- a/src/main/scala/nl.knaw.dans.easy.deposit/docs/UserInfo.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/docs/UserInfo.scala
@@ -26,7 +26,6 @@ case class UserInfo(userName: String,
                     prefix: Option[String] = None,
                     lastName: String,
                     displayName: String,
-                    email: String,
                    )
 object UserInfo extends DebugEnhancedLogging {
   def apply(input: JsonInput): Try[UserInfo] = input.deserialize[UserInfo]
@@ -38,7 +37,6 @@ object UserInfo extends DebugEnhancedLogging {
       prefix = data.prefix,
       lastName = data.lastName,
       displayName = data.name,
-      email = data.email,
     )
   }
 }

--- a/src/main/scala/nl.knaw.dans.easy.deposit/servlets/UserServlet.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/servlets/UserServlet.scala
@@ -27,7 +27,7 @@ class UserServlet(app: EasyDepositApiApp) extends ProtectedServlet(app) {
 
   get("/") {
     Try(app.getUserData(user.id)).flatten // no throw should slip through
-      .map(userInfo => Ok(toJson(userInfo)))
+      .map(userData => Ok(toJson(UserInfo(userData))))
       .getOrRecoverWithActionResult
   }
   put("/") {

--- a/src/test/scala/nl.knaw.dans.easy.deposit/servlets/HappyRoutesSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/servlets/HappyRoutesSpec.scala
@@ -98,7 +98,7 @@ class HappyRoutesSpec extends TestSupportFixture with ServletFixture with Scalat
       uri = "/user",
       headers = Seq(fooBarBasicAuthHeader)
     ) {
-      body shouldBe """{"id":"foo","name":"Jan v.d. Berg","firstName":"Jan","prefix":"van den","lastName":"Berg","address":"Anna van Saksenlaan 51","zipcode":"2593 HW","city":"Den Haag","country":"Netherlands","organisation":"DANS","phone":"+31 70 349 44 50","email":"does.not.exist@dans.knaw.nl"}"""
+      body shouldBe """{"userName":"foo","firstName":"Jan","prefix":"van den","lastName":"Berg","displayName":"Jan v.d. Berg"}"""
       status shouldBe OK_200
     }
   }
@@ -112,7 +112,7 @@ class HappyRoutesSpec extends TestSupportFixture with ServletFixture with Scalat
       uri = "/user",
       headers = Seq(fooBarBasicAuthHeader)
     ) {
-      body shouldBe """{"id":"user001","name":"fullName","lastName":"","address":"","zipcode":"","city":"","country":"","organisation":"","phone":"","email":"does.not.exist@dans.knaw.nl"}"""
+      body shouldBe """{"userName":"user001","lastName":"","displayName":"fullName"}"""
       status shouldBe OK_200
     }
   }


### PR DESCRIPTION
Fixes EASY-2500

#### When applied it will
* restore user data that is exposed through the servlet
* update the API documentation to conform to the expected output
* fix a copy-paste error in `AgreementUser`
* fix a incorrect key for fetching the firstname (initials) from the LDAP data

These bugs were introduced in https://github.com/DANS-KNAW/easy-deposit-api/pull/189; see also the analysis in the [issue](https://drivenbydata.atlassian.net/browse/EASY-2500).

@DANS-KNAW/easy for review