### PR TITLE
EASY-2512: fix incomplete pattern match that caused mail not to be sent on empty attachment

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.deposit/Mailer.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/Mailer.scala
@@ -82,8 +82,10 @@ case class Mailer(smtpHost: String,
     email.setFrom(fromAddress)
     email.setBounceAddress(bounceAddress)
     bccs.foreach(email.addBcc)
-    attachments.foreach { case (name, content) if notEmpty(content) =>
-      email.attach(content, name, name)
+    attachments.foreach {
+      case (name, content) =>
+        if (notEmpty(content))
+          email.attach(content, name, name)
     }
     email.setHostName(smtpHost)
     email.buildMimeMessage()

--- a/src/test/scala/nl.knaw.dans.easy.deposit/MailerSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/MailerSpec.scala
@@ -50,6 +50,13 @@ class MailerSpec extends TestSupportFixture {
       .buildMessage(data, attachments, UUID.randomUUID(), msg4Datamanager = Option("")) shouldBe a[Success[_]]
   }
 
+  it should "not add empty attachments" in {
+    val from = "does.not.exist@dans.knaw.nl"
+    val theseAttachments = attachments + (Mailer.filesAttachmentName -> Mailer.dataSource("".getBytes, "text/plain"))
+    Mailer(smtpHost = "localhost", fromAddress = from, bounceAddress = from, bccs = Seq.empty, validTemplateDir, url)
+      .buildMessage(data, theseAttachments, UUID.randomUUID(), msg4Datamanager = Option("")) shouldBe a[Success[_]]
+  }
+
   it should "report invalid address" in {
     val from = "dans.knaw.nl"
     Mailer(smtpHost = "localhost", fromAddress = from, bounceAddress = from, bccs = Seq.empty, validTemplateDir, url)


### PR DESCRIPTION
Fixes EASY-2512

#### When applied it will
* fix incomplete pattern match that caused mail not to be sent on empty attachment

@DANS-KNAW/easy for review