### PR TITLE
EASY-2332: validation of UUIDs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
         <dependency>
             <groupId>nl.knaw.dans.lib</groupId>
             <artifactId>dans-scala-lib_2.12</artifactId>
-            <version>1.6.0</version>
+            <version>1.6.1</version>
         </dependency>
         <dependency>
             <groupId>nl.knaw.dans.lib</groupId>

--- a/src/main/scala/nl.knaw.dans.easy.deposit/servlets/DepositServlet.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/servlets/DepositServlet.scala
@@ -74,7 +74,7 @@ class DepositServlet(app: EasyDepositApiApp)
         _ = logger.info(s"retrieve deposits for user '$userId'")
         deposits <- app.getDeposits(userId)
       } yield Ok(body = toJson(deposits), headers = Map(contentTypeJson))
-      }.getOrRecoverWithActionResult
+    }.getOrRecoverWithActionResult
   }
   post("/") {
     {
@@ -84,8 +84,8 @@ class DepositServlet(app: EasyDepositApiApp)
         depositInfo <- app.createDeposit(userId)
         _ = logger.info(s"[${ depositInfo.id }] created deposit for user '$userId'")
         locationHeader = "Location" -> s"${ request.getRequestURL }/${ depositInfo.id }"
-      } yield Created(body = toJson(depositInfo), headers = Map(contentTypeJson, locationHeader))
-      }.getOrRecoverWithActionResult
+      } yield Created(body = toJson(depositInfo), headers = Map(contentTypeJson, locationHeader)
+    }.getOrRecoverWithActionResult
   }
   get("/:uuid/metadata") {
     {
@@ -94,7 +94,7 @@ class DepositServlet(app: EasyDepositApiApp)
         _ = logger.info(s"[$uuid] retrieve metadata")
         dmd <- app.getDatasetMetadataForDeposit(user.id, uuid)
       } yield Ok(body = toJson(dmd), headers = Map(contentTypeJson))
-      }.getOrRecoverWithActionResult
+    }.getOrRecoverWithActionResult
   }
   get("/:uuid/doi") {
     {
@@ -103,7 +103,7 @@ class DepositServlet(app: EasyDepositApiApp)
         _ = logger.info(s"[$uuid] retrieve doi")
         doi <- app.getDoi(user.id, uuid)
       } yield Ok(body = s"""{"doi":"$doi"}""", headers = Map(contentTypeJson))
-      }.getOrRecoverWithActionResult
+    }.getOrRecoverWithActionResult
   }
   put("/:uuid/metadata") {
     {
@@ -117,7 +117,7 @@ class DepositServlet(app: EasyDepositApiApp)
         _ = logger.debug(s"[$uuid] writing newly uploaded dataset metadata to deposit")
         _ <- app.writeDataMetadataToDeposit(datasetMetadata, user.id, uuid)
       } yield NoContent()
-      }.getOrRecoverWithActionResult
+    }.getOrRecoverWithActionResult
   }
   get("/:uuid/state") {
     {
@@ -126,7 +126,7 @@ class DepositServlet(app: EasyDepositApiApp)
         _ = logger.info(s"[$uuid] retrieve deposit state")
         depositState <- app.getDepositState(user.id, uuid)
       } yield Ok(body = toJson(depositState), headers = Map(contentTypeJson))
-      }.getOrRecoverWithActionResult
+    }.getOrRecoverWithActionResult
   }
   put("/:uuid/state") {
     {
@@ -137,7 +137,7 @@ class DepositServlet(app: EasyDepositApiApp)
         _ = logger.info(s"[$uuid] changing state to ${ stateInfo.state } with description ${ stateInfo.stateDescription }")
         _ <- app.setDepositState(stateInfo, user.id, uuid)
       } yield NoContent()
-      }.getOrRecoverWithActionResult
+    }.getOrRecoverWithActionResult
   }
   delete("/:uuid") {
     {
@@ -146,7 +146,7 @@ class DepositServlet(app: EasyDepositApiApp)
         _ = logger.info(s"[$uuid] deleting deposit")
         _ <- app.deleteDeposit(user.id, uuid)
       } yield NoContent()
-      }.getOrRecoverWithActionResult
+    }.getOrRecoverWithActionResult
   }
   get("/:uuid/file/*") { //dir and file
     {
@@ -156,7 +156,7 @@ class DepositServlet(app: EasyDepositApiApp)
         _ = logger.info(s"[$uuid] retrieve file info for path '${ path.toString.toOption.getOrElse("/") }'")
         contents <- app.getFileInfo(user.id, uuid, path)
       } yield Ok(body = toJson(contents), headers = Map(contentTypeJson))
-      }.getOrRecoverWithActionResult
+    }.getOrRecoverWithActionResult
   }
   post("/:uuid/file/*") { //file(s)
     {
@@ -175,7 +175,7 @@ class DepositServlet(app: EasyDepositApiApp)
             .flatMap(_ => stagedFilesTarget.moveAllFrom(stagingDir))
         )
       } yield Created()
-      }.getOrRecoverWithActionResult
+    }.getOrRecoverWithActionResult
   }
 
   put("/:uuid/file/*") { //file
@@ -193,7 +193,7 @@ class DepositServlet(app: EasyDepositApiApp)
       } yield if (newFileWasCreated)
                 Created(headers = Map("Location" -> request.uri.toASCIIString))
               else NoContent()
-      }.getOrRecoverWithActionResult
+    }.getOrRecoverWithActionResult
   }
   delete("/:uuid/file/*") { //dir and file
     {
@@ -203,7 +203,7 @@ class DepositServlet(app: EasyDepositApiApp)
         _ = logger.info(s"[$uuid] deleting file ${ path.toString.toOption.getOrElse("/") }")
         _ <- app.deleteDepositFile(user.id, uuid, path)
       } yield NoContent()
-      }.getOrRecoverWithActionResult
+    }.getOrRecoverWithActionResult
   }
 
   private def getUserId: Try[String] = {

--- a/src/main/scala/nl.knaw.dans.easy.deposit/servlets/DepositServlet.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/servlets/DepositServlet.scala
@@ -210,10 +210,11 @@ class DepositServlet(app: EasyDepositApiApp)
     }
   }
 
-  private def getUUID: Try[UUID] = Try {
-    UUID.fromString(params("uuid"))
-  }.recoverWith { case t: Throwable =>
-    Failure(InvalidResourceException(s"Invalid deposit id: ${ t.getMessage }"))
+  private def getUUID: Try[UUID] = {
+    params("uuid").toUUID.toTry match {
+      case Success(uuid) => Success(uuid)
+      case Failure(e) => Failure(InvalidResourceException(s"Invalid deposit id: ${ e.getMessage }"))
+    }
   }
 
   private def getPath: Try[Path] = Try {

--- a/src/main/scala/nl.knaw.dans.easy.deposit/servlets/DepositServlet.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/servlets/DepositServlet.scala
@@ -84,7 +84,7 @@ class DepositServlet(app: EasyDepositApiApp)
         depositInfo <- app.createDeposit(userId)
         _ = logger.info(s"[${ depositInfo.id }] created deposit for user '$userId'")
         locationHeader = "Location" -> s"${ request.getRequestURL }/${ depositInfo.id }"
-      } yield Created(body = toJson(depositInfo), headers = Map(contentTypeJson, locationHeader)
+      } yield Created(body = toJson(depositInfo), headers = Map(contentTypeJson, locationHeader))
     }.getOrRecoverWithActionResult
   }
   get("/:uuid/metadata") {

--- a/src/test/scala/nl.knaw.dans.easy.deposit/servlets/DepositServletErrorSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/servlets/DepositServletErrorSpec.scala
@@ -105,4 +105,15 @@ class DepositServletErrorSpec extends TestSupportFixture with ServletFixture wit
       status shouldBe INTERNAL_SERVER_ERROR_500
     }
   }
+
+  it should "report an invalid UUID" in {
+    authMocker.expectsUserFooBar
+    get(
+      uri = s"/abc/metadata",
+      headers = Seq(fooBarBasicAuthHeader)
+    ) {
+      body shouldBe s"Invalid deposit id: String 'abc' is not a UUID"
+      status shouldBe NOT_FOUND_404
+    }
+  }
 }


### PR DESCRIPTION
Fixes EASY-2332

#### When applied it will
* validate `UUIDs` using `dans.lib.string.toUUID` method

**Note**: In the following classes `UUID` is created directly by calling `UUID.fromString` method because these bagId-strings come from already existing bags:
* DepositDir,  StateManager
#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### Related pull requests on github
repo                       | PR                | note
-------------------------- | ----------------- | ----
easy-archive-bag   | [PR#66](https://github.com/DANS-KNAW/easy-archive-bag/pull/66)     | ..
easy-auth-info   | [PR#36](https://github.com/DANS-KNAW/easy-auth-info/pull/36)     | ..
easy-bag-index  | [PR#50](https://github.com/DANS-KNAW/easy-bag-index/pull/50)     | ..
easy-bag-store  | [PR#100](https://github.com/DANS-KNAW/easy-bag-store/pull/100)     | ..
easy-delete-dataset  | [PR#19](https://github.com/DANS-KNAW/easy-delete-dataset/pull/19)     | ..
easy-deposit-properties  | [PR#23](https://github.com/DANS-KNAW/easy-deposit-properties/pull/23)     | ..
easy-ingest-flow  | [PR#137](https://github.com/DANS-KNAW/easy-ingest-flow/pull/137)     | ..
easy-solr4files-index  | [PR#54](https://github.com/DANS-KNAW/easy-solr4files-index/pull/54)     | ..
easy-split-multi-deposit  | [PR#146](https://github.com/DANS-KNAW/easy-split-multi-deposit/pull/146)     | ..
easy-transform-metadata  | [PR#11](https://github.com/DANS-KNAW/easy-transform-metadata/pull/11)     | ..
easy-validate-dans-bag  | [PR#73](https://github.com/DANS-KNAW/easy-validate-dans-bag/pull/73)     | ..

