### PR TITLE
EASY-2548: use draft depositId as the name of the bag in de submit depositId

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.deposit/DepositDir.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/DepositDir.scala
@@ -22,6 +22,7 @@ import java.util.UUID
 
 import better.files._
 import nl.knaw.dans.bag.v0.DansV0Bag
+import nl.knaw.dans.easy.deposit.DepositDir.bagDirName
 import nl.knaw.dans.easy.deposit.Errors._
 import nl.knaw.dans.easy.deposit.PidRequester.PidType
 import nl.knaw.dans.easy.deposit.docs.JsonUtil.toJson
@@ -170,6 +171,8 @@ case class DepositDir private(draftBase: File, user: String, id: UUID) extends D
 }
 
 object DepositDir {
+
+  private val bagDirName = "bag"
 
   /**
    * Lists the deposits of the specified user.

--- a/src/main/scala/nl.knaw.dans.easy.deposit/SubmitJob.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/SubmitJob.scala
@@ -75,7 +75,7 @@ class SubmitJob(draftDepositId: UUID,
     }
     logger.debug(s"[$draftDepositId] Message for the datamanager:\n$fullMsg4DataManager")
 
-    val stagedBagDir = stagedDepositDir / bagDirName
+    val stagedBagDir = stagedDepositDir / draftDepositId.toString
     logger.info(s"[$draftDepositId] Created staged bag in ${ stagedBagDir }")
     for {
       stageBag <- DansV0Bag.empty(stagedBagDir).map(_.withCreated())

--- a/src/main/scala/nl.knaw.dans.easy.deposit/package.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/package.scala
@@ -26,7 +26,6 @@ import scala.xml._
 package object deposit {
 
   val prologue = """<?xml version='1.0' encoding='UTF-8'?>"""
-  val bagDirName = "bag"
 
   implicit class XmlExtensions(val elem: Elem) extends AnyVal {
 

--- a/src/test/scala/nl.knaw.dans.easy.deposit/SubmitJobSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/SubmitJobSpec.scala
@@ -155,7 +155,7 @@ class SubmitJobSpec extends TestSupportFixture with MockFactory {
     (bag.baseDir / "manifest-sha1.txt").append("chk file")
 
     createSubmitter(userGroup).submit(depositDir, stateManager, defaultUserInfo, testDir / "staged") should matchPattern {
-      case Failure(e) if e.getMessage == s"invalid bag, missing [files, checksums]: [Set($testDir/drafts/user/${ depositDir.id }/bag/file), Set()]" =>
+      case Failure(e) if e.getMessage == s"invalid bag, missing [files, checksums]: [Set($testDir/drafts/user/${ depositDir.id }/$bagDirName/file), Set()]" =>
     }
   }
 

--- a/src/test/scala/nl.knaw.dans.easy.deposit/SubmitJobSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/SubmitJobSpec.scala
@@ -59,6 +59,7 @@ class SubmitJobSpec extends TestSupportFixture with MockFactory {
   it should "write all files" ignore {
     // preparations
     val depositDir = createDeposit(datasetMetadata.copy(messageForDataManager = Some(customMessage)))
+    val draftDepositId = depositDir.id.toString
     val bag = getBag(depositDir)
     addDoiToDepositProperties(bag)
     val bagDir = bag.baseDir
@@ -78,7 +79,7 @@ class SubmitJobSpec extends TestSupportFixture with MockFactory {
     (testDir / "staged") should not(exist)
     (bagDir / "metadata" / "dataset.json").size shouldBe mdOldSize
     // no DOI added
-    val submittedBagDir = testDir / "submitted" / bagStoreBagID / bagDirName
+    val submittedBagDir = testDir / "submitted" / bagStoreBagID / draftDepositId
     (submittedBagDir / "metadata" / "depositor-info" / "message-from-depositor.txt").contentAsString shouldBe s"$customMessage\n\nThe deposit can be found at http://does.not.exist/${ depositDir.id }"
     (submittedBagDir / "metadata" / "depositor-info" / "agreements.xml").lineIterator.next() shouldBe prologue
     (submittedBagDir / "metadata" / "dataset.xml").lineIterator.next() shouldBe prologue
@@ -95,11 +96,12 @@ class SubmitJobSpec extends TestSupportFixture with MockFactory {
 
   it should "write empty message-from-depositor file" ignore {
     val depositDir = createDeposit(datasetMetadata.copy(messageForDataManager = None))
+    val draftDepositId = depositDir.id.toString
     addDoiToDepositProperties(getBag(depositDir))
 
     val bagStoreBagId = succeedingSubmit(depositDir)
 
-    (testDir / "submitted" / bagStoreBagId / bagDirName / "metadata" / "depositor-info" / "message-from-depositor.txt")
+    (testDir / "submitted" / bagStoreBagId / draftDepositId / "metadata" / "depositor-info" / "message-from-depositor.txt")
       .contentAsString shouldBe s"The deposit can be found at http://does.not.exist/${ depositDir.id }"
   }
 

--- a/src/test/scala/nl.knaw.dans.easy.deposit/SubmitJobSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/SubmitJobSpec.scala
@@ -92,6 +92,8 @@ class SubmitJobSpec extends TestSupportFixture with MockFactory {
     depositDir.getDOI(null) shouldBe Success(doi) // no pid-requester so obtained from json and/or props
     new PropertiesConfiguration((bagDir.parent / "deposit.properties").toJava)
       .getString("state.label") shouldBe "SUBMITTED"
+    new PropertiesConfiguration((testDir / "submitted" / bagStoreBagID / "deposit.properties").toJava)
+      .getString("bag-store.bag-name") shouldBe draftDepositId
   }
 
   it should "write empty message-from-depositor file" ignore {

--- a/src/test/scala/nl.knaw.dans.easy.deposit/SubmitterSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/SubmitterSpec.scala
@@ -115,7 +115,7 @@ class SubmitterSpec extends TestSupportFixture with MockFactory {
 
     createSubmitter()
       .submit(draftDeposit, draftDepositStateManager = null, defaultUserInfo, stageDir) should matchPattern {
-      case Failure(e: NoSuchFileException) if e.getMessage.contains("bag/bagit.txt") =>
+      case Failure(e: NoSuchFileException) if e.getMessage.contains(s"$bagDirName/bagit.txt") =>
     }
   }
 

--- a/src/test/scala/nl.knaw.dans.easy.deposit/servlets/IntegrationSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/servlets/IntegrationSpec.scala
@@ -184,7 +184,7 @@ class IntegrationSpec extends TestSupportFixture with ServletFixture with Scalat
   private def submittedAgreementsHasEmail(uuid: String) = {
     // might be overkill with respect to AgreementsSpec
     val submittedUUID = new PropertiesConfiguration((testDir / "drafts" / "foo" / uuid / "deposit.properties").toJava).getString("bag-store.bag-id")
-    (testDir / "easy-ingest-flow-inbox" / submittedUUID / "bag" / "metadata" / "depositor-info" / "agreements.xml").contentAsString should
+    (testDir / "easy-ingest-flow-inbox" / submittedUUID / uuid / "metadata" / "depositor-info" / "agreements.xml").contentAsString should
       include("""<signerId easy-account="user001" email="does.not.exist@dans.knaw.nl">fullName</signerId>""")
   }
 


### PR DESCRIPTION
Fixes EASY-2548

#### When applied it will
* use draft `depositId` as the name of the bag in de submit `depositId`

@DANS-KNAW/easy for review