### PR TITLE
EASY-2582: add support for id-type:OTHER related identifiers

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.deposit/docs/DDM.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/docs/DDM.scala
@@ -108,6 +108,7 @@ object DDM extends SchemedXml with DebugEnhancedLogging {
       case RelatedIdentifier(Some("id-type:DOI"), Some(value), _) => <label scheme="id-type:DOI" href={ "https://doi.org/" + value }>{ value }</label>
       case RelatedIdentifier(Some("id-type:URN"), Some(value), _) => <label scheme="id-type:URN" href={ "http://persistent-identifier.nl/" + value }>{ value }</label>
       case RelatedIdentifier(Some(scheme @ ("id-type:URI" | "id-type:URL")), Some(value), _) => <label scheme={ scheme } href={ value }>{ value }</label>
+      case RelatedIdentifier(Some("id-type:OTHER"), Some(value), _) => <label>{ value }</label>
       case RelatedIdentifier(scheme, Some(value), _) => <label xsi:type={ scheme.nonBlankOrNull }>{ value }</label>
       // should not get at the next because of withNonEmpty
       case _ => throw new IllegalArgumentException("invalid relation " + JsonUtil.toJson(relation))


### PR DESCRIPTION
Fixes EASY-2582

#### When applied it will
* add support for `id-type:OTHER` related identifiers

@DANS-KNAW/easy for review