### PR TITLE
EASY-2529: include file size in FileInfo responses

### DIFF
--- a/docs/api/api.yml
+++ b/docs/api/api.yml
@@ -395,9 +395,11 @@ paths:
                   - filename: myfile.txt
                     dirpath: path/to/parent/dir
                     sha1sum: ab3aa0555f31a8d7809fae4b03a95195edb01f5c
+                    size: 12345
                   - filename: myfile2.txt
                     dirpath: path/to/parent/dir
                     sha1sum: ab3aa0555f31a8d7809fae4b03a95195edb01f5d
+                    size: 12345
 
         401:
           $ref: "#/components/responses/Unauthorized"
@@ -767,10 +769,13 @@ components:
           type: string
         sha1sum:
           type: string
+        size:
+          type: number
       example:
         filename: file.txt
         dirpath: path/to/containing/dir
         sha1sum: ab3aa0555f31a8d7809fae4b03a95195edb01f5c
+        size: 12345
 
     DatasetMetadata:
       type: object

--- a/src/main/scala/nl.knaw.dans.easy.deposit/DataFiles.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/DataFiles.scala
@@ -128,7 +128,12 @@ case class DataFiles(bag: DansBag, depositId: UUID) extends DebugEnhancedLogging
   }
 
   private def toFileInfo(absFile: File, checksum: String): FileInfo = {
-    FileInfo(absFile.name, uploadRoot.relativize(absFile.parent), checksum)
+    FileInfo(
+      absFile.name,
+      uploadRoot.relativize(absFile.parent),
+      checksum,
+      absFile.toJava.length(), // use `JFile.length` here instead of `file.size` because (1) that's the same way it is done in easy-ingest-flow and (2) https://stackoverflow.com/a/7226770/2389405
+    )
   }
 
   /**

--- a/src/main/scala/nl.knaw.dans.easy.deposit/docs/FileInfo.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/docs/FileInfo.scala
@@ -24,4 +24,4 @@ import java.nio.file.Path
  * @param dirpath  path of the containing directory, relative to the content base directory
  * @param sha1sum  the SHA-1 checksum of the file data
  */
-case class FileInfo(filename: String, dirpath: Path, sha1sum: String)
+case class FileInfo(filename: String, dirpath: Path, sha1sum: String, size: Long)

--- a/src/test/scala/nl.knaw.dans.easy.deposit/DataFilesSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/DataFilesSpec.scala
@@ -196,8 +196,8 @@ class DataFilesSpec extends TestSupportFixture {
     val sha1 = "a57ec0c3239f30b29f1e9270581be50a70c74c04"
     val sha2 = "815bc8056fe15e00f24514051f1d06016852360c"
     val expected = Seq(
-      FileInfo("1.txt", Paths.get("some/"), sha1),
-      FileInfo("2.txt", Paths.get("some/folder"), sha2),
+      FileInfo("1.txt", Paths.get("some/"), sha1, 11),
+      FileInfo("2.txt", Paths.get("some/folder"), sha2, 8),
     )
     val bag = newEmptyBag
       .addPayloadFile("lorum ipsum".inputStream, Paths.get("original/some/1.txt")).getOrRecover(payloadFailure)
@@ -206,7 +206,7 @@ class DataFilesSpec extends TestSupportFixture {
 
     // get FileInfo for a singe file, alias GET /deposit/{id}/file/some/folder/2.txt
     dataFiles.get(Paths.get("some/folder/2.txt")) should matchPattern {
-      case Success(FileInfo("2.txt", p, _)) if p.toString == "some/folder" =>
+      case Success(FileInfo("2.txt", p, _, _)) if p.toString == "some/folder" =>
     }
 
     // get FileInfo for all files, alias GET /deposit/{id}/file

--- a/src/test/scala/nl.knaw.dans.easy.deposit/docs/JsonUtilSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/docs/JsonUtilSpec.scala
@@ -53,8 +53,8 @@ class JsonUtilSpec extends TestSupportFixture {
   }
 
   "FileInfo" should "serialize with lower case, not camel case" in {
-    val fileInfo = FileInfo("test.txt", Paths.get("a/b"), "abc123")
-    toJson(fileInfo) shouldBe """{"filename":"test.txt","dirpath":"a/b","sha1sum":"abc123"}"""
+    val fileInfo = FileInfo("test.txt", Paths.get("a/b"), "abc123", 12345L)
+    toJson(fileInfo) shouldBe """{"filename":"test.txt","dirpath":"a/b","sha1sum":"abc123","size":12345}"""
   }
 
   "deserialize" should "reject additional json info" in {

--- a/src/test/scala/nl.knaw.dans.easy.deposit/servlets/HappyRoutesSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/servlets/HappyRoutesSpec.scala
@@ -135,13 +135,13 @@ class HappyRoutesSpec extends TestSupportFixture with ServletFixture with Scalat
   s"get /deposit/:uuid/file/path/to/directory" should "return a list with one FileInfo object in json format" in {
     authMocker.expectsUserFooBar
     (mockedApp.getFileInfo(_: String, _: UUID, _: Path)) expects("foo", uuid, *) returning
-      Success(Seq(FileInfo("a.txt", Paths.get("files"), "x")))
+      Success(Seq(FileInfo("a.txt", Paths.get("files"), "x", 12345L)))
 
     get(
       uri = s"/deposit/$uuid/file/path/to/directory",
       headers = Seq(fooBarBasicAuthHeader)
     ) {
-      body shouldBe s"""[{"filename":"a.txt","dirpath":"files","sha1sum":"x"}]"""
+      body shouldBe s"""[{"filename":"a.txt","dirpath":"files","sha1sum":"x","size":12345}]"""
       status shouldBe OK_200
     }
   }
@@ -149,13 +149,13 @@ class HappyRoutesSpec extends TestSupportFixture with ServletFixture with Scalat
   s"get /deposit/:uuid/file/a.txt" should "return a FileInfo object in json format" in {
     authMocker.expectsUserFooBar
     (mockedApp.getFileInfo(_: String, _: UUID, _: Path)) expects("foo", uuid, *) returning
-      Success(FileInfo("a.txt", Paths.get("files"), "x"))
+      Success(FileInfo("a.txt", Paths.get("files"), "x", 12345L))
 
     get(
       uri = s"/deposit/$uuid/file/a.txt",
       headers = Seq(fooBarBasicAuthHeader)
     ) {
-      body shouldBe s"""{"filename":"a.txt","dirpath":"files","sha1sum":"x"}"""
+      body shouldBe s"""{"filename":"a.txt","dirpath":"files","sha1sum":"x","size":12345}"""
       status shouldBe OK_200
     }
   }

--- a/src/test/scala/nl.knaw.dans.easy.deposit/servlets/IntegrationSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/servlets/IntegrationSpec.scala
@@ -169,7 +169,7 @@ class IntegrationSpec extends TestSupportFixture with ServletFixture with Scalat
     ) {
       status shouldBe OK_200
       // a single json object: {"..."}, more details are tested in DataFilesSpec.fileInfo
-      body should (fullyMatch regex """^\{.*"\}$""")
+      body should (fullyMatch regex """^\{.*\}$""")
     }
 
     // get directory
@@ -180,7 +180,7 @@ class IntegrationSpec extends TestSupportFixture with ServletFixture with Scalat
     ) {
       status shouldBe OK_200
       // a list of json objects: [{"..."}], more details are tested in DataFilesSpec.fileInfo
-      body should (fullyMatch regex """^\[\{.*"\}\]$""")
+      body should (fullyMatch regex """^\[\{.*\}\]$""")
     }
   }
 

--- a/src/test/scala/nl.knaw.dans.easy.deposit/servlets/UploadSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/servlets/UploadSpec.scala
@@ -363,7 +363,7 @@ class UploadSpec extends ServletFixture with Inspectors {
       headers = Seq(fooBarBasicAuthHeader),
     ) {
       status shouldBe OK_200
-      body shouldBe s"""[{"filename":"text.txt","dirpath":"path/to","sha1sum":"$sha"}]"""
+      body shouldBe s"""[{"filename":"text.txt","dirpath":"path/to","sha1sum":"$sha","size":11}]"""
     }
   }
 
@@ -389,7 +389,7 @@ class UploadSpec extends ServletFixture with Inspectors {
       headers = Seq(fooBarBasicAuthHeader),
     ) {
       status shouldBe OK_200
-      body shouldBe s"""[{"filename":"text.txt","dirpath":"","sha1sum":"$sha"}]"""
+      body shouldBe s"""[{"filename":"text.txt","dirpath":"","sha1sum":"$sha","size":11}]"""
     }
   }
 


### PR DESCRIPTION
Fixes EASY-2529

#### When applied it will
* include file size in FileInfo responses

@DANS-KNAW/easy for review

#### See also
* https://github.com/DANS-KNAW/easy-deposit-ui/pull/241