### PR TITLE
DD-412: white space treatment

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.deposit/docs/DDM.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/docs/DDM.scala
@@ -44,8 +44,7 @@ object DDM extends SchemedXml with DebugEnhancedLogging {
     >
       <ddm:profile>
         { dm.titles.withValue.map(str => <dc:title xml:lang={ lang }>{ str }</dc:title>) }
-        { dm.descriptions.withValue.map(str => <dcterms:description xml:lang={ lang }>{
-        str }</dcterms:description>) }
+        { dm.descriptions.withValue.map(str => <dcterms:description xml:lang={ lang }>{ str }</dcterms:description>) }
         { dm.instructionsForReuse.withValue.map(str => <ddm:description descriptionType="TechnicalInfo">{ str }</ddm:description>) }
         { dm.creators.withValue.map(author => <dcx-dai:creatorDetails>{ nestedXML(author, lang) }</dcx-dai:creatorDetails>) }
         { dm.datesCreated.withValue.map(src => <ddm:created>{ src.value.orEmpty }</ddm:created>) }

--- a/src/main/scala/nl.knaw.dans.easy.deposit/docs/DDM.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/docs/DDM.scala
@@ -44,7 +44,8 @@ object DDM extends SchemedXml with DebugEnhancedLogging {
     >
       <ddm:profile>
         { dm.titles.withValue.map(str => <dc:title xml:lang={ lang }>{ str }</dc:title>) }
-        { dm.descriptions.withValue.map(str => <dcterms:description xml:lang={ lang }>{ str }</dcterms:description>) }
+        { dm.descriptions.withValue.map(str => <dcterms:description xml:lang={ lang }>{
+        str }</dcterms:description>) }
         { dm.instructionsForReuse.withValue.map(str => <ddm:description descriptionType="TechnicalInfo">{ str }</ddm:description>) }
         { dm.creators.withValue.map(author => <dcx-dai:creatorDetails>{ nestedXML(author, lang) }</dcx-dai:creatorDetails>) }
         { dm.datesCreated.withValue.map(src => <ddm:created>{ src.value.orEmpty }</ddm:created>) }

--- a/src/main/scala/nl.knaw.dans.easy.deposit/package.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/package.scala
@@ -32,7 +32,7 @@ package object deposit {
     def serialize: String = {
       val printer = new PrettyPrinter(160, 2)
       val trimmed = Utility.trim(elem)
-      prologue + "\n" + printer.format(trimmed)
+      prologue + "\n" + printer.format(elem)
     }
   }
   implicit class BagExtensions(val bag: DansBag) extends AnyVal {

--- a/src/main/scala/nl.knaw.dans.easy.deposit/package.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/package.scala
@@ -30,9 +30,7 @@ package object deposit {
   implicit class XmlExtensions(val elem: Elem) extends AnyVal {
 
     def serialize: String = {
-      val printer = new PrettyPrinter(160, 2)
-      val trimmed = Utility.trim(elem)
-      prologue + "\n" + printer.format(elem)
+      prologue + "\n" + Utility.serialize(elem).toString
     }
   }
   implicit class BagExtensions(val bag: DansBag) extends AnyVal {

--- a/src/test/resources/manual-test/datasetmetadata-from-ui-all.json
+++ b/src/test/resources/manual-test/datasetmetadata-from-ui-all.json
@@ -19,7 +19,7 @@
     "alternative title2"
   ],
   "descriptions": [
-    "description1",
+    "description1\nwith another line",
     "description2"
   ],
   "creators": [

--- a/src/test/scala/nl.knaw.dans.easy.deposit/SubmitterSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/SubmitterSpec.scala
@@ -232,6 +232,10 @@ class SubmitterSpec extends TestSupportFixture with MockFactory with BeforeAndAf
       s"$submittedBag/metadata/depositor-info/agreements.xml",
       s"$submittedBag/metadata/depositor-info/message-from-depositor.txt",
     )
+    (submittedBag / "metadata" / "dataset.xml").contentAsString should include(
+      """<dcterms:description xml:lang="nld">description1
+        |with another line</dcterms:description>""".stripMargin
+    )
     (submittedBag / "metadata" / "files.xml").contentAsString should include("""<file filepath="data/folder/text.txt">""")
     (submittedBag / "metadata" / "depositor-info" / "message-from-depositor.txt").contentAsString shouldBe
       s"""Lorum Ipsum

--- a/src/test/scala/nl.knaw.dans.easy.deposit/docs/DDMSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/docs/DDMSpec.scala
@@ -121,7 +121,9 @@ class DDMSpec extends TestSupportFixture with DdmBehavior {
     expectedDdmContent =
       <ddm:profile>
         <dcterms:description>first</dcterms:description>
-        <dcterms:description>par1 par 2 par4</dcterms:description>
+        <dcterms:description>par1
+          par  2
+          par4</dcterms:description>
         <ddm:description descriptionType="TechnicalInfo">blabla rabarbera</ddm:description>
       </ddm:profile>
   )

--- a/src/test/scala/nl.knaw.dans.easy.deposit/docs/DDMSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/docs/DDMSpec.scala
@@ -282,45 +282,61 @@ class DDMSpec extends TestSupportFixture with DdmBehavior {
 
   // documenting (not exhaustive) what the client should validate to get the metadata ingested
   "Schema.validate(DDM(json))" should "report missing titles" in {
-    validate(new MinimalDatasetMetadata(titles = None)) should
+    val metadata = new MinimalDatasetMetadata(titles = None)
+    assume(triedSchema.isAvailable)
+    validate(metadata) should
       matchSaxMessage(".*Invalid content was found starting with element 'dcterms:description'. One of '.*:title.' is expected.")
   }
 
   it should "report missing descriptions" in {
-    validate(new MinimalDatasetMetadata(descriptions = None)) should
+    val metadata = new MinimalDatasetMetadata(descriptions = None)
+    assume(triedSchema.isAvailable)
+    validate(metadata) should
       matchSaxMessage(".*Invalid content was found starting with element 'dcx-dai:creatorDetails'. One of '.*:description.' is expected.")
   }
 
   it should "report missing audiences" in {
-    validate(new MinimalDatasetMetadata(audiences = None)) should
+    val metadata = new MinimalDatasetMetadata(audiences = None)
+    assume(triedSchema.isAvailable)
+    validate(metadata) should
       matchSaxMessage(".*Invalid content was found starting with element 'ddm:accessRights'. One of '.*:audience.' is expected.")
   }
 
   it should "report missing creators" in {
-    validate(new MinimalDatasetMetadata(creators = None)) should
+    val metadata = new MinimalDatasetMetadata(creators = None)
+    assume(triedSchema.isAvailable)
+    validate(metadata) should
       matchSaxMessage(".*Invalid content was found starting with element 'ddm:created'. One of '.*:description, .*:creator.' is expected.")
   }
 
   it should "report missing dateCreated" in {
-    validate(new MinimalDatasetMetadata(dates = Some(Seq(mandatoryDates.head)))) should
+    val metadata = new MinimalDatasetMetadata(dates = Some(Seq(mandatoryDates.head)))
+    assume(triedSchema.isAvailable)
+    validate(metadata) should
       matchSaxMessage(".*Invalid content was found starting with element 'ddm:audience'. One of '.*:available.' is expected.")
   }
 
   it should "report missing dateAvailable" in {
-    validate(new MinimalDatasetMetadata(dates = Some(Seq(mandatoryDates.last)))) should
+    val metadata = new MinimalDatasetMetadata(dates = Some(Seq(mandatoryDates.last)))
+    assume(triedSchema.isAvailable)
+    validate(metadata) should
       matchSaxMessage(".*Invalid content was found starting with element 'ddm:available'. One of '.*:creator, .*:created.' is expected.")
   }
 
   it should "report missing accessRights" in {
-    validate(new MinimalDatasetMetadata(accessRights = None)) should
+    val metadata = new MinimalDatasetMetadata(accessRights = None)
+    assume(triedSchema.isAvailable)
+    validate(metadata) should
       matchSaxMessage(".*The content of element 'ddm:profile' is not complete. One of '.*:audience, .*:accessRights.' is expected.")
   }
 
   it should "report spatial box without scheme" in {
     val box = """{"north": 1, "east": 2, "south": 3, "west": 4}"""
-    validate(new MinimalDatasetMetadata(
+    val metadata = new MinimalDatasetMetadata(
       spatialBoxes = parse(s"""{"spatialBoxes":[$box]}""").spatialBoxes
-    )) should matchSaxMessage(".*Attribute 'srsName' must appear on element 'Envelope'.")
+    )
+    assume(triedSchema.isAvailable)
+    validate(metadata) should matchSaxMessage(".*Attribute 'srsName' must appear on element 'Envelope'.")
   }
 
   it should "report an invalid name space for author ID" in {
@@ -332,6 +348,7 @@ class DDMSpec extends TestSupportFixture with DdmBehavior {
         |}"""
     val ddm = toDDM(new MinimalDatasetMetadata(contributors = parse(s"""{"contributors":[$author]}""").contributors))
     prettyPrinter.format(ddm) should include("<dcx-dai:dcx-dai:ISNI>ISNI:000000012281955X</dcx-dai:dcx-dai:ISNI>")
+    assume(triedSchema.isAvailable)
     triedSchema.validate(ddm) should matchSaxMessage(".*dcx-dai:dcx-dai.*") // note the duplication
   }
 
@@ -344,6 +361,7 @@ class DDMSpec extends TestSupportFixture with DdmBehavior {
         |}"""
     val ddm = toDDM(new MinimalDatasetMetadata(contributors = parse(s"""{"contributors":[$author]}""").contributors))
     prettyPrinter.format(ddm) should include("<dcx-dai:foo>bar</dcx-dai:foo>")
+    assume(triedSchema.isAvailable)
     triedSchema.validate(ddm) should matchSaxMessage(".*dcx-dai:foo.*")
   }
 

--- a/src/test/scala/nl.knaw.dans.easy.deposit/docs/DDMSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/docs/DDMSpec.scala
@@ -15,12 +15,12 @@
  */
 package nl.knaw.dans.easy.deposit.docs
 
-import javax.xml.validation.Schema
 import nl.knaw.dans.easy.deposit.TestSupportFixture
 import nl.knaw.dans.easy.deposit.docs.dm.DateScheme.W3CDTF
 import nl.knaw.dans.easy.deposit.docs.dm._
 import nl.knaw.dans.lib.error._
 
+import javax.xml.validation.Schema
 import scala.util.{ Failure, Success, Try }
 import scala.xml._
 
@@ -100,6 +100,29 @@ class DDMSpec extends TestSupportFixture with DdmBehavior {
       <ddm:profile>
         <dcterms:description>Lorum &lt;a href='mailto:does.not.exist@dans.knaw.nl'&gt;ipsum&lt;/a&gt;</dcterms:description>
         <dcterms:description>ipsum</dcterms:description>
+      </ddm:profile>
+  )
+
+  "descriptions with complex white space" should behave like validDatasetMetadata(
+    input = new MinimalDatasetMetadata(
+      descriptions = Some(Seq(
+        "first",
+        """par1
+          |par  2
+          |
+          |par4""".stripMargin
+      )),
+      instructionsForReuse = Some(Seq(
+        """blabla
+          |rabarbera""".stripMargin
+      )),
+    ),
+    subset = actualDDM => profileElements(actualDDM, "description"),
+    expectedDdmContent =
+      <ddm:profile>
+        <dcterms:description>first</dcterms:description>
+        <dcterms:description>par1 par 2 par4</dcterms:description>
+        <ddm:description descriptionType="TechnicalInfo">blabla rabarbera</ddm:description>
       </ddm:profile>
   )
 


### PR DESCRIPTION
demonstrates DD-412: white space treatment

#### When applied it will
* have a new unit test that demonstrates loss of white space as saved by the depoit-ui
* 

#### Where should the reviewer @DANS-KNAW/easy start?

run https://github.com/DANS-KNAW/easy-deposit-api/blob/ed02f121608d0b79d4796df1a0efd64730a89427/src/test/scala/nl.knaw.dans.easy.deposit/SubmitterSpec.scala#L187
and examine `target/test/SubmitterSpec/submitted/*/*/metadata/dataset.xml`

When debugging, all white space is still preserved in both `trimmed` and `elem` when formatting
https://github.com/DANS-KNAW/easy-deposit-api/blob/dfe23552767ae87d6081f6976d15bfbf6a9b4d5c/src/main/scala/nl.knaw.dans.easy.deposit/package.scala#L33-L35

Note that the `PrettyPrinter` is used everywhere down the chain.

#### How should this be manually tested?

#### Related pull requests on github
repo                       | PR                | note
-------------------------- | ----------------- | ----
easy-                      | [PR#](PRlink)     | ..
