### PR TITLE
EASY-2878 fix ezproxy in license URL

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.deposit/servlets/DepositServlet.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/servlets/DepositServlet.scala
@@ -98,7 +98,7 @@ class DepositServlet(app: EasyDepositApiApp)
 
   private def fixLicenseUrl(maybeSchemedValue: Option[SchemedValue]) = {
     def replace(str: String) = {
-      str.replaceAll("dans.knaw.nl.ezproxy[^/]+/", "dans.knaw.nl/")
+      str.replaceAll(".ezproxy[A-Za-z0-9.]+/", "/")
     }
 
     maybeSchemedValue.map(schemedValue => schemedValue.copy(value = schemedValue.value.map(replace)))

--- a/src/main/scala/nl.knaw.dans.easy.deposit/servlets/DepositServlet.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/servlets/DepositServlet.scala
@@ -18,10 +18,10 @@ package nl.knaw.dans.easy.deposit.servlets
 import java.io.IOException
 import java.nio.file.{ InvalidPathException, Path, Paths }
 import java.util.UUID
-
 import nl.knaw.dans.easy.deposit.EasyDepositApiApp
 import nl.knaw.dans.easy.deposit.Errors._
 import nl.knaw.dans.easy.deposit.docs.JsonUtil.toJson
+import nl.knaw.dans.easy.deposit.docs.dm.SchemedValue
 import nl.knaw.dans.easy.deposit.docs.{ DatasetMetadata, StateInfo }
 import nl.knaw.dans.lib.string._
 import org.scalatra._
@@ -95,6 +95,15 @@ class DepositServlet(app: EasyDepositApiApp)
       } yield Ok(body = s"""{"doi":"$doi"}""", headers = Map(contentTypeJson))
     }.getOrRecoverWithActionResult
   }
+
+  private def fixLicenseUrl(maybeSchemedValue: Option[SchemedValue]) = {
+    def replace(str: String) = {
+      str.replaceAll("dans.knaw.nl.ezproxy[^/]+/", "dans.knaw.nl/")
+    }
+
+    maybeSchemedValue.map(schemedValue => schemedValue.copy(value = schemedValue.value.map(replace)))
+  }
+
   put("/:uuid/metadata") {
     {
       for {
@@ -102,10 +111,11 @@ class DepositServlet(app: EasyDepositApiApp)
         _ = logger.info(s"[$uuid] saving metadata")
         managedIS = managed(request.getInputStream)
         datasetMetadata <- managedIS.apply(is => DatasetMetadata(is))
+        fixedDatasetMetadata = datasetMetadata.copy(license = fixLicenseUrl(datasetMetadata.license))
         _ = logger.debug(s"[$uuid] comparing DOI in deposit.properties and newly uploaded dataset metadata")
-        _ <- app.checkDoi(user.id, uuid, datasetMetadata)
+        _ <- app.checkDoi(user.id, uuid, fixedDatasetMetadata)
         _ = logger.debug(s"[$uuid] writing newly uploaded dataset metadata to deposit")
-        _ <- app.writeDataMetadataToDeposit(datasetMetadata, user.id, uuid)
+        _ <- app.writeDataMetadataToDeposit(fixedDatasetMetadata, user.id, uuid)
       } yield NoContent()
     }.getOrRecoverWithActionResult
   }

--- a/src/test/scala/nl.knaw.dans.easy.deposit/servlets/DoiSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/servlets/DoiSpec.scala
@@ -96,9 +96,8 @@ class DoiSpec extends TestSupportFixture with ServletFixture {
 
   it should "filter ezproxy from license URL (EASY-2878 ticket/10290)" in {
     val uuid = createDeposit
-    propsFile(uuid).append(doiProperty)
-    val license = """"license": { "scheme": "dcterms:URI", "value": "http://dans.knaw.nl.ezproxy2.something.nl/en/about/organisation-and-policy/legal-information/DANSLicence.pdf"}"""
-    put(s"/deposit/$uuid/metadata", headers = Seq(fooBarBasicAuthHeader), body = s"""{$doiForJson,$license}""") { status shouldBe NO_CONTENT_204 }
+    val license = """{"license": { "scheme": "dcterms:URI", "value": "http://dans.knaw.nl.ezproxy2.something.nl/en/about/organisation-and-policy/legal-information/DANSLicence.pdf"}}"""
+    put(s"/deposit/$uuid/metadata", headers = Seq(fooBarBasicAuthHeader), body = license) { status shouldBe NO_CONTENT_204 }
     val datasetMetadata = datasetMetadataFile(uuid).contentAsString
     datasetMetadata should include ("http://dans.knaw.nl/en/about")
     datasetMetadata should include ("DANSLicence.pdf")

--- a/src/test/scala/nl.knaw.dans.easy.deposit/servlets/DoiSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/servlets/DoiSpec.scala
@@ -26,7 +26,7 @@ import scala.util.Success
 class DoiSpec extends TestSupportFixture with ServletFixture {
   private def propsFile(uuid: String): File = testDir / "drafts/foo" / uuid / "deposit.properties"
 
-  private def jsonFile(uuid: String): File = testDir / "drafts/foo" / uuid / bagDirName / "metadata" / "dataset.json"
+  private def datasetMetadataFile(uuid: String): File = testDir / "drafts/foo" / uuid / bagDirName / "metadata" / "dataset.json"
 
   private val submit = """{"state":"SUBMITTED","stateDescription":"blabla"}"""
   private val doi = "10.17632/DANS.6wg5xccnjd.1"
@@ -71,13 +71,13 @@ class DoiSpec extends TestSupportFixture with ServletFixture {
 
   it should "fail when json has a DOI and properties not" in {
     val uuid = createDeposit
-    jsonFile(uuid).write(s"""{$doiForJson}""")
+    datasetMetadataFile(uuid).write(s"""{$doiForJson}""")
     get(s"/deposit/$uuid/doi", headers = Seq(fooBarBasicAuthHeader)) { shouldReturnBadRequest(uuid) }
   }
 
   it should "fail when DOI's are different" in {
     val uuid = createDeposit
-    jsonFile(uuid).write(s"""{$doiForJson}""")
+    datasetMetadataFile(uuid).write(s"""{$doiForJson}""")
     get(s"/deposit/$uuid/doi", headers = Seq(fooBarBasicAuthHeader)) { shouldReturnBadRequest(uuid) }
   }
 
@@ -92,6 +92,18 @@ class DoiSpec extends TestSupportFixture with ServletFixture {
     val uuid = createDeposit
     propsFile(uuid).append(doiProperty)
     put(s"/deposit/$uuid/metadata", headers = Seq(fooBarBasicAuthHeader), body = s"""{$doiForJson}""") { status shouldBe NO_CONTENT_204 }
+  }
+
+  it should "filter ezproxy from license URL (EASY-2878 ticket/10290)" in {
+    val uuid = createDeposit
+    propsFile(uuid).append(doiProperty)
+    val license = """"license": { "scheme": "dcterms:URI", "value": "http://dans.knaw.nl.ezproxy2.something.nl/en/about/organisation-and-policy/legal-information/DANSLicence.pdf"}"""
+    put(s"/deposit/$uuid/metadata", headers = Seq(fooBarBasicAuthHeader), body = s"""{$doiForJson,$license}""") { status shouldBe NO_CONTENT_204 }
+    val datasetMetadata = datasetMetadataFile(uuid).contentAsString
+    datasetMetadata should include ("http://dans.knaw.nl/en/about")
+    datasetMetadata should include ("DANSLicence.pdf")
+    datasetMetadata should not include "ezproxy"
+    datasetMetadata should not include "something"
   }
 
   it should "succeed without any DOI" in {
@@ -119,32 +131,32 @@ class DoiSpec extends TestSupportFixture with ServletFixture {
   "PUT /deposit/{id}/state" should "succeed when DOI's are equal" in {
     val uuid = createDeposit
     propsFile(uuid).append(doiProperty)
-    jsonFile(uuid).write(s"""{$doiForJson,$mandatoryOnSubmit}""")
+    datasetMetadataFile(uuid).write(s"""{$doiForJson,$mandatoryOnSubmit}""")
     put(s"/deposit/$uuid/state", headers = Seq(fooBarBasicAuthHeader), body = submit) { status shouldBe NO_CONTENT_204 }
   }
 
   it should "fail without any DOI" in {
     val uuid = createDeposit
-    jsonFile(uuid).write(s"""{$mandatoryOnSubmit}""")
+    datasetMetadataFile(uuid).write(s"""{$mandatoryOnSubmit}""")
     put(s"/deposit/$uuid/state", headers = Seq(fooBarBasicAuthHeader), body = submit) { shouldReturnBadRequest(uuid) }
   }
 
   it should "fail when DOI's are different" in {
     val uuid = createDeposit
     propsFile(uuid).append(doiProperty + "xyz")
-    jsonFile(uuid).write(s"""{$doiForJson,$mandatoryOnSubmit}""")
+    datasetMetadataFile(uuid).write(s"""{$doiForJson,$mandatoryOnSubmit}""")
     put(s"/deposit/$uuid/state", headers = Seq(fooBarBasicAuthHeader), body = submit) { shouldReturnBadRequest(uuid) }
   }
 
   it should "fail when json has a DOI but properties not" in {
     val uuid = createDeposit
-    jsonFile(uuid).write(s"""{$doiForJson,$mandatoryOnSubmit}""")
+    datasetMetadataFile(uuid).write(s"""{$doiForJson,$mandatoryOnSubmit}""")
     put(s"/deposit/$uuid/state", headers = Seq(fooBarBasicAuthHeader), body = submit) { shouldReturnBadRequest(uuid) }
   }
 
   it should "fail when properties has a DOI but json not" in {
     val uuid = createDeposit
-    jsonFile(uuid).write(s"""{$mandatoryOnSubmit}""")
+    datasetMetadataFile(uuid).write(s"""{$mandatoryOnSubmit}""")
     propsFile(uuid).append(doiProperty)
     put(s"/deposit/$uuid/state", headers = Seq(fooBarBasicAuthHeader), body = submit) { shouldReturnBadRequest(uuid) }
   }


### PR DESCRIPTION
Fixes EASY-2878: fix ezproxy in license URL

#### When applied it will
* 
* 
* 

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

* in `easy-dtap` run `start-preprovisioned-box.py -s deasy`o
* hack urls in `easy-licenses/src/main/resources/licenses/licenses.*`, build and deploy: no change visible with the browser inspector
* manual hack of the urls
![image](https://github.com/DANS-KNAW/easy-deposit-api/assets/10553630/49e4bd1b-efbe-4b93-b5cf-95a9b4c5c006) still saved the official link
* [ ] so far no luck seducing the client to send a ezproxy link. We could try to execute the scenario of the new unit test with curl commands: create a doi, save draft metadata.


#### Related pull requests on github
repo                       | PR                | note
-------------------------- | ----------------- | ----
easy-                      | [PR#](PRlink)     | ..
